### PR TITLE
fix type declaration with "bundler"  moduleRes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/maptiler-sdk.mjs"
+      "import": "./dist/maptiler-sdk.mjs",
+      "types": "./dist/maptiler-sdk.d.ts"
     },
     "./dist/maptiler-sdk.css": {
       "import": "./dist/maptiler-sdk.css"


### PR DESCRIPTION
Hi @jonathanlurie 

following up on our conversation with my last issue regarding type discoverability,
I did some research and found some mistakes we've made regarding the issue.

Vite's default module resolution is set to "bundler" which comes with typescript 5.0, [source](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler).
it is not legacy and should be the way forward.

some other maintainers have encountered this issue, and [solved it](https://github.com/nolimits4web/swiper/pull/6626)

I have attempted the same solution from source and it worked like a charm.
in regard to backwards compatibility, I have, of course, left everything else like it was although it seems to introduce some duplication. 