### PR TITLE
RD-318: propagating the beforeId option on heatmap layer helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bug Fixes
 - Updating from MapLibre v4.4.1 to v4.6.0. See Maplibre changelogs for [v4.5.0](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#450), [v4.5.1](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#451), [v4.5.2](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#452), and [v4.6.0](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#460)
 - Fixed the elevation shift glitch happening with terrain animation after calling `.easeTo()` (https://github.com/maptiler/maptiler-sdk-js/pull/110)
+- The heatmap layer helper missed the `beforeId` option
 ### New Features
 - Updating from MapLibre v4.4.1 to v4.5.2, adding the following features. See Maplibre changelogs for for [v4.5.0](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#450), [v4.5.1](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#451), [v4.5.2](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#452), and [v4.6.0](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#460)
 ### Others

--- a/src/helpers/vectorlayerhelpers.ts
+++ b/src/helpers/vectorlayerhelpers.ts
@@ -1352,7 +1352,8 @@ export function addHeatmap(
           ? opacity
           : (rampedOptionsToLayerPaintSpec(opacity) as PropertyValueSpecification<number>),
     },
-  });
+  },
+  options.beforeId);
 
   return returnedInfo;
 }

--- a/src/helpers/vectorlayerhelpers.ts
+++ b/src/helpers/vectorlayerhelpers.ts
@@ -1329,31 +1329,33 @@ export function addHeatmap(
     });
   }
 
-  map.addLayer({
-    id: layerId,
-    type: "heatmap",
-    source: sourceId,
-    minzoom,
-    maxzoom,
-    paint: {
-      "heatmap-weight": heatmapWeight,
+  map.addLayer(
+    {
+      id: layerId,
+      type: "heatmap",
+      source: sourceId,
+      minzoom,
+      maxzoom,
+      paint: {
+        "heatmap-weight": heatmapWeight,
 
-      "heatmap-intensity":
-        typeof intensity === "number"
-          ? intensity
-          : (rampedOptionsToLayerPaintSpec(intensity) as PropertyValueSpecification<number>),
+        "heatmap-intensity":
+          typeof intensity === "number"
+            ? intensity
+            : (rampedOptionsToLayerPaintSpec(intensity) as PropertyValueSpecification<number>),
 
-      "heatmap-color": heatmapIntensityFromColorRamp(colorRamp),
+        "heatmap-color": heatmapIntensityFromColorRamp(colorRamp),
 
-      "heatmap-radius": radiusHeatmap,
+        "heatmap-radius": radiusHeatmap,
 
-      "heatmap-opacity":
-        typeof opacity === "number"
-          ? opacity
-          : (rampedOptionsToLayerPaintSpec(opacity) as PropertyValueSpecification<number>),
+        "heatmap-opacity":
+          typeof opacity === "number"
+            ? opacity
+            : (rampedOptionsToLayerPaintSpec(opacity) as PropertyValueSpecification<number>),
+      },
     },
-  },
-  options.beforeId);
+    options.beforeId,
+  );
 
   return returnedInfo;
 }


### PR DESCRIPTION
[RD-318](https://maptiler.atlassian.net/browse/RD-318)

[RD-318]: https://maptiler.atlassian.net/browse/RD-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ