### PR TITLE
Better handling of non-webgl2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## DEVEL
 ### New Features
+- Displays a message in the map div when WebGL2 is not supported
 ### Bug Fixes
 ### Others
 

--- a/demos/simple.html
+++ b/demos/simple.html
@@ -8,9 +8,11 @@
 
       #map-container {
         position: absolute;
-        width: 100vw;
-        height: 100vh;
+        width: 70vw;
+        height: 70vh;
         background: radial-gradient(circle, rgb(186 226 255) 5%, rgb(0 100 159) 98%);
+        bottom: 0;
+        right: 0;
       }
 
       #style-picker-container {
@@ -36,7 +38,7 @@
     <script src ="../dist/maptiler-sdk.umd.js"></script>
     
     <script>
-      maptilersdk.config.apiKey = "YOUR_API_KEY";
+      maptilersdk.config.apiKey = "PhsGJ2SdW2MhmzzsT8zU";
 
       const map = new maptilersdk.Map({
         container: document.getElementById("map-container"),

--- a/demos/simple.html
+++ b/demos/simple.html
@@ -8,11 +8,10 @@
 
       #map-container {
         position: absolute;
-        width: 70vw;
-        height: 70vh;
-        background: radial-gradient(circle, rgb(186 226 255) 5%, rgb(0 100 159) 98%);
-        bottom: 0;
-        right: 0;
+        width: 100vw;
+        height: 100vh;
+        background: #ccc;
+        /* background: radial-gradient(circle, rgb(186 226 255) 5%, rgb(0 100 159) 98%); */
       }
 
       #style-picker-container {
@@ -38,7 +37,7 @@
     <script src ="../dist/maptiler-sdk.umd.js"></script>
     
     <script>
-      maptilersdk.config.apiKey = "PhsGJ2SdW2MhmzzsT8zU";
+      maptilersdk.config.apiKey = "YOUR_API_KEY";
 
       const map = new maptilersdk.Map({
         container: document.getElementById("map-container"),

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -24,7 +24,11 @@ import { ReferenceMapStyle, MapStyleVariant } from "@maptiler/client";
 import { config, MAPTILER_SESSION_ID, SdkConfig } from "./config";
 import { defaults } from "./defaults";
 import { MaptilerLogoControl } from "./MaptilerLogoControl";
-import { combineTransformRequest, enableRTL } from "./tools";
+import {
+  combineTransformRequest,
+  displayNoWebGlWarning,
+  enableRTL,
+} from "./tools";
 import {
   getBrowserLanguage,
   isLanguageSupported,
@@ -192,6 +196,8 @@ export class Map extends maplibregl.Map {
   private isReady: boolean = false;
 
   constructor(options: MapOptions) {
+    displayNoWebGlWarning(options.container);
+
     if (options.apiKey) {
       config.apiKey = options.apiKey;
     }

--- a/src/style/style_template.css
+++ b/src/style/style_template.css
@@ -144,3 +144,19 @@
   text-align: right;
   line-height: 14px;
 }
+
+.no-webgl-support-div {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+  width: fit-content;
+  height: fit-content;
+  padding: 10px;
+  background: white;
+  border-radius: 3px;
+  color: #fb8600;
+  text-align: center;
+}

--- a/src/style/style_template.css
+++ b/src/style/style_template.css
@@ -159,4 +159,8 @@
   border-radius: 3px;
   color: #fb8600;
   text-align: center;
+  font-family: sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  max-width: calc(100% - 80px);
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -168,3 +168,49 @@ export function isValidGeoJSON<T>(obj: T & { type: string }): boolean {
   if (validTypes.includes(obj.type)) return true;
   return false;
 }
+
+/**
+ * This function tests if WebGL2 is supported. Since it can be for a different reasons that WebGL2 is
+ * not supported but we do not have an action to take based on the reason, this function return null
+ * if there is no error (WebGL is supported), or returns a string with the error message if WebGL2 is
+ * not supported.
+ */
+export function getWebGLSupportError(): string | null {
+  const gl = document.createElement("canvas").getContext("webgl2");
+  if (!gl) {
+    if (typeof WebGL2RenderingContext !== "undefined") {
+      return "Graphic rendering with WebGL2 has been disabled or is not supported by your graphic card.<br>The map cannot be displayed.";
+    } else {
+      return "Your browser does not support graphic rendering with WebGL2.<br>The map cannot be displayed.";
+    }
+  } else {
+    return null;
+  }
+}
+
+/**
+ * Display an error message in the Map div if WebGL2 is not supported
+ */
+export function displayNoWebGlWarning(container: HTMLElement | string) {
+  const webglError = getWebGLSupportError();
+
+  if (!webglError) return;
+
+  let actualContainer: HTMLElement | null = null;
+
+  if (typeof container === "string") {
+    actualContainer = document.getElementById(container);
+  } else if (container instanceof HTMLElement) {
+    actualContainer = container;
+  }
+
+  if (!actualContainer) {
+    throw new Error("The Map container must be provided.");
+  }
+
+  const errorMessageDiv = document.createElement("div");
+  errorMessageDiv.innerHTML = webglError;
+  errorMessageDiv.classList.add("no-webgl-support-div");
+
+  actualContainer.appendChild(errorMessageDiv);
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -179,9 +179,9 @@ export function getWebGLSupportError(): string | null {
   const gl = document.createElement("canvas").getContext("webgl2");
   if (!gl) {
     if (typeof WebGL2RenderingContext !== "undefined") {
-      return "Graphic rendering with WebGL2 has been disabled or is not supported by your graphic card.<br>The map cannot be displayed.";
+      return "Graphic rendering with WebGL2 has been disabled or is not supported by your graphic card. The map cannot be displayed.";
     } else {
-      return "Your browser does not support graphic rendering with WebGL2.<br>The map cannot be displayed.";
+      return "Your browser does not support graphic rendering with WebGL2. The map cannot be displayed.";
     }
   } else {
     return null;
@@ -211,6 +211,6 @@ export function displayNoWebGlWarning(container: HTMLElement | string) {
   const errorMessageDiv = document.createElement("div");
   errorMessageDiv.innerHTML = webglError;
   errorMessageDiv.classList.add("no-webgl-support-div");
-
   actualContainer.appendChild(errorMessageDiv);
+  throw new Error(webglError);
 }


### PR DESCRIPTION
[RD-269](https://maptiler.atlassian.net/browse/RD-269)

Now showing a message in the map-hosting div as well as throw a more readable error:
<img width="1698" alt="Screenshot 2024-06-20 at 14 19 31" src="https://github.com/maptiler/maptiler-sdk-js/assets/1303310/f9716eaf-6621-45d9-b215-95f22c103bb0">

(the grey part is just the style given to the map container div in this example)

[RD-269]: https://maptiler.atlassian.net/browse/RD-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ