### PR TITLE
RD-902 Fixes MapLibre direct import due to CJS issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # MapTiler SDK Changelog
 
+
+
+## 3.2.1
+## ✨ Features and improvements
+## 🐛 Bug fixes
+[RD-902](https://maptiler.atlassian.net/browse/RD-902?atlOrigin=eyJpIjoiNGM2NGQxNzg0ZjEzNGJlMGI3M2Y1YTM3YTIyNjdkMDkiLCJwIjoiaiJ9) Changes to use default import for maplibre-gl as it uses commonjs modules under the hood.
+
 ## 3.2.0
 ## ✨ Features and improvements
 - Updates Maplibre-gl to 5.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # MapTiler SDK Changelog
 
-
-
 ## 3.2.1
 ## ✨ Features and improvements
+None
+
 ## 🐛 Bug fixes
-[RD-902](https://maptiler.atlassian.net/browse/RD-902?atlOrigin=eyJpIjoiNGM2NGQxNzg0ZjEzNGJlMGI3M2Y1YTM3YTIyNjdkMDkiLCJwIjoiaiJ9) Changes to use default import for maplibre-gl as it uses commonjs modules under the hood.
+- [RD-902](https://maptiler.atlassian.net/browse/RD-902?atlOrigin=eyJpIjoiNGM2NGQxNzg0ZjEzNGJlMGI3M2Y1YTM3YTIyNjdkMDkiLCJwIjoiaiJ9) Changes to use default import for maplibre-gl as it uses commonjs modules under the hood.
+
+## 🔧 Others
+- Adds linting config to check for non default maplibre defaults. Named imports from CJS modules fail on some build pipelines.
 
 ## 3.2.0
 ## ✨ Features and improvements

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,7 +70,7 @@ export default tseslint.config(
       "import/default-imports-only": [
         "error",
         {
-          "maplibre-gl(.*)": {
+          "maplibre-gl$": {
             locations: ["^(?!.*\.d\.ts$).*\.((ts|js))$"],
             message: `Maplibre-gl uses CJS modules, only default imports are supported, named imports may fail on some setups.`,
             ignoreTypeImports: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.2.1-rc1",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "3.2.1-rc1",
+      "version": "3.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.0.0",
@@ -616,7 +616,7 @@
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1-rc1",
+        "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
@@ -5517,7 +5517,7 @@
       "dependencies": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.2.1-rc1"
+        "pbf": "^3.2.1"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.2.1",
+  "version": "3.2.1-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "3.2.1",
+      "version": "3.2.1-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.0.0",
@@ -616,7 +616,7 @@
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
+        "import-fresh": "^3.2.1-rc1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
@@ -5517,7 +5517,7 @@
       "dependencies": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.2.1"
+        "pbf": "^3.2.1-rc1"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "author": "MapTiler",
   "module": "dist/maptiler-sdk.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.2.1",
+  "version": "3.2.1rc-1",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "author": "MapTiler",
   "module": "dist/maptiler-sdk.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.2.1rc-1",
+  "version": "3.2.1",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "author": "MapTiler",
   "module": "dist/maptiler-sdk.mjs",

--- a/src/caching.ts
+++ b/src/caching.ts
@@ -2,7 +2,7 @@ import type { GetResourceResponse, RequestParameters, ResourceType } from "mapli
 
 import { config } from "./config";
 
-import { addProtocol } from "maplibre-gl";
+import maplibregl from "maplibre-gl";
 
 import { defaults } from "./constants/defaults";
 
@@ -13,6 +13,8 @@ const LOCAL_CACHE_NAME = "maptiler_sdk";
 const CACHE_LIMIT_ITEMS = 1000;
 const CACHE_LIMIT_CHECK_INTERVAL = 100;
 export const CACHE_API_AVAILABLE = typeof caches !== "undefined";
+
+const { addProtocol } = maplibregl;
 
 export function localCacheTransformRequest(reqUrl: URL, resourceType?: ResourceType): string {
   if (CACHE_API_AVAILABLE && config.caching && config.session && reqUrl.host === defaults.maptilerApiHost) {


### PR DESCRIPTION
## Objective
To fix [RD-902](https://maptiler.atlassian.net/browse/RD-902?atlOrigin=eyJpIjoiNGM2NGQxNzg0ZjEzNGJlMGI3M2Y1YTM3YTIyNjdkMDkiLCJwIjoiaiJ9)

## Description
Changes to use default import for maplibre-gl as it uses commonjs modules under the hood.

## Acceptance
Manually Tested

## Checklist
- [x] I have added relevant info to the CHANGELOG.md

[RD-902]: https://maptiler.atlassian.net/browse/RD-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ