### PR TITLE
Quiet error on geolocate control with Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.5.1
 ### Bug fixes
-- The Geolocate control no longer throwing error when window is lost (issue on Firefox only)
+- The Geolocate control no longer throwing error when window is lost (issue on Firefox only) (https://github.com/maptiler/maptiler-sdk-js/pull/140)
 
 ## 2.5.0
 ### others

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MapTiler SDK Changelog
 
+## 2.5.1
+### Bug fixes
+- The Geolocate control no longer throwing error when window is lost (issue on Firefox only)
+
 ## 2.5.0
 ### others
 - Update MapTiler Client library to v2.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^20.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "module": "dist/maptiler-sdk.mjs",
   "types": "dist/maptiler-sdk.d.ts",

--- a/src/MaptilerGeolocateControl.ts
+++ b/src/MaptilerGeolocateControl.ts
@@ -167,6 +167,9 @@ export class MaptilerGeolocateControl extends GeolocateControl {
     }
   };
 
+  // We are overwriting the method _setErrorState from Maplibre's GeolocateControl because the
+  // case BACKGROUND_ERROR is not dealt with in the original function and yields an error.
+  // Related issue: https://github.com/maplibre/maplibre-gl-js/issues/2294
   _setErrorState() {
     switch (this._watchState) {
       case "WAITING_ACTIVE":

--- a/src/MaptilerGeolocateControl.ts
+++ b/src/MaptilerGeolocateControl.ts
@@ -166,4 +166,34 @@ export class MaptilerGeolocateControl extends GeolocateControl {
       this._updateCircleRadius();
     }
   };
+
+  _setErrorState() {
+    switch (this._watchState) {
+      case "WAITING_ACTIVE":
+        this._watchState = "ACTIVE_ERROR";
+        this._geolocateButton.classList.remove("maplibregl-ctrl-geolocate-active");
+        this._geolocateButton.classList.add("maplibregl-ctrl-geolocate-active-error");
+        break;
+      case "ACTIVE_LOCK":
+        this._watchState = "ACTIVE_ERROR";
+        this._geolocateButton.classList.remove("maplibregl-ctrl-geolocate-active");
+        this._geolocateButton.classList.add("maplibregl-ctrl-geolocate-active-error");
+        this._geolocateButton.classList.add("maplibregl-ctrl-geolocate-waiting");
+        // turn marker grey
+        break;
+      case "BACKGROUND":
+        this._watchState = "BACKGROUND_ERROR";
+        this._geolocateButton.classList.remove("maplibregl-ctrl-geolocate-background");
+        this._geolocateButton.classList.add("maplibregl-ctrl-geolocate-background-error");
+        this._geolocateButton.classList.add("maplibregl-ctrl-geolocate-waiting");
+        // turn marker grey
+        break;
+      case "ACTIVE_ERROR":
+        break;
+      case "BACKGROUND_ERROR":
+        break;
+      default:
+        throw new Error(`Unexpected watchState ${this._watchState}`);
+    }
+  }
 }


### PR DESCRIPTION
[RD-447](https://maptiler.atlassian.net/browse/RD-447)

The method added (`_setErrorState`) is a direct port from Maplibre but with a small modification. Since the class MaptilerGeolocateControl inherits Maplibre's GeolocateControl then the local version of the method is being used instead.

[RD-447]: https://maptiler.atlassian.net/browse/RD-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ