### PR TITLE
RD-315: sourcing the language list from the client library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Others
 - Updating from MapLibre v4.4.1 to v4.5.2
 - Updating `MapTilerGeolocateControl` to match latest Maplibre update (https://github.com/maptiler/maptiler-sdk-js/pull/104)
+- Now sourcing language list from `@maptiler/client` (https://github.com/maptiler/maptiler-client-js/pull/42)
 
 ## 2.2.2
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@maptiler/client": "^1.8.1",
+        "@maptiler/client": "file:../maptiler-client-js/maptiler-client-1.8.1.tgz",
         "events": "^3.3.0",
         "js-base64": "^3.7.4",
         "maplibre-gl": "^4.6.0",
@@ -707,8 +707,9 @@
     },
     "node_modules/@maptiler/client": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@maptiler/client/-/client-1.8.1.tgz",
-      "integrity": "sha512-G1z2xCBwT5WU1CqeukY3R4g1saSjKzi6tmg24LJWZHP81RQ4quVvwdmsx829BxITlFbFhND+BSphFgrDGmwhcA==",
+      "resolved": "file:../maptiler-client-js/maptiler-client-1.8.1.tgz",
+      "integrity": "sha512-jFIpayqVDYwbTDm3FLIvXhkccuD9zL8/JS+7CahBaOAp+VNDV6Q+mogPNNBDl002wPPjO5ouOO36ttgrfBZqFw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "quick-lru": "^7.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@maptiler/client": "file:../maptiler-client-js/maptiler-client-2.0.0.tgz",
+        "@maptiler/client": "^2.0.0",
         "events": "^3.3.0",
         "js-base64": "^3.7.4",
         "maplibre-gl": "^4.6.0",
@@ -707,9 +707,8 @@
     },
     "node_modules/@maptiler/client": {
       "version": "2.0.0",
-      "resolved": "file:../maptiler-client-js/maptiler-client-2.0.0.tgz",
-      "integrity": "sha512-WFiW/jrNnzhb3W0QGaMUUhcy10tDjvQNDvaAANT+eKtZ1ifCKsxx+vPEzKHpsElt3snv9HDn2jrJuuGiEqCMNQ==",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@maptiler/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-0sxRhpizfkZPY4cEBMUxF9WaWraMPkWNJxi373qaGfP/e8aKFudt5GlHvOKc3hI0bjAyevAdjVJbKC6SUxOGkg==",
       "dependencies": {
         "quick-lru": "^7.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -708,7 +708,7 @@
     "node_modules/@maptiler/client": {
       "version": "1.8.1",
       "resolved": "file:../maptiler-client-js/maptiler-client-1.8.1.tgz",
-      "integrity": "sha512-jFIpayqVDYwbTDm3FLIvXhkccuD9zL8/JS+7CahBaOAp+VNDV6Q+mogPNNBDl002wPPjO5ouOO36ttgrfBZqFw==",
+      "integrity": "sha512-IyNCWbUidEGbmFMdfehpf4M3g0oqq5Ll86DnX6B07g9PFGyBbi9awhS8X6OrGGRXUsfCBWrVAyNIbUwAX6KJ7g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "quick-lru": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@maptiler/client": "file:../maptiler-client-js/maptiler-client-1.8.1.tgz",
+        "@maptiler/client": "file:../maptiler-client-js/maptiler-client-2.0.0.tgz",
         "events": "^3.3.0",
         "js-base64": "^3.7.4",
         "maplibre-gl": "^4.6.0",
@@ -706,9 +706,9 @@
       }
     },
     "node_modules/@maptiler/client": {
-      "version": "1.8.1",
-      "resolved": "file:../maptiler-client-js/maptiler-client-1.8.1.tgz",
-      "integrity": "sha512-IyNCWbUidEGbmFMdfehpf4M3g0oqq5Ll86DnX6B07g9PFGyBbi9awhS8X6OrGGRXUsfCBWrVAyNIbUwAX6KJ7g==",
+      "version": "2.0.0",
+      "resolved": "file:../maptiler-client-js/maptiler-client-2.0.0.tgz",
+      "integrity": "sha512-WFiW/jrNnzhb3W0QGaMUUhcy10tDjvQNDvaAANT+eKtZ1ifCKsxx+vPEzKHpsElt3snv9HDn2jrJuuGiEqCMNQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "quick-lru": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "module": "dist/maptiler-sdk.mjs",
   "types": "dist/maptiler-sdk.d.ts",
@@ -61,7 +61,7 @@
     "vitest": "^0.34.2"
   },
   "dependencies": {
-    "@maptiler/client": "file:../maptiler-client-js/maptiler-client-2.0.0.tgz",
+    "@maptiler/client": "^2.0.0",
     "events": "^3.3.0",
     "js-base64": "^3.7.4",
     "maplibre-gl": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vitest": "^0.34.2"
   },
   "dependencies": {
-    "@maptiler/client": "file:../maptiler-client-js/maptiler-client-1.8.1.tgz",
+    "@maptiler/client": "file:../maptiler-client-js/maptiler-client-2.0.0.tgz",
     "events": "^3.3.0",
     "js-base64": "^3.7.4",
     "maplibre-gl": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vitest": "^0.34.2"
   },
   "dependencies": {
-    "@maptiler/client": "^1.8.1",
+    "@maptiler/client": "file:../maptiler-client-js/maptiler-client-1.8.1.tgz",
     "events": "^3.3.0",
     "js-base64": "^3.7.4",
     "maplibre-gl": "^4.6.0",

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -829,7 +829,13 @@ export class Map extends maplibregl.Map {
 
     // If the language is set to `STYLE` (which is the SDK default), but the language defined in
     // the style is `auto`, we need to bypass some verification and modify the languages anyway
-    if (!(language.flag === Language.STYLE.flag && (styleLanguage && (styleLanguage.flag === Language.AUTO.flag || styleLanguage.flag === Language.VISITOR.flag)))) {
+    if (
+      !(
+        language.flag === Language.STYLE.flag &&
+        styleLanguage &&
+        (styleLanguage.flag === Language.AUTO.flag || styleLanguage.flag === Language.VISITOR.flag)
+      )
+    ) {
       if (language.flag !== Language.STYLE.flag) {
         this.languageAlwaysBeenStyle = false;
       }
@@ -881,11 +887,17 @@ export class Map extends maplibregl.Map {
           ["==", ["get", langStr], ["get", Language.LOCAL.flag]],
           ["get", Language.LOCAL.flag],
 
-          ["format", ["get", langStr], { "font-scale": 0.8 }, "\n", ["get", Language.LOCAL.flag], { "font-scale": 1.1 }],
+          [
+            "format",
+            ["get", langStr],
+            { "font-scale": 0.8 },
+            "\n",
+            ["get", Language.LOCAL.flag],
+            { "font-scale": 1.1 },
+          ],
         ],
         ["get", Language.LOCAL.flag],
       ];
-
     } else if (languageNonStyle.flag === Language.VISITOR_ENGLISH.flag) {
       langStr = Language.ENGLISH.flag;
       replacer = [
@@ -896,11 +908,17 @@ export class Map extends maplibregl.Map {
           ["==", ["get", langStr], ["get", Language.LOCAL.flag]],
           ["get", Language.LOCAL.flag],
 
-          ["format", ["get", langStr], { "font-scale": 0.8 }, "\n", ["get", Language.LOCAL.flag], { "font-scale": 1.1 }],
+          [
+            "format",
+            ["get", langStr],
+            { "font-scale": 0.8 },
+            "\n",
+            ["get", Language.LOCAL.flag],
+            { "font-scale": 1.1 },
+          ],
         ],
         ["get", Language.LOCAL.flag],
       ];
-
     } else if (languageNonStyle.flag === Language.AUTO.flag) {
       langStr = getBrowserLanguage().flag;
       replacer = ["case", ["has", langStr], ["get", langStr], ["get", Language.LOCAL.flag]];

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import EventEmitter from "events";
-import type { LanguageString } from "./language";
+import type { LanguageInfo } from "./language";
 import { config as clientConfig, type FetchFunction } from "@maptiler/client";
 import { v4 as uuidv4 } from "uuid";
 import type { Unit } from "./unit";
@@ -14,13 +14,13 @@ class SdkConfig extends EventEmitter {
   /**
    * The primary language. By default, the language of the web browser is used.
    */
-  primaryLanguage: LanguageString = defaults.primaryLanguage;
+  primaryLanguage: LanguageInfo = defaults.primaryLanguage;
 
   /**
    * The secondary language, to overwrite the default language defined in the map style.
    * This settings is highly dependant on the style compatibility and may not work in most cases.
    */
-  secondaryLanguage?: LanguageString;
+  secondaryLanguage?: LanguageInfo;
 
   /**
    * Setting on whether of not the SDK runs with a session logic.

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,9 +220,7 @@ export {
   type GeolocationInfoOptions,
   type GeolocationResult,
   type GetDataOptions,
-  LanguageGeocoding,
   type LanguageGeocodingOptions,
-  type LanguageGeocodingString,
   MapStyle,
   type MapStylePreset,
   type MapStyleType,
@@ -243,7 +241,6 @@ export {
   expandMapStyle,
   geocoding,
   geolocation,
-  getAutoLanguageGeocoding,
   getBufferToPixelDataParser,
   getTileCache,
   mapStylePresetList,
@@ -251,6 +248,14 @@ export {
   misc,
   staticMaps,
   styleToStyle,
+  type LanguageInfo,
+  areSameLanguages,
+  toLanguageInfo,
+  isLanguageInfo,
+  getAutoLanguage,
+  getLanguageInfoFromFlag,
+  getLanguageInfoFromCode,
+  getLanguageInfoFromKey,
 } from "@maptiler/client";
 
 export { config, SdkConfig } from "./config";

--- a/src/language.ts
+++ b/src/language.ts
@@ -6,13 +6,27 @@ const Language = {
    * Language mode to display labels in both the local language and the language of the visitor's device, concatenated.
    * Note that if those two languages are the same, labels won't be duplicated.
    */
-  VISITOR: { code: null, flag: "visitor", name: "Visitor", latin: true, isMode: true, geocoding: false } as LanguageInfo,
+  VISITOR: {
+    code: null,
+    flag: "visitor",
+    name: "Visitor",
+    latin: true,
+    isMode: true,
+    geocoding: false,
+  } as LanguageInfo,
 
   /**
    * Language mode to display labels in both the local language and English, concatenated.
    * Note that if those two languages are the same, labels won't be duplicated.
    */
-  VISITOR_ENGLISH: { code: null, flag: "visitor_en", name: "Visitor English", latin: true, isMode: true, geocoding: false } as LanguageInfo,
+  VISITOR_ENGLISH: {
+    code: null,
+    flag: "visitor_en",
+    name: "Visitor English",
+    latin: true,
+    isMode: true,
+    geocoding: false,
+  } as LanguageInfo,
 
   /**
    * Language mode to display labels in a language enforced in the style.
@@ -22,11 +36,17 @@ const Language = {
   /**
    * Language mode to display labels in a language enforced in the style. The language cannot be further modified.
    */
-  STYLE_LOCK: { code: null, flag: "style_lock", name: "Style Lock", latin: false, isMode: true, geocoding: false } as LanguageInfo,
+  STYLE_LOCK: {
+    code: null,
+    flag: "style_lock",
+    name: "Style Lock",
+    latin: false,
+    isMode: true,
+    geocoding: false,
+  } as LanguageInfo,
 
   ...LanguageFromClient,
 } as const;
-
 
 /**
  * Get the browser language
@@ -41,9 +61,7 @@ export function getBrowserLanguage(): LanguageInfo {
     return Language.ENGLISH;
   }
 
-  const canditatelangs = Array.from(
-    new Set(navigator.languages.map((l) => l.split("-")[0])),
-  )
+  const canditatelangs = Array.from(new Set(navigator.languages.map((l) => l.split("-")[0])))
     .map((code) => getLanguageInfoFromCode(code))
     .filter((li) => li);
 

--- a/src/language.ts
+++ b/src/language.ts
@@ -2,8 +2,6 @@ import { Language as LanguageFromClient, getLanguageInfoFromCode, type LanguageI
 
 // Adding some language entries that are specific to the SDK
 const Language = {
-  ...LanguageFromClient,
-  
   /**
    * Language mode to display labels in both the local language and the language of the visitor's device, concatenated.
    * Note that if those two languages are the same, labels won't be duplicated.
@@ -26,6 +24,7 @@ const Language = {
    */
   STYLE_LOCK: { code: null, flag: "style_lock", name: "Style Lock", latin: false, isMode: true, geocoding: false } as LanguageInfo,
 
+  ...LanguageFromClient,
 } as const;
 
 

--- a/src/language.ts
+++ b/src/language.ts
@@ -1,173 +1,54 @@
-/**
- * Languages. Note that not all the languages of this list are available but the compatibility list may be expanded in the future.
- */
+import { Language as LanguageFromClient, getLanguageInfoFromCode, type LanguageInfo } from "@maptiler/client";
+
+// Adding some language entries that are specific to the SDK
 const Language = {
+  ...LanguageFromClient,
+  
   /**
-   * The visitor language mode concatenates the prefered language from the user settings and the "default name".
-   * Note: The "default name" is equivalent to OSM's `{name}`, which can be the most recognized names a global
-   * scale or the local name.
-   * This mode is helpful in the context where a user needs to access both the local names and the names in their
-   * own language, for instance when traveling abroad, where signs likely to be only available in the local language.
+   * Language mode to display labels in both the local language and the language of the visitor's device, concatenated.
+   * Note that if those two languages are the same, labels won't be duplicated.
    */
-  VISITOR: "visitor",
+  VISITOR: { code: null, flag: "visitor", name: "Visitor", latin: true, isMode: true, geocoding: false } as LanguageInfo,
 
   /**
-   * The visitor language mode concatenates English and the "default name".
-   * Note: The "default name" is equivalent to OSM's `{name}`, which can be the most recognized names a global
-   * scale or the local name.
-   * This mode is helpful in the context where a user needs to access both the local names and the names in their
-   * own language, for instance when traveling abroad, where signs likely to be only available in the local language.
+   * Language mode to display labels in both the local language and English, concatenated.
+   * Note that if those two languages are the same, labels won't be duplicated.
    */
-  VISITOR_ENGLISH: "visitor_en",
+  VISITOR_ENGLISH: { code: null, flag: "visitor_en", name: "Visitor English", latin: true, isMode: true, geocoding: false } as LanguageInfo,
 
   /**
-   * Language as the style is designed. Not that this is the default state and one
-   * the language has been changed to another than `STYLE`, then it cannot be set back to `STYLE`.
+   * Language mode to display labels in a language enforced in the style.
    */
-  STYLE: "style",
+  STYLE: { code: null, flag: "style", name: "Style", latin: false, isMode: true, geocoding: false } as LanguageInfo,
 
   /**
-   * AUTO mode uses the language of the browser
+   * Language mode to display labels in a language enforced in the style. The language cannot be further modified.
    */
-  AUTO: "auto",
+  STYLE_LOCK: { code: null, flag: "style_lock", name: "Style Lock", latin: false, isMode: true, geocoding: false } as LanguageInfo,
 
-  /**
-   * STYLE is a custom flag to keep the language of the map as defined into the style.
-   * If STYLE is set in the constructor, then further modification of the language
-   * with `.setLanguage()` is not possible.
-   */
-  STYLE_LOCK: "style_lock",
-
-  /**
-   * Default fallback languages that uses latin charaters
-   */
-  LATIN: "name:latin",
-
-  /**
-   * Default fallback languages that uses non-latin charaters
-   */
-  NON_LATIN: "name:nonlatin",
-
-  /**
-   * Labels are in their local language, when available
-   */
-  LOCAL: "name",
-
-  /**
-   * International name
-   */
-  INTERNATIONAL: "name_int",
-
-  ALBANIAN: "name:sq",
-  AMHARIC: "name:am",
-  ARABIC: "name:ar",
-  ARMENIAN: "name:hy",
-  AZERBAIJANI: "name:az",
-  BASQUE: "name:eu",
-  BELORUSSIAN: "name:be",
-  BENGALI: "name:bn",
-  BOSNIAN: "name:bs",
-  BRETON: "name:br",
-  BULGARIAN: "name:bg",
-  CATALAN: "name:ca",
-  CHINESE: "name:zh",
-  TRADITIONAL_CHINESE: "name:zh-Hant",
-  SIMPLIFIED_CHINESE: "name:zh-Hans",
-  CORSICAN: "name:co",
-  CROATIAN: "name:hr",
-  CZECH: "name:cs",
-  DANISH: "name:da",
-  DUTCH: "name:nl",
-  ENGLISH: "name:en",
-  ESPERANTO: "name:eo",
-  ESTONIAN: "name:et",
-  FINNISH: "name:fi",
-  FRENCH: "name:fr",
-  FRISIAN: "name:fy",
-  GEORGIAN: "name:ka",
-  GERMAN: "name:de",
-  GREEK: "name:el",
-  HEBREW: "name:he",
-  HINDI: "name:hi",
-  HUNGARIAN: "name:hu",
-  ICELANDIC: "name:is",
-  INDONESIAN: "name:id",
-  IRISH: "name:ga",
-  ITALIAN: "name:it",
-  JAPANESE: "name:ja",
-  JAPANESE_HIRAGANA: "name:ja-Hira",
-  JAPANESE_KANA: "name:ja_kana",
-  JAPANESE_LATIN: "name:ja_rm",
-  JAPANESE_2018: "name:ja-Latn",
-  KANNADA: "name:kn",
-  KAZAKH: "name:kk",
-  KOREAN: "name:ko",
-  KOREAN_LATIN: "name:ko-Latn",
-  KURDISH: "name:ku",
-  ROMAN_LATIN: "name:la",
-  LATVIAN: "name:lv",
-  LITHUANIAN: "name:lt",
-  LUXEMBOURGISH: "name:lb",
-  MACEDONIAN: "name:mk",
-  MALAYALAM: "name:ml",
-  MALTESE: "name:mt",
-  NORWEGIAN: "name:no",
-  OCCITAN: "name:oc",
-  PERSIAN: "name:fa",
-  POLISH: "name:pl",
-  PORTUGUESE: "name:pt",
-  PUNJABI: "name:pa",
-  WESTERN_PUNJABI: "name:pnb",
-  ROMANIAN: "name:ro",
-  ROMANSH: "name:rm",
-  RUSSIAN: "name:ru",
-  SCOTTISH_GAELIC: "name:gd",
-  SERBIAN_CYRILLIC: "name:sr",
-  SERBIAN_LATIN: "name:sr-Latn",
-  SLOVAK: "name:sk",
-  SLOVENE: "name:sl",
-  SPANISH: "name:es",
-  SWEDISH: "name:sv",
-  TAMIL: "name:ta",
-  TELUGU: "name:te",
-  THAI: "name:th",
-  TURKISH: "name:tr",
-  UKRAINIAN: "name:uk",
-  URDU: "name:ur",
-  VIETNAMIAN_LATIN: "name:vi",
-  WELSH: "name:cy",
 } as const;
 
-const languagesIsoSet = new Set(Object.values(Language) as Array<string>);
-
-function isLanguageSupported(lang: string): boolean {
-  return languagesIsoSet.has(lang);
-}
-
-const languageCodeSet = new Set(Object.values(Language));
 
 /**
- * Type representing the key of the Language object
+ * Get the browser language
  */
-type LanguageKey = keyof typeof Language;
-
-type Values<T> = T[keyof T];
-
-/**
- * Built-in languages values as strings
- */
-type LanguageString = Values<typeof Language>;
-
-function getBrowserLanguage(): LanguageString {
+export function getBrowserLanguage(): LanguageInfo {
   if (typeof navigator === "undefined") {
-    return `name:${Intl.DateTimeFormat().resolvedOptions().locale.split("-")[0]}` as LanguageString;
+    const code = Intl.DateTimeFormat().resolvedOptions().locale.split("-")[0];
+
+    const langInfo = getLanguageInfoFromCode(code);
+
+    if (langInfo) return langInfo;
+    return Language.ENGLISH;
   }
 
-  const canditatelangs = Array.from(new Set(navigator.languages.map((l) => `name:${l.split("-")[0]}`))).filter((l) =>
-    languageCodeSet.has(l as LanguageString),
-  );
+  const canditatelangs = Array.from(
+    new Set(navigator.languages.map((l) => l.split("-")[0])),
+  )
+    .map((code) => getLanguageInfoFromCode(code))
+    .filter((li) => li);
 
-  return canditatelangs.length ? (canditatelangs[0] as LanguageString) : Language.LOCAL;
+  return canditatelangs[0] ?? Language.LOCAL;
 }
 
-export { Language, type LanguageString, type LanguageKey, getBrowserLanguage, isLanguageSupported };
+export { Language, type LanguageInfo };


### PR DESCRIPTION
[RD-315](https://maptiler.atlassian.net/browse/RD-315)

This is about updating the language list that is now sourced from the Client library (https://github.com/maptiler/maptiler-client-js/pull/42)

[RD-315]: https://maptiler.atlassian.net/browse/RD-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ