### PR TITLE
Language switching fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MapTiler SDK Changelog
 
+## 2.4.2
+### Bug Fixes
+- The language switching is now more robust and preserves the original formatting from the style (`Map.setPrimareyLangage()`)
+
 ## 2.4.1
 ### Bug Fixes
 - The class `AJAXError` is now imported as part of the `maplibregl` namespace (CommonJS limitation from Maplibre GL JS) (https://github.com/maptiler/maptiler-sdk-js/pull/129)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.2
 ### Bug Fixes
-- The language switching is now more robust and preserves the original formatting from the style (`Map.setPrimareyLangage()`) (https://github.com/maptiler/maptiler-sdk-js/pull/134)
+- The language switching is now more robust and preserves the original formatting from the style (`Map.setPrimaryLangage()`) (https://github.com/maptiler/maptiler-sdk-js/pull/134)
 
 ## 2.4.1
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.2
 ### Bug Fixes
-- The language switching is now more robust and preserves the original formatting from the style (`Map.setPrimareyLangage()`)
+- The language switching is now more robust and preserves the original formatting from the style (`Map.setPrimareyLangage()`) (https://github.com/maptiler/maptiler-sdk-js/pull/134)
 
 ## 2.4.1
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "2.3.1",
+      "version": "2.4.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^20.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "module": "dist/maptiler-sdk.mjs",
   "types": "dist/maptiler-sdk.d.ts",

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -28,6 +28,7 @@ import {
   changeFirstLanguage,
   checkNamePattern,
   combineTransformRequest,
+  computeLabelsLocalizationMetrics,
   displayNoWebGlWarning,
   displayWebGLContextLostWarning,
   replaceLanguage,
@@ -198,6 +199,7 @@ export class Map extends maplibregl.Map {
   private monitoredStyleUrls!: Set<string>;
   private styleInProcess = false;
   private originalLabelStyle = new window.Map<string, ExpressionSpecification | string>();
+  private isStyleLocalized = false;
 
   constructor(options: MapOptions) {
     displayNoWebGlWarning(options.container);
@@ -1012,7 +1014,7 @@ export class Map extends maplibregl.Map {
     let langStr = Language.LOCAL.flag;
 
     // will be overwritten below
-    let replacer: ExpressionSpecification | string = ["get", langStr];
+    let replacer: ExpressionSpecification = ["get", langStr];
 
     if (languageNonStyle.flag === Language.VISITOR.flag) {
       langStr = getBrowserLanguage().flag;
@@ -1077,6 +1079,14 @@ export class Map extends maplibregl.Map {
 
     // True if it's the first time the language is updated for the current style
     const firstPassOnStyle = this.originalLabelStyle.size === 0;
+
+    // Analisis on all the label layers to check the languages being used
+    if (firstPassOnStyle) {
+      const labelsLocalizationMetrics = computeLabelsLocalizationMetrics(layers, this);
+      this.isStyleLocalized = Object.keys(labelsLocalizationMetrics.localized).length > 0;
+      console.log("this.isStyleLocalized", this.isStyleLocalized);
+      
+    }
 
     for (const genericLayer of layers) {
       // Only symbole layer can have a layout with text-field

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1010,7 +1010,7 @@ export class Map extends maplibregl.Map {
     let langStr = Language.LOCAL.flag;
 
     // will be overwritten below
-    let replacer: ExpressionSpecification | string = `{${langStr}}`;
+    let replacer: ExpressionSpecification | string = ["get", langStr];
 
     if (languageNonStyle.flag === Language.VISITOR.flag) {
       langStr = getBrowserLanguage().flag;
@@ -1062,7 +1062,7 @@ export class Map extends maplibregl.Map {
     // This is for using the regular names as {name}
     else if (languageNonStyle === Language.LOCAL) {
       langStr = Language.LOCAL.flag;
-      replacer = `{${langStr}}`;
+      replacer = ["get", langStr];
     }
 
     // This section is for the regular language ISO codes
@@ -1145,7 +1145,6 @@ export class Map extends maplibregl.Map {
       // The value of text-field is an object
       else {
         const newReplacer = changeFirstLanguage(textFieldLayoutProp, replacer);
-        console.log("New replacer:", newReplacer);
         this.setLayoutProperty(id, "text-field", newReplacer);
       }
     }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -226,3 +226,40 @@ export function displayWebGLContextLostWarning(container: HTMLElement | string) 
   actualContainer.appendChild(errorMessageDiv);
   // throw new Error(webglError);
 }
+
+/**
+ * Return true if the provided piece of style expression has the form ["get", "name:XX"]
+ * with XX benig a 2-letter is code for languages
+ */
+function isGetNameLanguage(subExpr: unknown): boolean {
+  if (!Array.isArray(subExpr)) return false;
+  if (subExpr.length !== 2) return false;
+  if (subExpr[0] !== "get") return false;
+  if (typeof subExpr[1] !== "string") return false;
+  if (!subExpr[1].startsWith("name:")) return false;
+
+  return true;
+}
+
+export function changeFirstLanguage(
+  origExpr: maplibregl.ExpressionSpecification,
+  replacer: maplibregl.ExpressionSpecification | string,
+): maplibregl.ExpressionSpecification {
+  const expr = structuredClone(origExpr) as maplibregl.ExpressionSpecification;
+
+  const exploreNode = (subExpr: maplibregl.ExpressionSpecification | string) => {
+    if (typeof subExpr === "string") return;
+
+    for (let i = 0; i < subExpr.length; i += 1) {
+      if (isGetNameLanguage(subExpr[i])) {
+        subExpr[i] = structuredClone(replacer);
+      } else {
+        exploreNode(subExpr[i] as maplibregl.ExpressionSpecification | string);
+      }
+    }
+  };
+
+  exploreNode(expr);
+
+  return expr;
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -273,7 +273,7 @@ export function changeFirstLanguage(
  * Tst if a string matches the pattern "{name:xx}" in a exact way or is a loose way (such as "foo {name:xx}")
  */
 export function checkNamePattern(str: string): { contains: boolean; exactMatch: boolean } {
-  const regex = /\{name:[a-zA-Z]{2}\}/;
+  const regex = /\{name:\S+\}/;
   return {
     contains: regex.test(str),
     exactMatch: new RegExp(`^${regex.source}$`).test(str),
@@ -287,7 +287,7 @@ export function replaceLanguage(
   origLang: string,
   newLang: maplibregl.ExpressionSpecification,
 ): maplibregl.ExpressionSpecification {
-  const elementsToConcat = origLang.split(/\{name:[a-zA-Z]{2}\}/);
+  const elementsToConcat = origLang.split(/\{name:\S+\}/);
 
   const allElements = elementsToConcat.flatMap((item, i) =>
     i === elementsToConcat.length - 1 ? [item] : [item, newLang],

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -268,3 +268,31 @@ export function changeFirstLanguage(
   exploreNode(expr);
   return expr;
 }
+
+/**
+ * Tst if a string matches the pattern "{name:xx}" in a exact way or is a loose way (such as "foo {name:xx}")
+ */
+export function checkNamePattern(str: string): { contains: boolean; exactMatch: boolean } {
+  const regex = /\{name:[a-zA-Z]{2}\}/;
+  return {
+    contains: regex.test(str),
+    exactMatch: new RegExp(`^${regex.source}$`).test(str),
+  };
+}
+
+/**
+ * Replaces the occurences of {name:xx} in a string by a provided object-expression to return a concat object expression
+ */
+export function replaceLanguage(
+  origLang: string,
+  newLang: maplibregl.ExpressionSpecification,
+): maplibregl.ExpressionSpecification {
+  const elementsToConcat = origLang.split(/\{name:[a-zA-Z]{2}\}/);
+
+  const allElements = elementsToConcat.flatMap((item, i) =>
+    i === elementsToConcat.length - 1 ? [item] : [item, newLang],
+  );
+
+  const expr = ["concat", ...allElements] as maplibregl.ExpressionSpecification;
+  return expr;
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -241,6 +241,12 @@ function isGetNameLanguage(subExpr: unknown): boolean {
   return true;
 }
 
+/**
+ * In a text-field style property (as an object, not a string) the langages that are specified as
+ * ["get", "name:XX"] are replaced by the proved replacer (also an object).
+ * This replacement happened regardless of how deep in the object the flag is.
+ * Note that it does not replace the occurences of ["get", "name"] (local names)
+ */
 export function changeFirstLanguage(
   origExpr: maplibregl.ExpressionSpecification,
   replacer: maplibregl.ExpressionSpecification | string,
@@ -260,6 +266,5 @@ export function changeFirstLanguage(
   };
 
   exploreNode(expr);
-
   return expr;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "baseUrl": "src",
     "moduleResolution": "Node",
-    "target": "ES2020",
+    "target": "es2021",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["es2021", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
[RD-438](https://maptiler.atlassian.net/browse/RD-438)

The language switching is now working better and is more robust when there is advance styling or ramping

[RD-438]: https://maptiler.atlassian.net/browse/RD-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ