### PR TITLE
Rd 1025 flyto then terrain does not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # MapTiler SDK Changelog
 
 ## 3.5.0
+
+### ✨ Features and improvements
 - Now able to include cubemap background images and Earth radial gradient halo via `space` and `halo` in map constructor _or_ via `setSpace` or `setHalo` methods _or_ via incoming MT style spec.
 - Additional bugfixes to  spacebox
+
+### Others
 - Version bump client-js to the latest version
 
 ## 3.4.1 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # MapTiler SDK Changelog
 
-## 3.5.0
+## __NEXT__
 
 ### ✨ Features and improvements
-- Now able to include cubemap background images and Earth radial gradient halo via `space` and `halo` in map constructor _or_ via `setSpace` or `setHalo` methods _or_ via incoming MT style spec.
-- Additional bugfixes to  spacebox
+- None 
+
+### 🐛 Bug fixes
+- Fixes bug where terrain does not load when `map.enableTerrain()` is called directly after `.flyTo`
+
+### Others
+- None
+
+## 3.5.0
+### ✨ Features and improvements
+- Now able to include cubemap background images and Earth radial gradient halo via `space` and `halo` in map 
+constructor _or_ via `setSpace` or `setHalo` methods _or_ via incoming MT style spec.
 
 ### Others
 - Version bump client-js to the latest version

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1560,11 +1560,20 @@ export class Map extends maplibregl.Map {
     if (this.loaded() || this.isTerrainEnabled) {
       addTerrain();
     } else {
-      this.once("load", () => {
+      const checkSourceAndAddTerrain = () => {
         if (this.getTerrain() && this.getSource(defaults.terrainSourceId)) {
           return;
         }
+
         addTerrain();
+      }
+
+      this.once("load", () => {
+        checkSourceAndAddTerrain();
+      });
+
+      this.once("moveend", () => {
+        checkSourceAndAddTerrain();
       });
     }
   }

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1566,7 +1566,7 @@ export class Map extends maplibregl.Map {
         }
 
         addTerrain();
-      }
+      };
 
       this.once("load", () => {
         checkSourceAndAddTerrain();


### PR DESCRIPTION
## Objective
Fixes [a bug](https://maptiler.atlassian.net/browse/RD-1025?atlOrigin=eyJpIjoiNzE2NDJiMjE2OWY4NDc0YThhMmUyMjhlMmQyNDBjODIiLCJwIjoiaiJ9) where calling `enableTerrain` directly after `flyTo` prevented the terrain from loading.

## Description
- eneableTerrain nows sets an event listener for `movend` event which fires when `flyTo` (or `moveTo`) is finished.
- better formatting of changelog.md

## Acceptance
Manually

## Checklist
- [x] I have added relevant info to the CHANGELOG.md