### PR TITLE
hotfix: remove duplicate commands from github publish action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-
-      - run: npm run make
 
       - name: Clear NPM cache
         run: npm cache clean --force


### PR DESCRIPTION
## Objective
Remove duplicate tasks in the github npm publish action

## Description
in `.github/workflows/npm-publish.yml`, remove duplicate tasks in the github npm publish action


## Acceptance
N/A

## Checklist
- ~[ ] I have added relevant info to the CHANGELOG.md~ N/A Does not change any public facing APIs nor build processes.