### PR TITLE
fix: update sdk package.json to have proper types exported

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/maptiler-sdk.mjs"
+      "import": "./dist/maptiler-sdk.mjs",
+      "types": "./dist/maptiler-sdk.d.ts"
     },
     "./dist/maptiler-sdk.css": {
       "import": "./dist/maptiler-sdk.css"


### PR DESCRIPTION
Currently, IDE like VS Code do not import types when we import the `@maptiler/sdk` package.
Instead, it shows the following error:

![image](https://github.com/maptiler/maptiler-sdk-js/assets/9287511/e61af5d1-56dd-4c03-bc11-6ff7a3fc1129)

This PR should fix it.