### PR TITLE
Rd 787 animated route layer tests

### DIFF
--- a/demos/07-animated-routes.html
+++ b/demos/07-animated-routes.html
@@ -281,7 +281,7 @@
       return [
         {
           delta: 0,
-          easing: 'Elastic.Out',
+          easing: maptilersdk.EasingFunctionName.ElasticOut,
           userData: {
             name: 'Start',
           },
@@ -295,7 +295,7 @@
         },
         {
           delta: 0.1,
-          easing: 'Elastic.Out',
+          easing: maptilersdk.EasingFunctionName.ElasticOut,
           userData: {
             name: 'Nossa Senhora da Penha 1',
           },
@@ -309,7 +309,7 @@
         },
         {
           delta: 0.3,
-          easing: 'Elastic.Out',
+          easing: maptilersdk.EasingFunctionName.ElasticOut,
           userData: {
             name: 'Nossa Senhora da Penha 2',
           },
@@ -323,7 +323,7 @@
         },
         {
           delta: 0.5,
-          easing: 'Elastic.Out',
+          easing: maptilersdk.EasingFunctionName.ElasticOut,
           userData: {
             name: 'Farmland 1',
           },
@@ -337,7 +337,7 @@
         },
         {
           delta: 0.7,
-          easing: 'Bounce.In',
+          easing: maptilersdk.EasingFunctionName.BounceIn,
           userData: {
             name: 'Farmland 2',
           },
@@ -349,7 +349,7 @@
         },
         {
           delta: 0.8,
-          easing: 'Bounce.Out',
+          easing: maptilersdk.EasingFunctionName.BounceOut,
           userData: {
             name: 'Castelo de Vide: Castelo 1',
           },
@@ -361,7 +361,7 @@
         },
         {
           delta: 0.9,
-          easing: 'Elastic.Out',
+          easing: maptilersdk.EasingFunctionName.ElasticOut,
           userData: {
             name: 'Castelo de Vide: Castelo 1',
           },
@@ -373,7 +373,7 @@
         },
         {
           delta: 1,
-          easing: 'Elastic.Out',
+          easing: maptilersdk.EasingFunctionName.ElasticOut,
           userData: {
             name: 'Finish',
           },

--- a/src/utils/MaptilerAnimation/animation-helpers.ts
+++ b/src/utils/MaptilerAnimation/animation-helpers.ts
@@ -288,6 +288,8 @@ export function getKeyframes(coordinates: number[][], deltas: number[], easings:
     `);
   }
 
+  const includeAltitude = !coordinates.every((coordinate) => coordinate.length < 3);
+
   return coordinates.map((coordinate: number[], index: number) => {
     const delta = deltas[index];
     const easing = easings[index];
@@ -303,7 +305,7 @@ export function getKeyframes(coordinates: number[][], deltas: number[], easings:
       ...propertyValuesForThisKeyframe,
       lng: coordinate[0],
       lat: coordinate[1],
-      altitude: coordinate[2] ?? null,
+      ...(includeAltitude && { altitude: coordinate[2] ?? null }),
     };
 
     return {

--- a/test/AnimatedRouteLayer/AnimatedRouteLayer.test.ts
+++ b/test/AnimatedRouteLayer/AnimatedRouteLayer.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, vi, test } from "vitest";
+// import { AnimatedRouteLayer } from "../../src/custom-layers/AnimatedRouteLayer";
+import { EasingFunctionName, Keyframe, MaptilerAnimation } from "../../src/utils";
+import { AnimatedRouteLayer } from "../../src/custom-layers/AnimatedRouteLayer";
+import { validFixture, validFixtureExpectedKeyframes } from "../fixtures/animations/keyframes.fixture";
+
+vi.mock("uuid", () => ({
+  v4: () => "PHONEY-UUID",
+}));
+
+const keyframes: Keyframe[] = [
+  {
+    delta: 0,
+    props: {
+      opacity: 0,
+      scale: 1,
+    },
+  },
+  {
+    delta: 0.5,
+    props: {
+      opacity: 0.5,
+      scale: 1.5,
+    },
+  },
+  {
+    delta: 1,
+    props: {
+      scale: 2,
+      opacity: 1,
+    },
+  },
+];
+
+const mockSource = {
+  getData: vi.fn(() => ({
+    type: "FeatureCollection",
+    features: [validFixture],
+  })),
+};
+
+class MockMap {
+  setPaintProperty = vi.fn();
+  getPitch = vi.fn();
+  getZoom = vi.fn();
+  getBearing = vi.fn();
+  jumpTo = vi.fn();
+  getSource = vi.fn(() => mockSource);
+  getLayersOrder = vi.fn();
+}
+
+describe("AnimatedRouteLayer", () => {
+  const map = new MockMap();
+
+  test("Instantiates correctly with the correct options", () => {
+    const layer = new AnimatedRouteLayer({
+      keyframes,
+      duration: 1000,
+      iterations: 2,
+      easing: EasingFunctionName.Linear,
+      autoplay: true,
+    });
+
+    expect(layer).toBeInstanceOf(AnimatedRouteLayer);
+    expect(layer.id).toBe("animated-route-layer-PHONEY-UUID");
+  });
+
+  test("Throws / rejects if the map already has an AnimatedRouteLayer added", () => {
+    // fake add a new map
+    map.getLayersOrder.mockImplementation(() => ["animated-route-layer-PHONEY-UUID-2"]);
+
+    const layer = new AnimatedRouteLayer({
+      keyframes,
+      duration: 1000,
+      iterations: 2,
+      easing: EasingFunctionName.Linear,
+      autoplay: true,
+    });
+
+    const testFn = async () => {
+      //@ts-expect-error map is mocked to avoid webgl explosions...
+      await layer.onAdd(map);
+    };
+
+    expect(testFn).rejects.toThrowError(
+      `[AnimatedRouteLayer.onAdd]: Currently, you can only have one active AnimatedRouteLayer at a time. Please remove the existing one before adding a new one.`,
+    );
+  });
+
+  test("Initialises the internal animation instance correctly when given keyframes", async () => {
+    map.getLayersOrder.mockImplementation(() => []);
+
+    const layer = new AnimatedRouteLayer({
+      keyframes,
+      duration: 1000,
+      iterations: 2,
+      easing: EasingFunctionName.Linear,
+      autoplay: true,
+    });
+
+    //@ts-expect-error map is mocked to avoid webgl explosions...
+    await layer.onAdd(map);
+
+    expect(layer.animationInstance).toBeInstanceOf(MaptilerAnimation);
+
+    //@ts-expect-error it is private but we can access it here...
+    layer.animationInstance.keyframes.forEach((keyframe, index) => {
+      expect(keyframe.delta).toEqual(keyframes[index].delta);
+      expect(keyframe.props).toEqual(keyframes[index].props);
+      expect(keyframe.easing).toEqual("Linear");
+      expect(keyframe.userData).toEqual(keyframes[index].userData);
+    });
+
+    expect(layer.animationInstance.duration).toEqual(1000);
+
+    //@ts-expect-error it is private but we can access it here...
+    expect(layer.animationInstance.iterations).toEqual(2);
+  });
+
+  test("Initialises the internal animation instance correctly when given a geojson source", async () => {
+    map.getLayersOrder.mockImplementation(() => []);
+
+    const layer = new AnimatedRouteLayer({
+      source: {
+        id: "test-source",
+        featureSetIndex: 0,
+        layerID: "test-layer",
+      },
+      duration: 1000,
+      iterations: 2,
+      easing: EasingFunctionName.Linear,
+      autoplay: true,
+    });
+
+    //@ts-expect-error map is mocked to avoid webgl explosions...
+    await layer.onAdd(map);
+
+    expect(layer.animationInstance).toBeInstanceOf(MaptilerAnimation);
+
+    const boundHandler = layer.animationInstance.update.bind(layer.animationInstance);
+
+    layer.animationInstance.addEventListener = vi.fn();
+
+    expect(layer.animationInstance.addEventListener).toHaveBeenCalledWith("timeupdate", boundHandler);
+
+    validFixtureExpectedKeyframes.forEach((keyframe, index) => {
+      expect(keyframe.delta).toEqual(validFixtureExpectedKeyframes[index].delta);
+      expect(keyframe.props).toEqual(validFixtureExpectedKeyframes[index].props);
+      expect(keyframe.easing).toEqual(validFixtureExpectedKeyframes[index].easing);
+      expect(keyframe.userData).toEqual(validFixtureExpectedKeyframes[index].userData);
+    });
+
+    expect(layer.animationInstance.duration).toEqual(1000);
+
+    //@ts-expect-error it is private but we can access it here...
+    expect(layer.animationInstance.iterations).toEqual(5);
+  });
+});

--- a/test/MaptilerAnimation/MaptilerAnimation.test.ts
+++ b/test/MaptilerAnimation/MaptilerAnimation.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import MaptilerAnimation from "../../src/utils/MaptilerAnimation";
 
 import { AnimationEventTypes, EasingFunctionName, Keyframe } from "../../src/utils/MaptilerAnimation/types";
-import { lerp, lerpArrayValues } from "../../src/utils/MaptilerAnimation/animation-helpers";
 
 const keyframes: Keyframe[] = [
   {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -147,8 +147,28 @@ const expectedExports = Array.from(
   ]),
 );
 
+// vi.stubGlobal('URL', {
+//   createObjectURL: vi.fn(() => 'blob:mockurl'),
+// })
+
 describe("Module Exports", async () => {
   const exportedModule = await import("../src/index");
+
+  console.info(
+    "\x1b[1m%s\x1b[0m",
+    `
+  At present you will likely see an error above:
+  
+  \`Error: Failed to load url <blob-filepath> (resolved id: <blob-filepath>). Does the file exist?\`
+
+  This is related to maplibre-gl and the way it handles CJS modules.
+  It is caused by the call to \`enableRTL()\` in src/index.ts.
+
+  There is a planned future work to remove this (the API it relies on
+  is deprecated in Maplibre). But, for now, we must tolerate some
+  noise in this test...
+  `,
+  );
 
   it("should match number of exptected exports with expected number of exports, logging any superfluous exports", () => {
     const actualExports = Object.keys(exportedModule);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "**/*.ts",
+    "**/*.test.ts"
+  ],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
   "include": [
     "src",
     "./eslint.config.mjs",
-    "test",
     "./vite.config-test.ts",
     "./vitest-setup-tests.ts"
   ],


### PR DESCRIPTION
## Objective
Better test coverage

## Description
- fix demos so that they use the correct enum for easing
- implement additional tests for AnimatedRouteLayer
- minor refactor
- add warning in exports.test regarding cjs module error
- code tidy-up
- add extended tsconfig for tests

## Acceptance
Tests passing

## Checklist
- ~[ ] I have added relevant info to the CHANGELOG.md~ N/A until feature is merged to main.