### PR TITLE
IT-1825 Unify NPM_TOKEN

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,14 +41,14 @@ jobs:
         run: |
           npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish NPM package (pre-release)
         if: "github.event.release.prerelease"
         run: |
           npm publish --tag next
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Send Dispatch Event to CDN Repo
         run: |

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -41,14 +41,14 @@ jobs:
         run: |
           npm publish --dry-run
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish NPM package (pre-release)
         if: "github.event.release.prerelease"
         run: |
           npm publish --tag next --dry-run
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Send Dispatch Event to CDN Repo
         run: |


### PR DESCRIPTION
## Objective
As a part of the ticket IT-1825

## Description
Update `npm_token` to `NPM_TOKEN` in workflows, as there is no `npm_token` secret is GitHub Actions settings, just NPM_TOKEN, now setup as MapTiler organisation secret.

## Acceptance
Secrets are case sensitive, so the previous state was not working, now it should use correct NPM_TOKEN.

## Checklist
- [ ] I have added relevant info to the CHANGELOG.md