### PR TITLE
Rd776 add easing functions to animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.0.0",
         "@maptiler/client": "^2.2.0",
+        "easing-functions": "^1.3.0",
         "events": "^3.3.0",
         "js-base64": "^3.7.7",
         "maplibre-gl": "^5.0.1",
@@ -2500,6 +2501,12 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
       "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==",
       "license": "ISC"
+    },
+    "node_modules/easing-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/easing-functions/-/easing-functions-1.3.0.tgz",
+      "integrity": "sha512-uA6jSE900PXdjQ5TYOcHgqS26lbe7kr5gUQvufQ5clmjqQN5GiSIzK9bbL0kT18iWw7ymHEVXiUkmIe1Shb2bA==",
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "@maplibre/maplibre-gl-style-spec": "^23.0.0",
     "@maptiler/client": "^2.2.0",
+    "easing-functions": "^1.3.0",
     "events": "^3.3.0",
     "js-base64": "^3.7.7",
     "maplibre-gl": "^5.0.1",

--- a/src/utils/MTAnimation/AnimationManager.ts
+++ b/src/utils/MTAnimation/AnimationManager.ts
@@ -14,10 +14,10 @@ import MTAnimation from "./MTAnimation";
  *
  */
 const AnimationManager = {
-  animations: new Set<MTAnimation>(),
+  animations: new Array<MTAnimation>(),
   running: false,
   add(animation: MTAnimation) {
-    this.animations.add(animation);
+    this.animations.push(animation);
     if (!this.running) {
       this.running = true;
       this.start();
@@ -25,8 +25,8 @@ const AnimationManager = {
   },
 
   remove(animation: MTAnimation) {
-    this.animations.delete(animation);
-    if (this.animations.size === 0) {
+    this.animations = this.animations.filter((a) => a !== animation);
+    if (this.animations.length === 0) {
       this.stop();
     }
   },
@@ -40,17 +40,16 @@ const AnimationManager = {
       return;
     }
     const loop = () => {
-      if (this.animations.size === 0) {
+      if (this.animations.length === 0) {
         this.running = false;
         return;
       }
 
-      for (const animation of this.animations) {
-        if (!animation.isPlaying) {
-          continue;
+      this.animations.forEach((animation) => {
+        if (animation.isPlaying) {
+          animation.update();
         }
-        animation.update();
-      }
+      });
 
       requestAnimationFrame(loop);
     };

--- a/src/utils/MTAnimation/MTAnimation.ts
+++ b/src/utils/MTAnimation/MTAnimation.ts
@@ -123,10 +123,12 @@ export default class MTAnimation {
   // 0 start of the animation, 1 end of the animation
   private currentDelta: number;
 
+  // the time the animation started
   private animationStartTime: number = 0;
 
+  // the time the last frame was rendered
   private lastFrameAt: number = 0;
-  
+
   private listeners: AnimationEventListenersRecord = Object.values(
     AnimationEventTypes,
   ).reduce((acc, type) => {
@@ -378,7 +380,9 @@ export default class MTAnimation {
    * @returns Object containing current and next keyframes, which may be null
    */
   getCurrentAndNextKeyFramesAtTime(time: number) {
-    return this.getCurrentAndNextKeyFramesAtDelta(time / this.effectiveDuration);
+    return this.getCurrentAndNextKeyFramesAtDelta(
+      time / this.effectiveDuration,
+    );
   }
 
   /**

--- a/src/utils/MTAnimation/animation-helpers.ts
+++ b/src/utils/MTAnimation/animation-helpers.ts
@@ -4,6 +4,8 @@ export function lerp(a: number, b: number, alpha: number) {
   return a + (b - a) * alpha;
 }
 
+export const linear = (k: number) => k;
+
 export function lerpArrayValues(numericArray: NumericArrayWithNull): number[] {
   if (numericArray.length === 0) {
     console.warn("Array empty, nothing to interpolate");

--- a/src/utils/MTAnimation/easing.ts
+++ b/src/utils/MTAnimation/easing.ts
@@ -13,10 +13,12 @@ const EasingFunctions: Record<EasingFunctionName, (K: number) => number> = {
   [EasingFunctionName.CubicInOut]: (n: number) => Easing.cubic.InOut(n),
   [EasingFunctionName.SinusoidalIn]: (n: number) => Easing.sinusoidal.In(n),
   [EasingFunctionName.SinusoidalOut]: (n: number) => Easing.sinusoidal.Out(n),
-  [EasingFunctionName.SinusoidalInOut]: (n: number) => Easing.sinusoidal.InOut(n),
+  [EasingFunctionName.SinusoidalInOut]: (n: number) =>
+    Easing.sinusoidal.InOut(n),
   [EasingFunctionName.ExponentialIn]: (n: number) => Easing.exponential.In(n),
   [EasingFunctionName.ExponentialOut]: (n: number) => Easing.exponential.Out(n),
-  [EasingFunctionName.ExponentialInOut]: (n: number) => Easing.exponential.InOut(n),
+  [EasingFunctionName.ExponentialInOut]: (n: number) =>
+    Easing.exponential.InOut(n),
   [EasingFunctionName.ElasticIn]: (n: number) => Easing.elastic.In(n),
   [EasingFunctionName.ElasticOut]: (n: number) => Easing.elastic.Out(n),
   [EasingFunctionName.ElasticInOut]: (n: number) => Easing.elastic.InOut(n),

--- a/src/utils/MTAnimation/easing.ts
+++ b/src/utils/MTAnimation/easing.ts
@@ -1,0 +1,26 @@
+import Easing from "easing-functions"
+import { EasingFunctionName } from "./types"
+
+const EasingFunctions: Record<EasingFunctionName, (K: number) => number> = {
+  [EasingFunctionName.Linear]: Easing.Linear,
+  [EasingFunctionName.QuadraticIn]: Easing.quadratic.In,
+  [EasingFunctionName.QuadraticOut]: Easing.quadratic.Out,
+  [EasingFunctionName.QuadraticInOut]: Easing.quadratic.InOut,
+  [EasingFunctionName.CubicIn]: Easing.cubic.In,
+  [EasingFunctionName.CubicOut]: Easing.cubic.Out,
+  [EasingFunctionName.CubicInOut]: Easing.cubic.InOut,
+  [EasingFunctionName.SinusoidalIn]: Easing.sinusoidal.In,
+  [EasingFunctionName.SinusoidalOut]: Easing.sinusoidal.Out,
+  [EasingFunctionName.SinusoidalInOut]: Easing.sinusoidal.InOut,
+  [EasingFunctionName.ExponentialIn]: Easing.exponential.In,
+  [EasingFunctionName.ExponentialOut]: Easing.exponential.Out,
+  [EasingFunctionName.ExponentialInOut]: Easing.exponential.InOut,
+  [EasingFunctionName.ElasticIn]: Easing.elastic.In,
+  [EasingFunctionName.ElasticOut]: Easing.elastic.Out,
+  [EasingFunctionName.ElasticInOut]: Easing.elastic.InOut,
+  [EasingFunctionName.BounceIn]: Easing.bounce.In,
+  [EasingFunctionName.BounceOut]: Easing.bounce.Out,
+  [EasingFunctionName.BounceInOut]: Easing.bounce.InOut,
+}
+
+export default EasingFunctions

--- a/src/utils/MTAnimation/easing.ts
+++ b/src/utils/MTAnimation/easing.ts
@@ -1,26 +1,28 @@
-import Easing from "easing-functions"
-import { EasingFunctionName } from "./types"
+import Easing from "easing-functions";
+import { EasingFunctionName } from "./types";
 
+// We are wrapping these in arrow functions to avoid ts complaining about
+// unboud `this` in the easing functions.
 const EasingFunctions: Record<EasingFunctionName, (K: number) => number> = {
-  [EasingFunctionName.Linear]: Easing.Linear,
-  [EasingFunctionName.QuadraticIn]: Easing.quadratic.In,
-  [EasingFunctionName.QuadraticOut]: Easing.quadratic.Out,
-  [EasingFunctionName.QuadraticInOut]: Easing.quadratic.InOut,
-  [EasingFunctionName.CubicIn]: Easing.cubic.In,
-  [EasingFunctionName.CubicOut]: Easing.cubic.Out,
-  [EasingFunctionName.CubicInOut]: Easing.cubic.InOut,
-  [EasingFunctionName.SinusoidalIn]: Easing.sinusoidal.In,
-  [EasingFunctionName.SinusoidalOut]: Easing.sinusoidal.Out,
-  [EasingFunctionName.SinusoidalInOut]: Easing.sinusoidal.InOut,
-  [EasingFunctionName.ExponentialIn]: Easing.exponential.In,
-  [EasingFunctionName.ExponentialOut]: Easing.exponential.Out,
-  [EasingFunctionName.ExponentialInOut]: Easing.exponential.InOut,
-  [EasingFunctionName.ElasticIn]: Easing.elastic.In,
-  [EasingFunctionName.ElasticOut]: Easing.elastic.Out,
-  [EasingFunctionName.ElasticInOut]: Easing.elastic.InOut,
-  [EasingFunctionName.BounceIn]: Easing.bounce.In,
-  [EasingFunctionName.BounceOut]: Easing.bounce.Out,
-  [EasingFunctionName.BounceInOut]: Easing.bounce.InOut,
-}
+  [EasingFunctionName.Linear]: (n: number) => Easing.Linear(n),
+  [EasingFunctionName.QuadraticIn]: (n: number) => Easing.quadratic.In(n),
+  [EasingFunctionName.QuadraticOut]: (n: number) => Easing.quadratic.Out(n),
+  [EasingFunctionName.QuadraticInOut]: (n: number) => Easing.quadratic.InOut(n),
+  [EasingFunctionName.CubicIn]: (n: number) => Easing.cubic.In(n),
+  [EasingFunctionName.CubicOut]: (n: number) => Easing.cubic.Out(n),
+  [EasingFunctionName.CubicInOut]: (n: number) => Easing.cubic.InOut(n),
+  [EasingFunctionName.SinusoidalIn]: (n: number) => Easing.sinusoidal.In(n),
+  [EasingFunctionName.SinusoidalOut]: (n: number) => Easing.sinusoidal.Out(n),
+  [EasingFunctionName.SinusoidalInOut]: (n: number) => Easing.sinusoidal.InOut(n),
+  [EasingFunctionName.ExponentialIn]: (n: number) => Easing.exponential.In(n),
+  [EasingFunctionName.ExponentialOut]: (n: number) => Easing.exponential.Out(n),
+  [EasingFunctionName.ExponentialInOut]: (n: number) => Easing.exponential.InOut(n),
+  [EasingFunctionName.ElasticIn]: (n: number) => Easing.elastic.In(n),
+  [EasingFunctionName.ElasticOut]: (n: number) => Easing.elastic.Out(n),
+  [EasingFunctionName.ElasticInOut]: (n: number) => Easing.elastic.InOut(n),
+  [EasingFunctionName.BounceIn]: (n: number) => Easing.bounce.In(n),
+  [EasingFunctionName.BounceOut]: (n: number) => Easing.bounce.Out(n),
+  [EasingFunctionName.BounceInOut]: (n: number) => Easing.bounce.InOut(n),
+};
 
-export default EasingFunctions
+export default EasingFunctions;

--- a/src/utils/MTAnimation/easings.d.ts
+++ b/src/utils/MTAnimation/easings.d.ts
@@ -1,0 +1,29 @@
+declare module "easing-functions" {
+  type EasingFunction = (k: number) => number;
+
+  export interface EasingMethod {
+    In(k: number): number;
+    Out(k: number): number;
+    InOut(k: number): number;
+  }
+
+  export interface Easing {
+    Linear: EasingFunction;
+    quadratic: EasingMethod;
+    cubic: EasingMethod;
+    quartic: EasingMethod;
+    quintic: EasingMethod;
+    sinusoidal: EasingMethod;
+    exponential: EasingMethod;
+    circular: EasingMethod;
+    elastic: EasingMethod;
+    back: EasingMethod;
+    bounce: EasingMethod;
+
+    [key: string]: EasingFunction | EasingMethod;
+  }
+
+  const Easing: Easing;
+
+  export = Easing;
+}

--- a/src/utils/MTAnimation/types.ts
+++ b/src/utils/MTAnimation/types.ts
@@ -4,7 +4,7 @@ import MTAnimation from "./MTAnimation";
 // but in future we will add more
 export enum EasingFunctionName {
   Linear = "linear",
-  QuadraticIn = "Quadratic.I",
+  QuadraticIn = "Quadratic.In",
   QuadraticOut = "Quadratic.Out",
   QuadraticInOut = "Quadratic.InOut",
   CubicIn = "Cubic.In",
@@ -24,136 +24,6 @@ export enum EasingFunctionName {
   BounceInOut = "Bounce.InOut",
 }
 
-/**
- * Interface for animation control with keyframe support.
- *
- * This interface provides methods to control animation playback,
- * query and manipulate animation state, and manage animation events.
- */
-export interface IMTAnimation {
-  /** Indicates whether the animation is currently playing */
-  readonly isPlaying: boolean;
-
-  /**
-   * Starts or resumes the animation
-   * @returns This animation instance for method chaining
-   */
-  play(): IMTAnimation;
-
-  /**
-   * Pauses the animation
-   * @returns This animation instance for method chaining
-   */
-  pause(): IMTAnimation;
-
-  /**
-   * Stops the animation and resets to initial state
-   * @returns This animation instance for method chaining
-   */
-  stop(): IMTAnimation;
-
-  /**
-   * Resets the animation to its initial state without stopping
-   * @returns This animation instance for method chaining
-   */
-  reset(): IMTAnimation;
-
-  /**
-   * Updates the animation state
-   * @returns This animation instance for method chaining
-   */
-  update(): IMTAnimation;
-
-  /**
-   * Gets the current and next keyframes at a specific time
-   * @param time - The time position to query
-   * @returns Object containing current and next keyframes, which may be null
-   */
-  getCurrentAndNextKeyFramesAtTime(time: number): {
-    current: Keyframe | null;
-    next: Keyframe | null;
-  };
-
-  /**
-   * Gets the current and next keyframes at a specific delta value
-   * @param delta - The delta value to query
-   * @returns Object containing current and next keyframes, which may be null
-   */
-  getCurrentAndNextKeyFramesAtDelta(delta: number): {
-    current: Keyframe | null;
-    next: Keyframe | null;
-  };
-
-  /**
-   * Gets the current time position of the animation
-   * @returns The current time in milliseconds
-   */
-  getCurrentTime(): number;
-
-  /**
-   * Sets the current time position of the animation
-   * @param time - The time to set in milliseconds
-   * @returns This animation instance for method chaining
-   */
-  setCurrentTime(time: number): IMTAnimation;
-
-  /**
-   * Gets the current delta value of the animation
-   * @returns The current delta value (normalized progress between 0 and 1)
-   */
-  getCurrentDelta(): number;
-
-  /**
-   * Sets the current delta value of the animation
-   * @param delta - The delta value to set (normalized progress between 0 and 1)
-   * @returns This animation instance for method chaining
-   */
-  setCurrentDelta(delta: number): IMTAnimation;
-
-  /**
-   * Sets the playback rate of the animation
-   * @param rate - The playback rate (1.0 is normal speed)
-   * @returns This animation instance for method chaining
-   */
-  setPlaybackRate(rate: number): IMTAnimation;
-
-  /**
-   * Gets the current playback rate
-   * @returns The current playback rate
-   */
-  getPlaybackRate(): number;
-
-  /**
-   * Adds an event listener for animation events
-   * @param type - The type of event to listen for
-   * @param callback - The callback function to execute when the event occurs
-   * @returns This animation instance for method chaining
-   */
-  addEventListener(
-    type: AnimationEventTypes,
-    callback: AnimationEventCallback,
-  ): IMTAnimation;
-
-  /**
-   * Removes an event listener
-   * @param type - The type of event to remove
-   * @param callback - The callback function to remove
-   * @returns This animation instance for method chaining
-   */
-  removeEventListener(
-    type: AnimationEventTypes,
-    callback: AnimationEventCallback,
-  ): IMTAnimation;
-
-  /**
-   * Creates a clone of this animation
-   * @returns A new animation instance with the same properties as this one
-   */
-  clone(): IMTAnimation;
-}
-
-// https://www.npmjs.com/search?page=0&q=easing%20functions&sortBy=score
-
 export type Keyframe = {
   // the properties to interpolate between
   props: Record<string, number | null>;
@@ -163,7 +33,7 @@ export type Keyframe = {
   delta: number;
 
   // the easing function to use between this keyframe and the next
-  easing?: EasingFunctionName | string;
+  easing?: EasingFunctionName;
 };
 
 export enum AnimationEventTypes {

--- a/src/utils/MTAnimation/types.ts
+++ b/src/utils/MTAnimation/types.ts
@@ -2,8 +2,26 @@ import MTAnimation from "./MTAnimation";
 
 // at present we only have one easing type
 // but in future we will add more
-export enum EasingFunction {
+export enum EasingFunctionName {
   Linear = "linear",
+  QuadraticIn = "Quadratic.I",
+  QuadraticOut = "Quadratic.Out",
+  QuadraticInOut = "Quadratic.InOut",
+  CubicIn = "Cubic.In",
+  CubicOut = "Cubic.Out",
+  CubicInOut = "Cubic.InOut",
+  SinusoidalIn = "Sinusoidal.In",
+  SinusoidalOut = "Sinusoidal.Out",
+  SinusoidalInOut = "Sinusoidal.InOut",
+  ExponentialIn = "Exponential.In",
+  ExponentialOut = "Exponential.Out",
+  ExponentialInOut = "Exponential.InOut",
+  ElasticIn = "Elastic.In",
+  ElasticOut = "Elastic.Out",
+  ElasticInOut = "Elastic.InOut",
+  BounceIn = "Bounce.In",
+  BounceOut = "Bounce.Out",
+  BounceInOut = "Bounce.InOut",
 }
 
 /**
@@ -145,7 +163,7 @@ export type Keyframe = {
   delta: number;
 
   // the easing function to use between this keyframe and the next
-  easing?: EasingFunction;
+  easing?: EasingFunctionName | string;
 };
 
 export enum AnimationEventTypes {
@@ -181,3 +199,5 @@ export type AnimationEventListenersRecord = Record<
 >;
 
 export type AnimationEventCallback = (event: AnimationEvent) => void;
+
+export type EasingFunctionsModule = typeof import("./easing").default;


### PR DESCRIPTION
## Objective
To allow for easing functions to be applied between keyframes

## Description
- async loading of easing functions lib to avoid package bloat, defaults to linear.
- implement easing functions and alpha in update method.
- switch from using `Set` to using array in `AnimationManager` `update` method (more performant)
- removes superflous interface declaration for `MTAnimation` and inline documents methods.

## Acceptance
Manually, tests will be in a later ticket

## Checklist
- ~[ ] I have added relevant info to the CHANGELOG.md~ N/A as we're merging to feature / epic branch, version bump and changelog entry will come when epic branch is merged