### PR TITLE
Client-side caching for fonts and tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## 2.0.0
 ### New Features
 - Updating with MapLibre GL JS v4.1
+- Added client-side caching mechanism for tiles and fonts
 ### Bug Fixes
 ### Others
 - Removed `Map.loadImageAsync()` as MapLibre's `.loadImage()` is now promise based.
@@ -143,7 +144,7 @@
 ### New Features
 - The `apiKey` can now be specified in the `Map` constructor (will propagate to `config`)
 - The `language` can now be speficifed in the `Map` constructo (will **not** propagete to `config` and will apply only to this specific instance)
-- `Map` now has the method `.getSdkConfig()` to retrieve the config object. 
+- `Map` now has the method `.getSdkConfig()` to retrieve the config object.
 - `Map` now has the method `.getMaptilerSessionId()` to retrieve the MapTiler session ID
 Both `.getSdkConfig()` and `.getMaptilerSessionId()` are handy for layers or control built outside of the SDK that still need some of the configuration to interact with the server. Those components do not always have access to the internal of the SDK (especially that the config is scoped) but can access to the `Map` instance to which they are added with the implementation of the `.onAdd()` method.
 

--- a/src/caching.ts
+++ b/src/caching.ts
@@ -1,0 +1,128 @@
+import {
+  GetResourceResponse,
+  RequestParameters,
+  ResourceType,
+  addProtocol,
+} from "maplibre-gl";
+import { config } from ".";
+import { defaults } from "./defaults";
+
+const LOCAL_CACHE_PROTOCOL_SOURCE = "localcache_source";
+const LOCAL_CACHE_PROTOCOL_DATA = "localcache";
+const LOCAL_CACHE_NAME = "maptiler_sdk";
+
+export function localCacheTransformRequest(
+  reqUrl: URL,
+  resourceType?: ResourceType,
+): string {
+  if (
+    config.caching &&
+    config.session &&
+    reqUrl.host === defaults.maptilerApiHost
+  ) {
+    if (resourceType == "Source") {
+      return reqUrl.href.replace(
+        "https://",
+        `${LOCAL_CACHE_PROTOCOL_SOURCE}://`,
+      );
+    } else if (resourceType == "Tile" || resourceType == "Glyphs") {
+      return reqUrl.href.replace("https://", `${LOCAL_CACHE_PROTOCOL_DATA}://`);
+    }
+  }
+  return reqUrl.href;
+}
+
+export function registerLocalCacheProtocol() {
+  // TODO cleanup
+  // TODO make safer
+  // TODO cache cleaning ?
+  addProtocol(
+    LOCAL_CACHE_PROTOCOL_SOURCE,
+    async (
+      params: RequestParameters,
+      abortController: AbortController,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): Promise<GetResourceResponse<any>> => {
+      if (!params.url) throw new Error("");
+
+      params.url = params.url.replace(
+        `${LOCAL_CACHE_PROTOCOL_SOURCE}://`,
+        "https://",
+      );
+
+      const requestInit: RequestInit = params;
+      requestInit.signal = abortController.signal;
+      const response = await fetch(params.url, requestInit);
+      const json = await response.json();
+
+      // move `Last-Modified` to query so it propagates to tile URLs
+      json.tiles[0] +=
+        "&last-modified=" + response.headers.get("Last-Modified");
+
+      return {
+        data: json,
+        cacheControl: response.headers.get("Cache-Control"),
+        expires: response.headers.get("Expires"),
+      };
+    },
+  );
+  addProtocol(
+    LOCAL_CACHE_PROTOCOL_DATA,
+    async (
+      params: RequestParameters,
+      abortController: AbortController,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): Promise<GetResourceResponse<any>> => {
+      if (!params.url) throw new Error("");
+
+      params.url = params.url.replace(
+        `${LOCAL_CACHE_PROTOCOL_DATA}://`,
+        "https://",
+      );
+
+      const url = new URL(params.url);
+
+      const cacheableUrl = new URL(url);
+      cacheableUrl.searchParams.delete("mtsid");
+      cacheableUrl.searchParams.delete("key");
+      const cacheKey = cacheableUrl.toString();
+
+      const fetchableUrl = new URL(url);
+      fetchableUrl.searchParams.delete("last-modified");
+      const fetchUrl = fetchableUrl.toString();
+
+      const respond = async (
+        response: Response,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ): Promise<GetResourceResponse<any>> => {
+        return {
+          data: await response.arrayBuffer(),
+          cacheControl: response.headers.get("Cache-Control"),
+          expires: response.headers.get("Expires"),
+        };
+      };
+
+      // TODO do only once somehow
+      const cache = await caches.open(LOCAL_CACHE_NAME);
+
+      const cacheMatch = await cache.match(cacheKey);
+
+      if (cacheMatch) {
+        console.log("Cache hit", cacheKey);
+        return respond(cacheMatch);
+      } else {
+        console.log("Cache miss", cacheKey);
+        const requestInit: RequestInit = params;
+        requestInit.signal = abortController.signal;
+        const response = await fetch(fetchUrl, requestInit);
+        if (response.status >= 200 && response.status < 300) {
+          cache.put(cacheKey, response.clone()).catch(() => {
+            // "DOMException: Cache.put() was aborted"
+            // can happen here because the response is not done streaming yet
+          });
+        }
+        return respond(response);
+      }
+    },
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,9 @@ class SdkConfig extends EventEmitter {
   session = true;
 
   /**
-   * TODO description
+   * Enables client-side caching of requests for tiles and fonts.
+   * The cached requests persist multiple browser sessions and will be reused when possible.
+   * Works only for requests to the MapTiler Cloud API when sessions are enabled.
    */
   caching = true;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,11 @@ class SdkConfig extends EventEmitter {
   session = true;
 
   /**
+   * TODO description
+   */
+  caching = true;
+
+  /**
    * Unit to be used
    */
   private _unit: Unit = "metric";

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -59,9 +59,7 @@ export function DOMremove(node: HTMLElement) {
  */
 export function maptilerCloudTransformRequest(
   url: string,
-  // keep incase we need it in the future
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _resourceType?: ResourceType,
+  resourceType?: ResourceType,
 ): RequestParameters {
   let reqUrl = null;
 
@@ -86,6 +84,19 @@ export function maptilerCloudTransformRequest(
     }
   }
 
+  if (
+    config.caching &&
+    config.session &&
+    reqUrl.host === defaults.maptilerApiHost &&
+    (resourceType == "Tile" ||
+      resourceType == "Source" ||
+      resourceType == "Glyphs")
+  ) {
+    return {
+      url: reqUrl.href.replace("https://", "localcache://"),
+    };
+  }
+
   return {
     url: reqUrl.href,
   };
@@ -104,14 +115,14 @@ export function combineTransformRequest(
   ): RequestParameters {
     if (userDefinedRTF !== undefined) {
       const rp = userDefinedRTF(url, resourceType);
-      const rp2 = maptilerCloudTransformRequest(rp?.url ?? "");
+      const rp2 = maptilerCloudTransformRequest(rp?.url ?? "", resourceType);
 
       return {
         ...rp,
         ...rp2,
       };
     } else {
-      return maptilerCloudTransformRequest(url);
+      return maptilerCloudTransformRequest(url, resourceType);
     }
   };
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -7,6 +7,7 @@ import type {
 import { defaults } from "./defaults";
 import { config } from "./config";
 import { MAPTILER_SESSION_ID } from "./config";
+import { localCacheTransformRequest } from "./caching";
 
 export function enableRTL() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,21 +85,8 @@ export function maptilerCloudTransformRequest(
     }
   }
 
-  if (
-    config.caching &&
-    config.session &&
-    reqUrl.host === defaults.maptilerApiHost &&
-    (resourceType == "Tile" ||
-      resourceType == "Source" ||
-      resourceType == "Glyphs")
-  ) {
-    return {
-      url: reqUrl.href.replace("https://", "localcache://"),
-    };
-  }
-
   return {
-    url: reqUrl.href,
+    url: localCacheTransformRequest(reqUrl, resourceType),
   };
 }
 


### PR DESCRIPTION
RD-235

## Objective
Add client-side caching using browser Cache API to reduce network load for repeated sessions.

## Description
- `transformRequest` + `addProtocol` used to hook into the maplibre
- The cache is reused even between different map sessions (`mtsid` and `key` are ignored).
- Soft limit of 1000 items in the cache, checked periodically, oldest items are then removed.
- Special handling for TileJSON to actually propagate `Last-Modified` to the tile requests (so that the cache is not reused when outdated).

## Acceptance
Tested locally

## Checklist
- [x] I have added relevant info to the CHANGELOG.md