### PR TITLE
RD-1167 Space crashes in UMD when only a color is defined

### DIFF
--- a/demos/src/07-spacebox.ts
+++ b/demos/src/07-spacebox.ts
@@ -17,7 +17,7 @@ function main() {
     projection: "globe",
     center: [0, -20],
     space: true, // these can also be config objects CubemapLayerConstructorOptions
-    halo: true, // same here, RadialGradientLayerConstructorOptions
+    halo: true,// same here, RadialGradientLayerConstructorOptions
   });
 
   let currentHaloIndex = 0;

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -223,7 +223,12 @@ export class Map extends maplibregl.Map {
    * If an option is not set it will internally revert to the default option
    * unless explicitly set when calling.
    */
-  public setSpace(space: CubemapDefinition) {
+  public setSpace(space: CubemapDefinition | boolean) {
+    if (space === false) {
+      this.space = undefined;
+      return;
+    }
+
     if (!this.isGlobeProjection()) {
       return;
     }
@@ -244,7 +249,13 @@ export class Map extends maplibregl.Map {
   }
 
   private setSpaceFromStyle({ style }: { style: StyleSpecificationWithMetaData }) {
+    if (this.options.space) {
+      this.setSpace(this.options.space);
+      return;
+    }
+
     const space = style.metadata?.maptiler?.space;
+
     if (!space) {
       this.setSpace({
         color: "transparent",
@@ -298,7 +309,7 @@ export class Map extends maplibregl.Map {
       return;
     }
 
-    if (!maptiler?.halo) {
+    if (!maptiler?.halo && !this.options.halo) {
       this.setHalo({
         stops: [
           [0, "transparent"],
@@ -317,7 +328,11 @@ export class Map extends maplibregl.Map {
           this.addLayer(this.halo, before);
         }
 
-        void this.halo.setGradient(maptiler.halo);
+        const spec = maptiler?.halo ?? this.options.halo;
+
+        if (spec) {
+          void this.halo.setGradient(spec);
+        }
       }
     };
 

--- a/src/Telemetry.ts
+++ b/src/Telemetry.ts
@@ -1,7 +1,7 @@
+import { getVersion } from ".";
 import type { Map as MapSDK } from "./Map";
 import { config, MAPTILER_SESSION_ID } from "./config";
 import { defaults } from "./constants/defaults";
-import packagejson from "../package.json";
 
 /**
  * A Telemetry instance sends some usage and merics to a dedicated endpoint at MapTiler Cloud.
@@ -55,7 +55,7 @@ export class Telemetry {
     const telemetryUrl = new URL(defaults.telemetryURL);
 
     // Adding the version of the SDK
-    telemetryUrl.searchParams.append("sdk", packagejson.version);
+    telemetryUrl.searchParams.append("sdk", getVersion());
 
     // Adding the API key
     telemetryUrl.searchParams.append("key", config.apiKey);

--- a/src/custom-layers/CubemapLayer/CubemapLayer.ts
+++ b/src/custom-layers/CubemapLayer/CubemapLayer.ts
@@ -20,7 +20,6 @@ const GL_USE_TEXTURE_MACRO_MARKER = "%USE_TEXTURE_MACRO_MARKER%";
 const GL_USE_TEXTURE_MACRO = "#define USE_TEXTURE";
 
 const defaultConstructorOptions: CubemapLayerConstructorOptions = cubemapPresets.stars;
-
 /**
  * Configures options for the CubemapLayer by merging defaults with provided options.
  *
@@ -420,6 +419,8 @@ class CubemapLayer implements CustomLayerInterface {
       return;
     }
 
+    console.log(__MT_NODE_ENV__, "AYEEEEEE");
+
     if (this.map === undefined) {
       throw new Error("[CubemapLayer]: Map is undefined");
     }
@@ -428,7 +429,7 @@ class CubemapLayer implements CustomLayerInterface {
       throw new Error("[CubemapLayer]: Cubemap is undefined");
     }
 
-    if (this.texture === undefined && process.env.NODE_ENV === "development") {
+    if (this.texture === undefined && __MT_NODE_ENV__ === "development") {
       console.warn("[CubemapLayer]: Texture is undefined, no texture will be rendered to cubemap");
     }
 
@@ -540,8 +541,11 @@ class CubemapLayer implements CustomLayerInterface {
    * and if so, it updates the cubemap faces.
    * Finally, it calls `updateCubemap` to apply the changes and trigger a repaint of the map.
    */
-  public async setCubemap(cubemap: CubemapDefinition): Promise<void> {
+  public async setCubemap(spec: CubemapDefinition | boolean): Promise<void> {
+    const cubemap = typeof spec === "boolean" ? defaultConstructorOptions : spec;
+
     this.options = cubemap;
+
     const facesKey = JSON.stringify(cubemap.faces ?? cubemap.preset ?? cubemap.path);
 
     const facesNeedUpdate = this.currentFacesDefinitionKey !== facesKey;
@@ -582,7 +586,11 @@ class CubemapLayer implements CustomLayerInterface {
   }
 }
 
-export function validateSpaceSpecification(space: CubemapDefinition | boolean): boolean {
+export function validateSpaceSpecification(space?: CubemapDefinition | boolean): boolean {
+  if (!space) {
+    return false;
+  }
+
   if (typeof space === "boolean") {
     return true;
   }

--- a/src/custom-layers/RadialGradientLayer/RadialGradientLayer.ts
+++ b/src/custom-layers/RadialGradientLayer/RadialGradientLayer.ts
@@ -324,8 +324,14 @@ export class RadialGradientLayer implements CustomLayerInterface {
    * @param {GradientDefinition} gradient - The new gradient definition to set for this layer.
    * @returns {Promise<void>} A promise that resolves when the new gradient is set and animated in.
    */
-  public async setGradient(gradient: GradientDefinition): Promise<void> {
+  public async setGradient(gradient: GradientDefinition | boolean): Promise<void> {
+    if (gradient === false) {
+      await this.animateOut();
+      return;
+    }
+
     await this.animateOut();
+
     if (!validateHaloSpecification(gradient)) {
       this.gradient.scale = defaultConstructorOptions.scale;
       this.gradient.stops = [
@@ -334,8 +340,14 @@ export class RadialGradientLayer implements CustomLayerInterface {
       ];
       return;
     }
-    this.gradient.scale = gradient.scale ?? defaultConstructorOptions.scale;
-    this.gradient.stops = gradient.stops ?? defaultConstructorOptions.stops;
+
+    if (gradient === true) {
+      this.gradient.scale = defaultConstructorOptions.scale;
+      this.gradient.stops = defaultConstructorOptions.stops;
+    } else {
+      this.gradient.scale = gradient.scale ?? defaultConstructorOptions.scale;
+      this.gradient.stops = gradient.stops ?? defaultConstructorOptions.stops;
+    }
 
     await this.animateIn();
   }

--- a/src/custom-layers/extractCustomLayerStyle.ts
+++ b/src/custom-layers/extractCustomLayerStyle.ts
@@ -25,14 +25,14 @@ export default function extractCustomLayerStyle<T extends CubemapLayerConstructo
   const style = map.getStyle() as StyleSpecificationWithMetaData;
 
   if (!style) {
-    if (process.env.NODE_ENV === "development") {
+    if (__MT_NODE_ENV__ === "development") {
       console.warn("[extractCustomLayerStyle]: `Map.getStyle()` is returning undefined, are you initiating before style is ready?");
     }
     return null;
   }
 
   if (!style.metadata?.maptiler) {
-    if (process.env.NODE_ENV === "development") {
+    if (__MT_NODE_ENV__ === "development") {
       console.warn(`[extractCustomLayerStyle]: Attempting to find styling for "${property}" in "metadata.maptiler". But no MapTiler metadata entry was found in the style.`);
     }
     return null;

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -4,3 +4,4 @@ declare module "*?raw" {
 }
 
 declare const __MT_SDK_VERSION__: string;
+declare const __MT_NODE_ENV__: string;

--- a/vite.config-dev.ts
+++ b/vite.config-dev.ts
@@ -62,6 +62,7 @@ export default defineConfig({
   },
   define: {
     __MT_SDK_VERSION__: JSON.stringify(packagejson.version),
+    __MT_NODE_ENV__: JSON.stringify(process.env.NODE_ENV),
   },
   plugins: [
     {

--- a/vite.config-es.ts
+++ b/vite.config-es.ts
@@ -62,6 +62,7 @@ export default defineConfig({
   },
     define: {
     __MT_SDK_VERSION__: JSON.stringify(packagejson.version),
+    __MT_NODE_ENV__: JSON.stringify(process.env.NODE_ENV),
   },
   plugins,
 })

--- a/vite.config-test.ts
+++ b/vite.config-test.ts
@@ -13,5 +13,6 @@ export default defineConfig({
   },
   define: {
     __MT_SDK_VERSION__: JSON.stringify(packagejson.version),
+    __MT_NODE_ENV__: JSON.stringify(process.env.NODE_ENV === "development"),
   },
 });

--- a/vite.config-umd.ts
+++ b/vite.config-umd.ts
@@ -20,6 +20,7 @@ export default defineConfig({
   },
   define: {
     __MT_SDK_VERSION__: JSON.stringify(packagejson.version),
+    __MT_NODE_ENV__: JSON.stringify(process.env.NODE_ENV),
   },
   plugins: [],
 });


### PR DESCRIPTION
## Objective
Fixes [RD-1167](https://maptiler.atlassian.net/browse/RD-1167)

## Description
- process.env.NODE_ENV is not present in UMD bundle, so we leverage Vite to pass a custom define.
- better handling of space configs in constructor

## Acceptance
- Unit tests
- Manually tested

## Checklist
- [x] I have added relevant info to the CHANGELOG.md

[RD-1167]: https://maptiler.atlassian.net/browse/RD-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ