### PR TITLE
Rd-324: Handle invalid map style in constructor

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -632,7 +632,10 @@ export class Map extends maplibregl.Map {
       this.forceLanguageUpdate = false;
     });
 
-    return super.setStyle(styleToStyle(style), options);
+    const compatibleStyle = styleToStyle(style);
+    // TODO: async check remote style
+    super.setStyle(compatibleStyle, options);
+    return this;
   }
 
   /**

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -29,7 +29,7 @@ import { getBrowserLanguage, Language, type LanguageInfo } from "./language";
 import { styleToStyle } from "./mapstyle";
 import { MaptilerTerrainControl } from "./MaptilerTerrainControl";
 import { MaptilerNavigationControl } from "./MaptilerNavigationControl";
-import { geolocation, getLanguageInfoFromFlag, toLanguageInfo } from "@maptiler/client";
+import { MapStyle, geolocation, getLanguageInfoFromFlag, toLanguageInfo } from "@maptiler/client";
 import { MaptilerGeolocateControl } from "./MaptilerGeolocateControl";
 import { ScaleControl } from "./MLAdapters/ScaleControl";
 import { FullscreenControl } from "./MLAdapters/FullscreenControl";
@@ -632,8 +632,17 @@ export class Map extends maplibregl.Map {
       this.forceLanguageUpdate = false;
     });
 
-    const compatibleStyle = styleToStyle(style);
-    // TODO: async check remote style
+    const compatibleStyle = styleToStyle(
+      style,
+      // onStyleUrlNotFound callback
+      // This callback is async (performs a header fetch)
+      // and will most likely run after the `super.setStyle()` below
+      (styleURL: string) => {
+        console.warn(`The style URL ${styleURL} does not yield a valid style. Loading the default style instead.`);
+        this.setStyle(MapStyle.STREETS);
+      },
+    );
+
     super.setStyle(compatibleStyle, options);
     return this;
   }

--- a/src/RequestLogger.ts
+++ b/src/RequestLogger.ts
@@ -1,0 +1,68 @@
+import type { ResourceType } from "maplibre-gl";
+
+/**
+ * Entry for a request
+ */
+export type RequestRecord = {
+  /**
+   * URL, absolute or relative
+   */
+  url: string;
+
+  /**
+   * Code for the type of resource
+   */
+  resourceType?: ResourceType;
+
+  /**
+   * Timestamps (ms) just before perfoaming the request
+   */
+  timestamp: [number];
+};
+
+/**
+ * Logs all the request (http and custom protocols) with resource types.
+ * Essentially a JS Map object.
+ */
+class RequestLogger {
+  private records = new Map<string, RequestRecord>();
+
+  /**
+   * Add a record. The unique key is the URL. If URL already exists,
+   * a new timestamp is added to the array for the already existing record.
+   */
+  add(url: string, resourceType?: ResourceType) {
+    if (this.records.has(url)) {
+      const record = this.records.get(url);
+      record?.timestamp.push(+new Date());
+    } else {
+      this.records.set(url, {
+        url,
+        resourceType,
+        timestamp: [+new Date()],
+      } as RequestRecord);
+    }
+  }
+
+  /**
+   * Gets a record or `null`.
+   */
+  get(url: string): RequestRecord | null {
+    if (this.records.has(url)) {
+      return this.records.get(url) as RequestRecord;
+    }
+    return null;
+  }
+}
+
+let requestLogger: RequestLogger | null = null;
+
+/**
+ * Get a singleton RequetLogger instance
+ */
+export function getRequestlogger(): RequestLogger {
+  if (!requestLogger) {
+    requestLogger = new RequestLogger();
+  }
+  return requestLogger;
+}

--- a/src/mapstyle.ts
+++ b/src/mapstyle.ts
@@ -1,7 +1,10 @@
 import { MapStyle, ReferenceMapStyle, MapStyleVariant, mapStylePresetList, expandMapStyle } from "@maptiler/client";
+import { config } from "./config";
+import { defaults } from "./defaults";
 
 export function styleToStyle(
   style: string | ReferenceMapStyle | MapStyleVariant | maplibregl.StyleSpecification | null | undefined,
+  onStyleUrlNotFound?: (url: string) => void,
 ): string | maplibregl.StyleSpecification {
   if (!style) {
     return MapStyle[mapStylePresetList[0].referenceStyleID as keyof typeof MapStyle]
@@ -11,13 +14,27 @@ export function styleToStyle(
 
   // If the provided style is a shorthand (eg. "streets-v2") or a full style URL
   if (typeof style === "string" || style instanceof String) {
+    let styleURL: string;
+
     if (!style.startsWith("http") && style.toLowerCase().includes(".json")) {
       // If a style does not start by http but still contains the extension ".json"
       // we assume it's a relative path to a style json file
-      return style as string;
+      styleURL = style as string;
+    } else {
+      styleURL = expandMapStyle(style);
     }
 
-    return expandMapStyle(style);
+    // Validating the style by fetching at the URL.
+    // If the response is not "ok", the optional callback is executed
+    if (onStyleUrlNotFound) {
+      validateRemoteStyle(styleURL).then((isStyleOK) => {
+        if (!isStyleOK) {
+          onStyleUrlNotFound(styleURL);
+        }
+      });
+    }
+
+    return styleURL;
   }
 
   if (style instanceof MapStyleVariant) {
@@ -31,7 +48,21 @@ export function styleToStyle(
   return style as maplibregl.StyleSpecification;
 }
 
+/**
+ * Tests if a distant style URL resolves
+ */
+export async function validateRemoteStyle(styleURL: string): Promise<boolean> {
+  let url: URL;
 
-// export async function validateRemoteStyle(styleURL: string, apiKey: string): boolean {
+  if (styleURL.startsWith("http")) {
+    url = new URL(styleURL);
+    if (url.host === defaults.maptilerApiHost && url.searchParams.get("key") === null) {
+      url.searchParams.set("key", config.apiKey);
+    }
+  } else {
+    url = new URL(styleURL, location.origin);
+  }
 
-// }
+  const res = await fetch(url.href);
+  return res.ok;
+}

--- a/src/mapstyle.ts
+++ b/src/mapstyle.ts
@@ -1,10 +1,7 @@
 import { MapStyle, ReferenceMapStyle, MapStyleVariant, mapStylePresetList, expandMapStyle } from "@maptiler/client";
-import { config } from "./config";
-import { defaults } from "./defaults";
 
 export function styleToStyle(
   style: string | ReferenceMapStyle | MapStyleVariant | maplibregl.StyleSpecification | null | undefined,
-  onStyleUrlNotFound?: (url: string) => void,
 ): string | maplibregl.StyleSpecification {
   if (!style) {
     return MapStyle[mapStylePresetList[0].referenceStyleID as keyof typeof MapStyle]
@@ -14,27 +11,13 @@ export function styleToStyle(
 
   // If the provided style is a shorthand (eg. "streets-v2") or a full style URL
   if (typeof style === "string" || style instanceof String) {
-    let styleURL: string;
-
     if (!style.startsWith("http") && style.toLowerCase().includes(".json")) {
       // If a style does not start by http but still contains the extension ".json"
       // we assume it's a relative path to a style json file
-      styleURL = style as string;
-    } else {
-      styleURL = expandMapStyle(style);
+      return style as string;
     }
 
-    // Validating the style by fetching at the URL.
-    // If the response is not "ok", the optional callback is executed
-    if (onStyleUrlNotFound) {
-      validateRemoteStyle(styleURL).then((isStyleOK) => {
-        if (!isStyleOK) {
-          onStyleUrlNotFound(styleURL);
-        }
-      });
-    }
-
-    return styleURL;
+    return expandMapStyle(style);
   }
 
   if (style instanceof MapStyleVariant) {
@@ -46,23 +29,4 @@ export function styleToStyle(
   }
 
   return style as maplibregl.StyleSpecification;
-}
-
-/**
- * Tests if a distant style URL resolves
- */
-export async function validateRemoteStyle(styleURL: string): Promise<boolean> {
-  let url: URL;
-
-  if (styleURL.startsWith("http")) {
-    url = new URL(styleURL);
-    if (url.host === defaults.maptilerApiHost && url.searchParams.get("key") === null) {
-      url.searchParams.set("key", config.apiKey);
-    }
-  } else {
-    url = new URL(styleURL, location.origin);
-  }
-
-  const res = await fetch(url.href);
-  return res.ok;
 }

--- a/src/mapstyle.ts
+++ b/src/mapstyle.ts
@@ -30,3 +30,8 @@ export function styleToStyle(
 
   return style as maplibregl.StyleSpecification;
 }
+
+
+// export async function validateRemoteStyle(styleURL: string, apiKey: string): boolean {
+
+// }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,6 +4,7 @@ import { defaults } from "./defaults";
 import { config } from "./config";
 import { MAPTILER_SESSION_ID } from "./config";
 import { localCacheTransformRequest } from "./caching";
+import { getRequestlogger } from "./RequestLogger";
 
 export function enableRTL() {
   // Prevent this from running server side
@@ -79,8 +80,13 @@ export function maptilerCloudTransformRequest(url: string, resourceType?: Resour
     }
   }
 
+  const localCacheTransformedReq = localCacheTransformRequest(reqUrl, resourceType);
+
+  const requestLogger = getRequestlogger();
+  requestLogger.add(localCacheTransformedReq, resourceType);
+
   return {
-    url: localCacheTransformRequest(reqUrl, resourceType),
+    url: localCacheTransformedReq,
   };
 }
 


### PR DESCRIPTION
[RD-324](https://maptiler.atlassian.net/browse/RD-324)

If an invalid style URL or shorthand is provided to the `Map` constructor or to the `.setStyle(...)` method it was failing without any message other than the Maplibre HTTP error in the console.

Now, if the style leads to a URL with an HTTP status other than 2xx, it falls back to the built-in `STREETS` style and displays a message in the console.

It can be tested with 

```ts
const map = new maptilersdk.Map({
  container: "map-container",
  style: "streets-v100", // this one does not exist
});

// or

const map = new maptilersdk.Map({
  container: "map-container",
  style: "00000000-0000-0000-0000-000000000000", // a wrong UUID that has the shape of a real onw
});

// or 

const map = new maptilersdk.Map({
  container: "map-container",
  style: "/some-inesisting-style.json", // a local URL pointing to something inexisting
});
```

Note: Using an invalid`ReferenceMapStyle` or `MapStyleVariant` such as `MapStyle.STREEEETS` or `MapStyle.STREETS.DAAAARK` is a situation that was already dealt with by using a fallback.

[RD-324]: https://maptiler.atlassian.net/browse/RD-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ