### PR TITLE
RD858 `projection` is sometimes undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # MapTiler SDK Changelog
 
+## 3.0.3
+## ✨ Features and improvements
+None
+
+## 🐛 Bug fixes
+Fixes a bug that accesses undefined `projection` object in `Map.getProjection` method
+
+## 🔧 Others
+None
+
 ## 3.0.2
 ## ✨ Features and improvements
 None

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "author": "MapTiler",
   "module": "dist/maptiler-sdk.mjs",

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1517,6 +1517,11 @@ export class Map extends maplibregl.Map {
    */
   isGlobeProjection(): boolean {
     const projection = this.getProjection();
+    // this type is incorrect, `projection` be undefined
+
+    if (!projection) {
+      return false;
+    }
 
     return projection.type === "globe";
   }

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1517,7 +1517,7 @@ export class Map extends maplibregl.Map {
    */
   isGlobeProjection(): boolean {
     const projection = this.getProjection();
-    // this type is incorrect, `projection` be undefined
+    // this type is incorrect, `projection` can be undefined
 
     if (!projection) {
       return false;


### PR DESCRIPTION
## Objective

To fix the reported issues below in addition to a bug where `ProjectionControl` would intermittently error, this was also observed when the `projectionControl` was loaded and then a subsequent call to `Map.setStyle` was made.

https://github.com/maptiler/maptiler-sdk-js/issues/175
https://github.com/maptiler/maptiler-sdk-js/issues/174

## Description
Method tests for existence of projection object before accessing a field (this type is incorrect in maplibre)

## Acceptance
Manually tested.

## Checklist
- [x] I have added relevant info to the CHANGELOG.md