### PR TITLE
Fixing bundled imports

### DIFF
--- a/src/caching.ts
+++ b/src/caching.ts
@@ -3,8 +3,8 @@ import {
   RequestParameters,
   ResourceType,
   addProtocol,
-} from "maplibre-gl";
-import { config } from ".";
+  config,
+} from ".";
 import { defaults } from "./defaults";
 
 const LOCAL_CACHE_PROTOCOL_SOURCE = "localcache_source";


### PR DESCRIPTION
## Objective
See #78 for details. Bundled code contained an import from maplibre-gl.

```ts
import maplibregl, {addProtocol as addProtocol$1} from 'maplibre-gl';
```

Rather than importing from maplibre-gl _again_, the functions can be imported from `index.ts` where they are re-exported anyway, preventing the bundler from importing `addProtocol` as named import and renaming it.

## Description
In `caching.ts` I tweaked the import.

## Acceptance
The resulting bundle imports the default import from maplibre-gl only.

## Checklist
- [ ] I have added relevant info to the CHANGELOG.md (is it big enough to make it 2.0.1?)