### PR TITLE
Fix for the client-side caching breaking GeoJSON sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## DEVEL
 ### New Features
 ### Bug Fixes
+- Fix for the client-side caching breaking GeoJSON sources [#82](https://github.com/maptiler/maptiler-sdk-js/pull/82)
 ### Others
 
 ## 2.0.1

--- a/src/caching.ts
+++ b/src/caching.ts
@@ -23,7 +23,7 @@ export function localCacheTransformRequest(
     config.session &&
     reqUrl.host === defaults.maptilerApiHost
   ) {
-    if (resourceType == "Source") {
+    if (resourceType == "Source" && reqUrl.href.includes("tiles.json")) {
       return reqUrl.href.replace(
         "https://",
         `${LOCAL_CACHE_PROTOCOL_SOURCE}://`,
@@ -74,9 +74,11 @@ export function registerLocalCacheProtocol() {
       const response = await fetch(params.url, requestInit);
       const json = await response.json();
 
-      // move `Last-Modified` to query so it propagates to tile URLs
-      json.tiles[0] +=
-        "&last-modified=" + response.headers.get("Last-Modified");
+      if (json.tiles && json.tiles.length > 0) {
+        // move `Last-Modified` to query so it propagates to tile URLs
+        json.tiles[0] +=
+          "&last-modified=" + response.headers.get("Last-Modified");
+      }
 
       return {
         data: json,


### PR DESCRIPTION
RD-254

## Objective
Loading GeoJSON sources from api.maptiler.com is currently broken due to a bug in the client-side caching mechanism

## Description
More robust filtering. `ResourceType` was not enough, because the same value is actually used for TileJSONs and GeoJSONs.

## Checklist
- [x] I have added relevant info to the CHANGELOG.md