### PR TITLE
RD-287: RTL plugin no longer loads automatically 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 # MapTiler SDK Changelog
 
-## 2.2.1
+## 2.2.0
 ### New Features
-- Displays a message in the map div when WebGL2 is not supported
-- Fails quietly if caching API is not usable (non https, non localhost)
+- Displays a message in the map div when WebGL2 is not supported (https://github.com/maptiler/maptiler-sdk-js/pull/92)
+- Fails quietly if caching API is not usable (non https, non localhost) (https://github.com/maptiler/maptiler-sdk-js/pull/93)
 ### Bug Fixes
-- Removed `Inflight` as a second degree dependency
-- Removed double export of class+type from Maplibre
+- Removed `Inflight` as a second degree dependency (https://github.com/maptiler/maptiler-sdk-js/pull/95)
+- Removed double export of class+type from Maplibre (https://github.com/maptiler/maptiler-sdk-js/pull/95)
+- Fixing the loading of the RTL plugin (https://github.com/maptiler/maptiler-sdk-js/pull/96)
 ### Others
-- Replaced Eslint and Prettier by BiomeJS (ang got rid of tons of dependencies, some were problematic)
-- Fixed many formatting and linting issues pointed by BiomeJS
+- Replaced Eslint and Prettier by BiomeJS (ang got rid of tons of dependencies, some were problematic) (https://github.com/maptiler/maptiler-sdk-js/pull/95)
+- Fixed many formatting and linting issues pointed by BiomeJS (https://github.com/maptiler/maptiler-sdk-js/pull/95)
 
 ## 2.1.0
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "module": "dist/maptiler-sdk.mjs",
   "types": "dist/maptiler-sdk.d.ts",
@@ -36,10 +36,6 @@
   "scripts": {
     "build": "rm -rf dist/* && NODE_ENV=production rollup -c",
     "dev": "rm -rf dist/* && NODE_ENV=development rollup -c -w",
-    "format:fix": "prettier --write \"src/**/*.{js,ts,tsx}\"",
-    "format": "prettier -c \"src/**/*.{js,ts,tsx}\"",
-    "lint:fix": "eslint --fix \"src/**/*.{js,ts}\"",
-    "lint": "eslint \"src/**/*.{js,ts}\"",
     "biome": "biome check --max-diagnostics=1000",
     "biome:fix": "npx @biomejs/biome check --max-diagnostics=1000 --write",
     "doc": "rm -rf docs/* && typedoc --out docs && cp -r images docs/",

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -346,7 +346,7 @@ export class Map extends maplibregl.Map {
     });
 
     // load the Right-to-Left text plugin (will happen only once)
-    this.once("load", async () => {
+    this.once("load", () => {
       enableRTL();
     });
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,14 +6,14 @@ import { MAPTILER_SESSION_ID } from "./config";
 import { localCacheTransformRequest } from "./caching";
 
 export function enableRTL() {
-  if (maplibregl.getRTLTextPluginStatus() === "unavailable") {
-    maplibregl.setRTLTextPlugin(
-      defaults.rtlPluginURL,
-      (err?: Error | undefined) => {
-        if (err) console.error(err);
-      },
-      true, // Lazy load the plugin
-    );
+  const status = maplibregl.getRTLTextPluginStatus();
+
+  if (status === "unavailable" || status === "requested") {
+    try {
+      maplibregl.setRTLTextPlugin(defaults.rtlPluginURL, true);
+    } catch (e) {
+      // nothing
+    }
   }
 }
 


### PR DESCRIPTION
[RD-287](https://maptiler.atlassian.net/browse/RD-287)

Since Maplibre v4 many callback logic has been replaced by Promises and for some reason, I forgot to update this one as part of SDK v2. This PR address that.

[RD-287]: https://maptiler.atlassian.net/browse/RD-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ