### PR TITLE
Rd 1099 spacebox style is not done loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # MapTiler SDK Changelog
 
+## 3.5.1
+### ✨ Features and improvements
+None
+
+### 🐛 Bug fixes
+- Fixes an issue where SDK would fail when changing spacebox style with terrain enabled.
+
+### 🔧 Others
+None
+
 ## 3.5.0
 - Now able to include cubemap background images and Earth radial gradient halo via `space` and `halo` in map constructor _or_ via `setSpace` or `setHalo` methods _or_ via incoming MT style spec.
 - Additional bugfixes to  spacebox

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/sdk",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "~23.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/sdk",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "The Javascript & TypeScript map SDK tailored for MapTiler Cloud",
   "author": "MapTiler",
   "module": "dist/maptiler-sdk.mjs",

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1016,22 +1016,24 @@ export class Map extends maplibregl.Map {
 
     // if style is json object
     if (typeof styleInfo.style !== "string" && !styleInfo.requiresUrlMonitoring) {
+      const styleWithMetaData = styleInfo.style as StyleSpecificationWithMetaData;
       const initSpaceAndHalo = () => {
         if (this.halo) {
           const styleWithMetaData = styleInfo.style as StyleSpecificationWithMetaData;
           this.setHaloFromStyle({ style: styleWithMetaData });
         } else {
-          const metadata = styleInfo.style.metadata as StyleSpecificationWithMetaData["metadata"];
+          const metadata = styleWithMetaData.metadata as StyleSpecificationWithMetaData["metadata"];
           const before = this.getLayersOrder()[0] === this.space?.id ? this.getLayersOrder()[1] : this.getLayersOrder()[0];
 
-          // we need to push this to the next tick to allow maplibre to internally add all other layers
-          this.initHalo({
-            before,
-            options: {
-              ...this.options,
-              halo: metadata?.maptiler?.halo as GradientDefinition,
-            },
-          });
+          if (metadata?.maptiler?.halo) {
+            this.initHalo({
+              before,
+              options: {
+                ...this.options,
+                halo: metadata.maptiler.halo,
+              },
+            });
+          }
         }
 
         if (this.space) {

--- a/src/custom-layers/RadialGradientLayer/RadialGradientLayer.ts
+++ b/src/custom-layers/RadialGradientLayer/RadialGradientLayer.ts
@@ -38,7 +38,7 @@ const defaultConstructorOptions: RadialGradientLayerConstructorOptions = {
   ],
 };
 
-const DELTA_CHANGE = 0.075;
+const DELTA_CHANGE = 0.06;
 
 /**
  * A custom map layer that renders a radial gradient effect, typically used as a halo around a globe.


### PR DESCRIPTION
## Objective
Fixes A bug that causes the app to break when calling setStyle with terrain active on spacebox.

## Description
Checks if terrain is enabled and defers spacebox call until _after_ the terrain has loaded.

## Acceptance
- Manually
- unit tests

## Checklist
- [x] I have added relevant info to the CHANGELOG.md