### PR TITLE
Fix broken imports from maplibre-gl in v.2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MapTiler SDK Changelog
 
+## 2.2.2
+### Bug Fixes
+- Fix broken Maplibre imports in v2.2.1 (https://github.com/maptiler/maptiler-sdk-js/pull/100)
+
 ## 2.2.1
 ### Bug Fixes
 - The types from classes defined in Maplibre are now exposed more reliably (https://github.com/maptiler/maptiler-sdk-js/pull/98)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "module": "dist/maptiler-sdk.mjs",
   "types": "dist/maptiler-sdk.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ export function getVersion(): string {
   return packagejson.version;
 }
 
-// Re-export classes and methods from MapLibre, which is a CommonJS module
+// Re-export classes and methods from MapLibre. Since it’s a CommonJS module,
+// we can’t re-export them directly with `export { ... } from "maplibre-gl"`.
 export const {
   // The following elements have MapTiler SDK equivalents to make
   // them fully compatible with the SDK Map class definition (see src/MLAdapters).

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import maplibre from "maplibre-gl";
 import packagejson from "../package.json";
 import { enableRTL } from "./tools";
 
@@ -14,39 +15,40 @@ export function getVersion(): string {
   return packagejson.version;
 }
 
-export {
+// Re-export classes and methods from MapLibre, which is a CommonJS module
+export const {
   // The following elements have MapTiler SDK equivalents to make
   // them fully compatible with the SDK Map class definition (see src/MLAdapters).
   // Still, for MapLibre compatibility reasons, we want to export them
   // with the suffic "MLGL".
-  Map as MapMLGL,
-  Marker as MarkerMLGL,
-  Popup as PopupMLGL,
-  Style as StyleMLGL,
-  CanvasSource as CanvasSourceMLGL,
-  GeoJSONSource as GeoJSONSourceMLGL,
-  ImageSource as ImageSourceMLGL,
-  RasterTileSource as RasterTileSourceMLGL,
-  RasterDEMTileSource as RasterDEMTileSourceMLGL,
-  VectorTileSource as VectorTileSourceMLGL,
-  VideoSource as VideoSourceMLGL,
-  NavigationControl as NavigationControlMLGL,
-  GeolocateControl as GeolocateControlMLGL,
-  AttributionControl as AttributionControlMLGL,
-  LogoControl as LogoControlMLGL,
-  ScaleControl as ScaleControlMLGL,
-  FullscreenControl as FullscreenControlMLGL,
-  TerrainControl as TerrainControlMLGL,
-  BoxZoomHandler as BoxZoomHandlerMLGL,
-  ScrollZoomHandler as ScrollZoomHandlerMLGL,
-  CooperativeGesturesHandler as CooperativeGesturesHandlerMLGL,
-  KeyboardHandler as KeyboardHandlerMLGL,
-  TwoFingersTouchPitchHandler as TwoFingersTouchPitchHandlerMLGL,
-  MapWheelEvent as MapWheelEventMLGL,
-  MapTouchEvent as MapTouchEventMLGL,
-  MapMouseEvent as MapMouseEventMLGL,
-  config as configMLGL,
-  getVersion as getMapLibreVersion,
+  Map: MapMLGL,
+  Marker: MarkerMLGL,
+  Popup: PopupMLGL,
+  Style: StyleMLGL,
+  CanvasSource: CanvasSourceMLGL,
+  GeoJSONSource: GeoJSONSourceMLGL,
+  ImageSource: ImageSourceMLGL,
+  RasterTileSource: RasterTileSourceMLGL,
+  RasterDEMTileSource: RasterDEMTileSourceMLGL,
+  VectorTileSource: VectorTileSourceMLGL,
+  VideoSource: VideoSourceMLGL,
+  NavigationControl: NavigationControlMLGL,
+  GeolocateControl: GeolocateControlMLGL,
+  AttributionControl: AttributionControlMLGL,
+  LogoControl: LogoControlMLGL,
+  ScaleControl: ScaleControlMLGL,
+  FullscreenControl: FullscreenControlMLGL,
+  TerrainControl: TerrainControlMLGL,
+  BoxZoomHandler: BoxZoomHandlerMLGL,
+  ScrollZoomHandler: ScrollZoomHandlerMLGL,
+  CooperativeGesturesHandler: CooperativeGesturesHandlerMLGL,
+  KeyboardHandler: KeyboardHandlerMLGL,
+  TwoFingersTouchPitchHandler: TwoFingersTouchPitchHandlerMLGL,
+  MapWheelEvent: MapWheelEventMLGL,
+  MapTouchEvent: MapTouchEventMLGL,
+  MapMouseEvent: MapMouseEventMLGL,
+  config: configMLGL,
+  getVersion: getMapLibreVersion,
   // The folowing items are exported from MapLibre as-is because they
   // are already compatible with MapTiler SDK.
   setRTLTextPlugin,
@@ -77,7 +79,7 @@ export {
   importScriptInWorkers,
   addProtocol,
   removeProtocol,
-} from "maplibre-gl";
+} = maplibre;
 
 // The following items are only MapLibre adapted to MapTiler SDK Map class
 export { Marker } from "./MLAdapters/Marker";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import maplibre from "maplibre-gl";
+import maplibregl from "maplibre-gl";
 import packagejson from "../package.json";
 import { enableRTL } from "./tools";
 
@@ -79,7 +79,7 @@ export const {
   importScriptInWorkers,
   addProtocol,
   removeProtocol,
-} = maplibre;
+} = maplibregl;
 
 // The following items are only MapLibre adapted to MapTiler SDK Map class
 export { Marker } from "./MLAdapters/Marker";


### PR DESCRIPTION
## Objective
Fix #99.

## Description
Re-export classes and methods from MapLibre in a proper way to avoid CJS import errors in SvelteKit/Vite projects.

## Acceptance
No test cases were added, but tested locally with my client project to confirm the error was gone.

## Checklist
- [x] I have added relevant info to the CHANGELOG.md