### PR TITLE
Rd 1086 reduce logging output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # MapTiler SDK Changelog
 
-## __NEXT__
+## 3.6.0
 
 ### ✨ Features and improvements
 - None 
 
 ### 🐛 Bug fixes
 - Fixes bug where terrain does not load when `map.enableTerrain()` is called directly after `.flyTo`
+- Adds `StyleDefinitionWithMetadata` as an accepted type to `setStyle` ([#216](https://github.com/maptiler/maptiler-sdk-js/issues/216))
+- Adds condition to log calls in `extractCustomLayerStyle` ([#216](https://github.com/maptiler/maptiler-sdk-js/issues/216))
 
 ### Others
 - None

--- a/demos/src/01-simple.ts
+++ b/demos/src/01-simple.ts
@@ -19,8 +19,6 @@ const map = new Map({
 
 const styleDropDown = document.getElementById("mapstyles-picker") as HTMLOptionElement;
 
-window._map = map;
-
 styleDropDown.onchange = () => {
   map.setStyle(styleDropDown.value);
 };

--- a/demos/src/01-simple.ts
+++ b/demos/src/01-simple.ts
@@ -19,6 +19,8 @@ const map = new Map({
 
 const styleDropDown = document.getElementById("mapstyles-picker") as HTMLOptionElement;
 
+window._map = map;
+
 styleDropDown.onchange = () => {
   map.setStyle(styleDropDown.value);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "~23.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "author": "MapTiler",
   "module": "dist/maptiler-sdk.mjs",

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -838,9 +838,13 @@ export class Map extends maplibregl.Map {
       });
 
       const firstLayer = this.getLayersOrder()[0];
+      if (options.space) {
+        this.initSpace({ options, before: firstLayer });
+      }
 
-      this.initSpace({ options, before: firstLayer });
-      this.initHalo({ options, before: firstLayer });
+      if (options.halo) {
+        this.initHalo({ options, before: firstLayer });
+      }
     });
 
     this.telemetry = new Telemetry(this);
@@ -956,7 +960,10 @@ export class Map extends maplibregl.Map {
    * - a shorthand with only the MapTIler style name (eg. `"streets-v2"`)
    * - a longer form with the prefix `"maptiler://"` (eg. `"maptiler://streets-v2"`)
    */
-  override setStyle(style: null | ReferenceMapStyle | MapStyleVariant | StyleSpecification | string, options?: StyleSwapOptions & StyleOptions): this {
+  override setStyle(
+    style: null | ReferenceMapStyle | MapStyleVariant | StyleSpecification | StyleSpecificationWithMetaData | string,
+    options?: StyleSwapOptions & StyleOptions,
+  ): this {
     this.originalLabelStyle.clear();
     this.minimap?.setStyle(style);
     this.forceLanguageUpdate = true;

--- a/src/custom-layers/extractCustomLayerStyle.ts
+++ b/src/custom-layers/extractCustomLayerStyle.ts
@@ -32,7 +32,9 @@ export default function extractCustomLayerStyle<T extends CubemapLayerConstructo
   }
 
   if (!style.metadata?.maptiler) {
-    console.warn(`[extractCustomLayerStyle]: No custom layer metadata found in the style for property \`${property}\`. The property will use default values.`);
+    if (process.env.NODE_ENV === "development") {
+      console.warn(`[extractCustomLayerStyle]: Attempting to find styling for "${property}" in metadata. No MapTiler metadata found in the style.`);
+    }
     return null;
   }
 

--- a/src/custom-layers/extractCustomLayerStyle.ts
+++ b/src/custom-layers/extractCustomLayerStyle.ts
@@ -33,7 +33,7 @@ export default function extractCustomLayerStyle<T extends CubemapLayerConstructo
 
   if (!style.metadata?.maptiler) {
     if (process.env.NODE_ENV === "development") {
-      console.warn(`[extractCustomLayerStyle]: Attempting to find styling for "${property}" in metadata. No MapTiler metadata found in the style.`);
+      console.warn(`[extractCustomLayerStyle]: Attempting to find styling for "${property}" in "metadata.maptiler". But no MapTiler metadata entry was found in the style.`);
     }
     return null;
   }

--- a/src/custom-layers/index.ts
+++ b/src/custom-layers/index.ts
@@ -5,3 +5,4 @@ export { RadialGradientLayer, CubemapLayer };
 
 export * from "./RadialGradientLayer/types";
 export * from "./CubemapLayer/types";
+export type { StyleSpecificationWithMetaData } from "./extractCustomLayerStyle";


### PR DESCRIPTION
## Objective
Fixes [216](https://github.com/maptiler/maptiler-sdk-js/issues/216)

## Description
- Add additional conditions to logging in `extractCustomLayerStyle`
- Updates API to stop typescript erroring when `map.setStyle` is called with a `StyleSpecificationWithMetaData` object.

## Acceptance
- Unit tests
- Manually

## Checklist
- [x] I have added relevant info to the CHANGELOG.md