### PR TITLE
RD-901 Fix style.json changes not being reflected in CubemapLayer

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -243,6 +243,7 @@ export class Map extends maplibregl.Map {
     if (!style.metadata?.maptiler?.space) {
       return;
     }
+
     const space = style.metadata.maptiler.space;
 
     const updateSpace = () => {
@@ -258,9 +259,7 @@ export class Map extends maplibregl.Map {
       return;
     }
 
-    void this.once("style.load", () => {
-      updateSpace();
-    });
+    updateSpace();
   }
 
   private setHaloFromStyle({ style }: { style: StyleSpecificationWithMetaData }) {
@@ -279,14 +278,7 @@ export class Map extends maplibregl.Map {
       }
     };
 
-    if (!this.styleInProcess) {
-      updateHalo();
-      return;
-    }
-
-    void this.once("style.load", () => {
-      updateHalo();
-    });
+    updateHalo();
   }
 
   private setSpaceFromCurrentStyle() {
@@ -971,7 +963,6 @@ export class Map extends maplibregl.Map {
     this.originalLabelStyle.clear();
     this.minimap?.setStyle(style);
     this.forceLanguageUpdate = true;
-
     this.once("idle", () => {
       this.forceLanguageUpdate = false;
     });

--- a/src/custom-layers/CubemapLayer/loadCubemapTexture.ts
+++ b/src/custom-layers/CubemapLayer/loadCubemapTexture.ts
@@ -77,7 +77,7 @@ export function loadCubemapTexture({ gl, faces, onReady, forceRefresh }: LoadCub
     return;
   }
 
-  const promises = Object.entries(faces as CubemapFaces).map(([key, face], faceIndex) => {
+  const promises = Object.entries(faces as CubemapFaces).map(([key, face]) => {
     return new Promise<HTMLImageElement>((resolve, reject) => {
       if (face === undefined) {
         console.warn(`[CubemapLayer][loadCubemapTexture]: Face ${key} is undefined`);

--- a/src/custom-layers/extractCustomLayerStyle.ts
+++ b/src/custom-layers/extractCustomLayerStyle.ts
@@ -25,7 +25,9 @@ export default function extractCustomLayerStyle<T extends CubemapLayerConstructo
   const style = map.getStyle() as StyleSpecificationWithMetaData;
 
   if (!style) {
-    console.warn("[extractCustomLayerStyle]: `Map.getStyle()` is returning undefined, are you initiating before style is ready?");
+    if (process.env.NODE_ENV === "development") {
+      console.warn("[extractCustomLayerStyle]: `Map.getStyle()` is returning undefined, are you initiating before style is ready?");
+    }
     return null;
   }
 


### PR DESCRIPTION
## Objective
To fix a bug where changes to style.json only partially applies changes in CubemapLayer

## Description
- add promises and callback to `loadCubemapTexture` to ensure onReady callback is only fired when all images are loaded
- add image.complete check to avoid non-firing of load event when image is cached.
- refactor logic that updates texture when styles are changed.

## Acceptance
Manually

## Checklist
- [ ] ~~I have added relevant info to the CHANGELOG.md~~ Changelog is updated in release.