### PR TITLE
Rd 902/remove eslint mjs from tsconfig

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,8 +21,24 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: npm ci
+
       - run: npm run make
-      
+
+      - name: Clear NPM cache
+        run: npm cache clean --force
+
+      - name: Install dependencies and build
+        run: npm ci
+
+      - name: Make release
+        run: npm run make
+        id: makeRelease
+
+      - name: Fail job if makeRelease failed
+        if: steps.makeRelease.outcome == 'failure'
+        run: exit 1
+
+        id: check-build-status
       - name: Publish NPM package (regular)
         if: "!github.event.release.prerelease"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MapTiler SDK Changelog
 
-## 3.2.1
+## 3.2.2
 ## ✨ Features and improvements
 None
 
@@ -9,6 +9,10 @@ None
 
 ## 🔧 Others
 - Adds linting config to check for non default maplibre defaults. Named imports from CJS modules fail on some build pipelines.
+
+## 3.2.1
+### ⚠️ Warning
+- This version was published in error. Please use `3.2.2` instead.
 
 ## 3.2.0
 ## ✨ Features and improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "author": "MapTiler",
   "module": "dist/maptiler-sdk.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,6 @@
   },
   "include": [
     "src",
-    "./eslint.config.mjs",
     "test",
     "./vite.config-test.ts",
     "./vitest-setup-tests.ts"


### PR DESCRIPTION
## Objective
To update tsconfig to prevent build failures in CI

## Description
- Updated tsconfig to prevent build failures in CI, and avoid linting the lint config
- Add github action to check if build passed before publishing to npm

## Acceptance
Manually tested

## Checklist
- [x] I have added relevant info to the CHANGELOG.md