### PR TITLE
RD-509 Custom Controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 ### ✨ Features and improvements
-- None
+- Adds custom controls that can be styled however you wish and can do whatever you need, in both declarative (auto-detected) and programmatic way
 
 ### 🐛 Bug fixes
 - fixes bug where space would not load correctly when style is a URI.

--- a/README.md
+++ b/README.md
@@ -451,7 +451,145 @@ const map = new Map({
 })
 ```
 
+# 🧩 Custom Controls
 
+MapTiler SDK JS supports two flexible ways to add custom controls to your map interface. Whether you're building a dynamic application or integrating with static HTML, there's a matching approach for both.
+
+## Programmatic Controls
+
+Use `map.addControl()` with `MaptilerExternalControl` to register custom UI elements manually. This approach is ideal for dynamic logic, event-driven behavior, or integration with frameworks like React. The control element can be provided either as a reference to the **element itself**, or as its **CSS selector**. Optionally, two callback functions can be provided:
+
+* `onClick` function that is called when the element is clicked, and
+* `onRender` function that is called every time the map renders a new state.
+
+Both callbacks receive the active `Map` instance, the associated control element itself, and an event object associated with the original event (`PointerEvent` and `MapLibreEvent` respectively).
+
+### Example
+
+```ts
+const panControl = new maptilersdk.MaptilerExternalControl(
+  ".pan-control",
+  (map) => map.panBy([10, 10]), // Move southeast on click
+  (map, el) => el.classList.toggle( // Style based on hemisphere
+    "northern-hemisphere", map.getCenter().lat > 0
+  )
+);
+map.addControl(panControl);
+
+const element = document.createElement("button");
+element.textContent = "Pan NW";
+map.addControl(
+  new maptilersdk.MaptilerExternalControl(
+    element,
+    (map) => map.panBy([-10, -10]) // Move northwest
+  ),
+  "top-left"
+);
+```
+
+### Behavior Overview
+
+- On add, control element is moved into the map UI
+- `onClick` binds user interaction
+- `onRender` enables state-based styling or logic
+- Control maintains its own DOM context
+- On removal, element is returned to its original DOM position (if any) to not interfere with DOM handling of frameworks like React
+
+## Declarative Controls
+
+Add controls using HTML attributes – no JavaScript required. This is perfect for simple UI setups.
+
+### Enabling Detection
+
+```ts
+const map = new maptilersdk.Map({
+  container: "map",
+  customControls: true, // or ".custom-ui"
+});
+```
+
+You can pass `true` to enable detection globally, or a CSS selector to scope it.
+
+### Declaring Controls
+
+Use `data-maptiler-control` attribute:
+
+```html
+<button data-maptiler-control="zoom-in">+</button>
+```
+
+Supported values:
+
+| Value               | Description                                      |
+|---------------------|--------------------------------------------------|
+| `zoom-in`           | Zooms in                                         |
+| `zoom-out`          | Zooms out                                        |
+| `toggle-projection` | Switches Mercator ↔ Globe                        |
+| `toggle-terrain`    | Toggles terrain layer                            |
+| `reset-view`        | Resets bearing, pitch, and roll                  |
+| `reset-bearing`     | Resets bearing only                              |
+| `reset-pitch`       | Resets pitch only                                |
+| `reset-roll`        | Resets roll only                                 |
+| *(empty)*           | Registers control without built-in functionality |
+
+> ⚠️ An error is thrown if an unrecognized value is used.
+
+### Grouping Controls
+
+Use `data-maptiler-control-group` to group buttons:
+
+```html
+<div data-maptiler-control-group>
+  <button data-maptiler-control="zoom-in">+</button>
+  <button data-maptiler-control="zoom-out">−</button>
+</div>
+```
+
+Groups are styled and positioned together but don't add functionality themselves. Functional behavior is attached to valid descendant elements.
+
+### Positioning Controls
+
+Use `data-maptiler-position` to set placement:
+
+```html
+<button data-maptiler-control="reset-view" data-maptiler-position="top-left">↻</button>
+<div data-maptiler-control-group data-maptiler-position="bottom-right">
+  <button data-maptiler-control="zoom-in">+</button>
+  <button data-maptiler-control="zoom-out">−</button>
+</div>
+```
+
+Valid positions: `'top-left'`, `'top-right'`, `'bottom-left'`, `'bottom-right'`
+
+## Styling with CSS Variables
+
+When declarative controls are enabled, the map container exposes dynamic CSS variables:
+
+| Variable                         | Description                                      | Type            |
+|----------------------------------|--------------------------------------------------|-----------------|
+| `--maptiler-center-lng`          | Longitude of center                              | unitless number |
+| `--maptiler-center-lat`          | Latitude of center                               | unitless number |
+| `--maptiler-zoom`                | Zoom level                                       | unitless number |
+| `--maptiler-bearing`             | Map rotation                                     | unitless number |
+| `--maptiler-pitch`               | Pitch angle                                      | unitless number |
+| `--maptiler-roll`                | Roll angle                                       | unitless number |
+| `--maptiler-is-globe-projection` | `true` if globe is active<br>`false` otherwise   | string          |
+| `--maptiler-has-terrain`         | `true` if terrain is active<br>`false` otherwise | string          |
+
+### Example
+
+```css
+.compass-icon {
+  transform: rotateX(calc(var(--maptiler-pitch) * 1deg))
+             rotateZ(calc(var(--maptiler-bearing) * -1deg));
+}
+
+@container style(--maptiler-is-globe-projection: true) {
+  .projection-icon {
+    content: "globe";
+  }
+}
+```
 
 # 3D terrain in one call
 <p align="center">

--- a/demos/public/09-custom-controls-declarative.html
+++ b/demos/public/09-custom-controls-declarative.html
@@ -1,0 +1,71 @@
+<html>
+
+<head>
+  <title>MapTiler JS SDK example</title>
+  <style>
+    .maplibregl-control-container .btn {
+      pointer-events: auto;
+      display: block;
+    }
+
+    [data-maptiler-control="reset-view"] span {
+      transform: rotateX(calc(var(--maptiler-pitch) * 1deg))
+        rotateZ(calc(var(--maptiler-bearing) * -1deg));
+    }
+    [data-maptiler-control="toggle-projection"] span::after {
+      content: "globe";
+    }
+    @container style(--maptiler-is-globe-projection: true) {
+      [data-maptiler-control="toggle-projection"] span::after {
+        content: "map";
+      }
+    }
+    [data-maptiler-control="toggle-terrain"] span, .home-button span {
+      transition: font-variation-settings 1s ease-in-out;
+      font-variation-settings: 'FILL' 0;
+    }
+    @container style(--maptiler-has-terrain: true) {
+      [data-maptiler-control="toggle-terrain"] span {
+        font-variation-settings: 'FILL' 1;
+      }
+    }
+    @container style(--maptiler-center-lng: 15) and style(--maptiler-center-lat: 50) {
+      .home-button span {
+        font-variation-settings: 'FILL' 1;
+      }
+    }
+  </style>
+
+  <link rel="stylesheet" href="demo-styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1">
+</head>
+
+<body>
+  <div id="map"></div>
+  <div data-maptiler-control-group class="btn-group-vertical m-2">
+    <button data-maptiler-control="zoom-in" class="btn btn-light">
+      <span class="material-symbols-outlined">zoom_in</span>
+    </button>
+    <button data-maptiler-control="zoom-out" class="btn btn-light">
+      <span class="material-symbols-outlined">zoom_out</span>
+    </button>
+    <button data-maptiler-control="reset-view" class="btn btn-light">
+      <span class="material-symbols-outlined">navigation</span>
+    </button>
+  </div>
+  <button data-maptiler-control="toggle-projection" data-maptiler-position="top-left" class="btn btn-primary m-2">
+    <span class="material-symbols-outlined"></span>
+  </button>
+  <button data-maptiler-control="toggle-terrain" data-maptiler-position="top-left" class="btn btn-success m-2">
+    <span class="material-symbols-outlined">terrain</span>
+  </button>
+  <button data-maptiler-control data-maptiler-position="bottom-right" class="btn btn-danger m-2 float-end home-button">
+    <span class="material-symbols-outlined">home</span>
+  </button>
+
+  <script type="module" src="/src/08-custom-controls-declarative.ts"></script>
+</body>
+
+</html>
+

--- a/demos/public/10-custom-controls-programmatic.html
+++ b/demos/public/10-custom-controls-programmatic.html
@@ -1,0 +1,51 @@
+<html>
+
+<head>
+  <title>MapTiler JS SDK example</title>
+  <style>
+    .maplibregl-control-container .btn {
+      pointer-events: auto;
+      display: block;
+    }
+
+    .material-symbols-outlined {
+      transition: font-variation-settings 1s ease-in-out;
+      font-variation-settings: 'FILL' 0;
+    }
+    .icon-fill {
+      font-variation-settings: 'FILL' 1;
+    }
+  </style>
+
+  <link rel="stylesheet" href="demo-styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1">
+</head>
+
+<body>
+  <div id="map"></div>
+  <div hidden>
+    <div class="btn-group-vertical m-2 navigation-controls">
+      <button class="btn btn-light zoom-in-control">
+        <span class="material-symbols-outlined">zoom_in</span>
+      </button>
+      <button class="btn btn-light zoom-out-control">
+        <span class="material-symbols-outlined">zoom_out</span>
+      </button>
+      <button class="btn btn-light compass-control">
+        <span class="material-symbols-outlined">navigation</span>
+      </button>
+    </div>
+    <button class="btn btn-primary m-2 projection-control">
+      <span class="material-symbols-outlined">globe</span>
+    </button>
+    <button class="btn btn-danger m-2 float-end home-button">
+      <span class="material-symbols-outlined">home</span>
+    </button>
+  </div>
+
+  <script type="module" src="/src/09-custom-controls-programmatic.ts"></script>
+</body>
+
+</html>
+

--- a/demos/public/index.html
+++ b/demos/public/index.html
@@ -59,6 +59,8 @@
       <a href="05-transform-request.html">Transform request →</a>
       <a href="06-handling-webgl-errors.html">Handling WebGL Errors →</a>
       <a href="07-spacebox.html">SpaceBox →</a>
+      <a href="09-custom-controls-declarative.html">Custom Controls: Declarative →</a>
+      <a href="10-custom-controls-programmatic.html">Custom Controls: Programmatic →</a>
     </div>
   </div>
 </body>

--- a/demos/src/09-custom-controls-declarative.ts
+++ b/demos/src/09-custom-controls-declarative.ts
@@ -1,0 +1,20 @@
+import "../../src/style/style_template.css";
+import { Map, MapStyle, config } from "../../src/index";
+import { addPerformanceStats, setupMapTilerApiKey } from "./demo-utils";
+
+addPerformanceStats();
+setupMapTilerApiKey({ config });
+
+const container = document.getElementById("map") as HTMLDivElement;
+
+const map = new Map({
+  container,
+  style: MapStyle.STREETS.DEFAULT,
+  hash: true,
+  customControls: true,
+  geolocateControl: false,
+  navigationControl: false,
+  terrainExaggeration: 4,
+});
+
+document.querySelector(".home-button")?.addEventListener("click", () => map.easeTo({ center: [15, 50], zoom: 7 }));

--- a/demos/src/10-custom-controls-programmatic.ts
+++ b/demos/src/10-custom-controls-programmatic.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion, @typescript-eslint/non-nullable-type-assertion-style */
+import "../../src/style/style_template.css";
+import { Map, MapStyle, config, toggleProjection, toggleTerrain } from "../../src/index";
+import { addPerformanceStats, setupMapTilerApiKey } from "./demo-utils";
+import { MaptilerCustomControl } from "../../src/controls/MaptilerCustomControl";
+
+addPerformanceStats();
+setupMapTilerApiKey({ config });
+
+const container = document.getElementById("map") as HTMLDivElement;
+
+const map = new Map({
+  container,
+  style: MapStyle.STREETS.DEFAULT,
+  hash: true,
+  geolocateControl: false,
+  navigationControl: false,
+  terrainExaggeration: 4,
+});
+
+const compassControlElement = document.querySelector(".compass-control") as HTMLElement;
+const navigationControl = new MaptilerCustomControl(
+  ".navigation-controls",
+  (map, _, event) => {
+    if ((event.target as HTMLElement).closest(".zoom-in-control")) {
+      map.zoomIn();
+    }
+  },
+  (map) => {
+    (compassControlElement.firstElementChild as HTMLElement).style.transform = `rotateX(${String(map.getPitch())}deg) rotateZ(${String(-map.getBearing())}deg)`;
+  },
+);
+map.addControl(navigationControl);
+document.querySelector(".zoom-out-control")?.addEventListener("click", () => map.zoomOut());
+compassControlElement.addEventListener("click", () => map.resetNorthPitch());
+
+const projectionControlElement = document.querySelector(".projection-control") as HTMLElement;
+const projectionControl = new MaptilerCustomControl(projectionControlElement, toggleProjection, (map, element) => {
+  element.firstElementChild!.textContent = map.isGlobeProjection() ? "map" : "globe";
+  element.title = map.isGlobeProjection() ? "Switch to Mercator projection" : "Switch to Globe projection";
+});
+map.addControl(projectionControl, "top-left");
+
+const terrainControlElement = document.createElement("div");
+terrainControlElement.className = "btn btn-success m-2 terrain-control";
+const terrainControlIcon = document.createElement("span");
+terrainControlIcon.textContent = "terrain";
+terrainControlIcon.classList.add("material-symbols-outlined");
+terrainControlElement.appendChild(terrainControlIcon);
+const terrainControl = new MaptilerCustomControl(terrainControlElement, toggleTerrain, (map) => {
+  terrainControlIcon.classList.toggle("icon-fill", map.hasTerrain());
+  terrainControlElement.title = map.hasTerrain() ? "Turn off Terrain" : "Turn on Terrain";
+});
+map.addControl(terrainControl, "top-left");
+
+const home = { lng: 15.4, lat: 49.8 };
+map.addControl(
+  new MaptilerCustomControl(
+    ".home-button",
+    (map) => {
+      map.easeTo({ center: home, zoom: 7 });
+    },
+    (map, element) => {
+      const center = map.getCenter();
+      const zoom = map.getZoom();
+      (element.firstElementChild as HTMLElement).classList.toggle(
+        "icon-fill",
+        Math.abs(center.lng - home.lng) < Math.max(0, zoom - 6.8) * 1.5 && Math.abs(center.lat - home.lat) < Math.max(0, zoom - 6.8) / 2,
+      );
+    },
+  ),
+  "bottom-right",
+);

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -33,6 +33,7 @@ import { MapStyle, geolocation, getLanguageInfoFromFlag, toLanguageInfo } from "
 import { MaptilerGeolocateControl } from "./controls/MaptilerGeolocateControl";
 import { ScaleControl } from "./MLAdapters/ScaleControl";
 import { FullscreenControl } from "./MLAdapters/FullscreenControl";
+import { MaptilerExternalControlType, MaptilerExternalControl } from "./controls/MaptilerExternalControl";
 
 import Minimap from "./controls/Minimap";
 import type { MinimapOptionsInput } from "./controls/Minimap";
@@ -150,6 +151,11 @@ export type MapOptions = Omit<MapOptionsML, "style" | "maplibreLogo"> & {
    * Show the full screen control. (default: `false`, will show if `true`)
    */
   fullscreenControl?: boolean | ControlPosition;
+
+  /**
+   * Detect custom external controls. (default: `false`, will detect automatically if `true`)
+   */
+  customControls?: boolean | string;
 
   /**
    * Display a minimap in a user defined corner of the map. (default: `bottom-left` corner)
@@ -654,7 +660,8 @@ export class Map extends maplibregl.Map {
     });
 
     // Update logo and attibution
-    this.once("load", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    void this.once("load", async () => {
       let tileJsonContent = { logo: null };
 
       try {
@@ -672,6 +679,57 @@ export class Map extends maplibregl.Map {
         tileJsonContent = await tileJsonRes.json();
       } catch (_e) {
         // No tiles.json found (should not happen on maintained styles)
+      }
+
+      if (options.customControls) {
+        const groupSelector = "[data-maptiler-control-group]";
+        const controlSelector = "[data-maptiler-control]";
+        const getControlType = (element: HTMLElement) => {
+          let type = element.dataset.maptilerControl as MaptilerExternalControlType | "true" | "" | undefined;
+          // value of empty data attribute in React is string "true", empty string elsewhere
+          if (type === "true" || type === "") type = undefined;
+          return type;
+        };
+        const getPosition = (element: HTMLElement) => element.dataset.maptilerPosition as ControlPosition | undefined;
+
+        let groupElements = [...(this._container.ownerDocument.querySelectorAll(groupSelector) as NodeListOf<HTMLElement>)];
+        let controlElements = [...(this._container.ownerDocument.querySelectorAll(controlSelector) as NodeListOf<HTMLElement>)].filter(
+          (controlElement) => controlElement.closest(groupSelector) === null,
+        );
+
+        if (typeof options.customControls === "string") {
+          const limitingSelector = options.customControls;
+          groupElements = groupElements.filter((groupElement) => groupElement.matches(limitingSelector) || groupElement.closest(limitingSelector) !== null);
+          controlElements = controlElements.filter((controlElement) => controlElement.matches(limitingSelector) || controlElement.closest(limitingSelector) !== null);
+        }
+
+        for (const groupElement of groupElements) {
+          const control = new MaptilerExternalControl(groupElement);
+          this.addControl(control, getPosition(groupElement));
+
+          for (const controlElement of groupElement.querySelectorAll(controlSelector) as NodeListOf<HTMLElement>) {
+            control.configureGroupItem(controlElement, getControlType(controlElement));
+          }
+        }
+
+        for (const controlElement of controlElements) {
+          this.addControl(new MaptilerExternalControl(controlElement, getControlType(controlElement)), getPosition(controlElement));
+        }
+
+        const setStyleProps = () => {
+          const { lng, lat } = this.getCenter();
+          this._container.style.setProperty("--maptiler-center-lng", String(lng));
+          this._container.style.setProperty("--maptiler-center-lat", String(lat));
+          this._container.style.setProperty("--maptiler-zoom", String(this.getZoom()));
+          this._container.style.setProperty("--maptiler-bearing", String(this.getBearing()));
+          this._container.style.setProperty("--maptiler-pitch", String(this.getPitch()));
+          this._container.style.setProperty("--maptiler-roll", String(this.getRoll()));
+          this._container.style.setProperty("--maptiler-is-globe-projection", String(this.isGlobeProjection()));
+          this._container.style.setProperty("--maptiler-has-terrain", String(this.hasTerrain()));
+        };
+
+        setStyleProps();
+        this.on("render", setStyleProps);
       }
 
       // The attribution and logo must show when required

--- a/src/controls/MaptilerCustomControl.ts
+++ b/src/controls/MaptilerCustomControl.ts
@@ -1,0 +1,73 @@
+import { DOMremove } from "../utils/dom";
+import type { Map as SDKMap } from "../Map";
+import type { IControl, MapLibreEvent } from "maplibre-gl";
+
+export type MaptilerCustomControlCallback<E> = (map: SDKMap, element: HTMLElement, event: E) => void;
+
+/**
+ * The MaptilerCustomControl allows any existing element to become a map control.
+ */
+export class MaptilerCustomControl implements IControl {
+  #map!: SDKMap;
+  #element!: HTMLElement;
+  #onClickFn?: (event: Event) => void;
+  #onRenderFn?: (event: MapLibreEvent) => void;
+  #originalParent: HTMLElement | null;
+
+  /**
+   * @param selectorOrElement Element to be used as control, specified as either reference to element itself or a CSS selector to find the element in DOM
+   * @param onClick Function called when the element is clicked
+   * @param onRender Function called every time the underlying map renders a new state
+   */
+  constructor(selectorOrElement: string | HTMLElement, onClick?: MaptilerCustomControlCallback<Event>, onRender?: MaptilerCustomControlCallback<MapLibreEvent>) {
+    if (typeof selectorOrElement === "string") {
+      const element = document.querySelector(selectorOrElement) as HTMLElement | null;
+      if (!element) throw new Error(`No element has been found with selector "${selectorOrElement}" when creating an external control.`);
+      this.#element = element;
+    } else {
+      this.#element = selectorOrElement;
+    }
+
+    if (onClick) {
+      this.#onClickFn = (event: Event) => {
+        onClick(this.#map, this.#element, event);
+      };
+    }
+    if (onRender) {
+      this.#onRenderFn = (event: MapLibreEvent) => {
+        onRender(this.#map, this.#element, event);
+      };
+    }
+
+    this.#originalParent = this.#element.parentElement;
+  }
+
+  onAdd(map: SDKMap): HTMLElement {
+    this.#map = map;
+
+    if (this.#onClickFn) {
+      this.#element.addEventListener("click", this.#onClickFn);
+    }
+    if (this.#onRenderFn) {
+      this.#map.on("render", this.#onRenderFn);
+    }
+
+    DOMremove(this.#element);
+    return this.#element;
+  }
+
+  onRemove(): void {
+    if (this.#onClickFn) {
+      this.#element.removeEventListener("click", this.#onClickFn);
+    }
+    if (this.#onRenderFn) {
+      this.#map.off("render", this.#onRenderFn);
+    }
+
+    if (this.#originalParent) {
+      this.#originalParent.appendChild(this.#element);
+    } else {
+      DOMremove(this.#element);
+    }
+  }
+}

--- a/src/controls/MaptilerExternalControl.ts
+++ b/src/controls/MaptilerExternalControl.ts
@@ -1,0 +1,84 @@
+import type { Map as SDKMap } from "../Map";
+import type { IControl } from "maplibre-gl";
+import { MaptilerCustomControl, MaptilerCustomControlCallback } from "./MaptilerCustomControl";
+import { toggleProjection } from "./MaptilerProjectionControl";
+import { toggleTerrain } from "./MaptilerTerrainControl";
+
+export type MaptilerExternalControlType = "zoom-in" | "zoom-out" | "toggle-projection" | "toggle-terrain" | "reset-view" | "reset-bearing" | "reset-pitch" | "reset-roll";
+
+const controlCallbacks: Record<MaptilerExternalControlType, MaptilerCustomControlCallback<Event>> = {
+  "zoom-in": (map) => map.zoomIn(),
+  "zoom-out": (map) => map.zoomOut(),
+  "toggle-projection": toggleProjection,
+  "toggle-terrain": toggleTerrain,
+  "reset-view": (map) => {
+    const currentPitch = map.getPitch();
+    if (currentPitch === 0) {
+      map.easeTo({ pitch: Math.min(map.getMaxPitch(), 80) });
+    } else {
+      map.resetNorthPitch();
+    }
+  },
+  "reset-bearing": (map) => {
+    map.rotateTo(0);
+  },
+  "reset-pitch": (map) => {
+    map.setPitch(0);
+  },
+  "reset-roll": (map) => {
+    map.setRoll(0);
+  },
+};
+
+/**
+ * The MaptilerExternalControl allows any existing element to automatically become a map control. Used for detected controls if `customControls` config is turned on.
+ */
+export class MaptilerExternalControl extends MaptilerCustomControl implements IControl {
+  static controlCallbacks = controlCallbacks;
+
+  #map!: SDKMap;
+  #groupItemEvents = new Map<WeakRef<HTMLElement>, (event: Event) => void>();
+
+  /**
+   * Constructs an instance of External Control to have a predefined functionality
+   * @param controlElement Element to be used as control, specified as reference to element itself
+   * @param controlType One of the predefined types of functionality
+   */
+  constructor(controlElement: HTMLElement, controlType?: MaptilerExternalControlType) {
+    if (controlType && !(controlType in controlCallbacks)) throw new Error(`data-maptiler-control value "${controlType}" is invalid.`);
+    super(controlElement, controlType && controlCallbacks[controlType]);
+  }
+
+  onAdd(map: SDKMap): HTMLElement {
+    this.#map = map;
+
+    return super.onAdd(map);
+  }
+
+  onRemove(): void {
+    for (const [elementRef, onClickFn] of this.#groupItemEvents) {
+      const element = elementRef.deref();
+      if (element) {
+        element.removeEventListener("click", onClickFn);
+      }
+    }
+    this.#groupItemEvents.clear();
+
+    super.onRemove();
+  }
+
+  /**
+   * Configure a child element to be part of this control and to have a predefined functionality added
+   * @param controlElement Element that is a descendant of the control element and that optionally should have some functionality
+   * @param controlType One of the predefined types of functionality
+   */
+  configureGroupItem(controlElement: HTMLElement, controlType: MaptilerExternalControlType | undefined): void {
+    if (!controlType) return;
+    if (!(controlType in controlCallbacks)) throw new Error(`data-maptiler-control value "${controlType}" is invalid.`);
+    const onClickFn = (event: Event) => {
+      controlCallbacks[controlType](this.#map, controlElement, event);
+    };
+    controlElement.addEventListener("click", onClickFn);
+    this.#groupItemEvents.set(new WeakRef(controlElement), onClickFn);
+  }
+}

--- a/src/controls/MaptilerProjectionControl.ts
+++ b/src/controls/MaptilerProjectionControl.ts
@@ -32,14 +32,7 @@ export class MaptilerProjectionControl implements IControl {
   }
 
   private toggleProjection(): void {
-    if (this.map.getProjection() === undefined) {
-      this.map.setProjection({ type: "mercator" });
-    }
-    if (this.map.isGlobeProjection()) {
-      this.map.enableMercatorProjection();
-    } else {
-      this.map.enableGlobeProjection();
-    }
+    toggleProjection(this.map);
     this.updateProjectionIcon();
   }
 
@@ -53,5 +46,16 @@ export class MaptilerProjectionControl implements IControl {
       this.projectionButton.classList.add("maplibregl-ctrl-projection-globe");
       this.projectionButton.title = "Enable Globe projection";
     }
+  }
+}
+
+export function toggleProjection(map: SDKMap): void {
+  if (map.getProjection() === undefined) {
+    map.setProjection({ type: "mercator" });
+  }
+  if (map.isGlobeProjection()) {
+    map.enableMercatorProjection();
+  } else {
+    map.enableGlobeProjection();
   }
 }

--- a/src/controls/MaptilerTerrainControl.ts
+++ b/src/controls/MaptilerTerrainControl.ts
@@ -38,12 +38,7 @@ export class MaptilerTerrainControl implements IControl {
   }
 
   _toggleTerrain(): void {
-    if (this._map.hasTerrain()) {
-      this._map.disableTerrain();
-    } else {
-      this._map.enableTerrain();
-    }
-
+    toggleTerrain(this._map);
     this._updateTerrainIcon();
   }
 
@@ -58,5 +53,13 @@ export class MaptilerTerrainControl implements IControl {
       this._terrainButton.classList.add("maplibregl-ctrl-terrain");
       this._terrainButton.title = this._map._getUIString("TerrainControl.Enable");
     }
+  }
+}
+
+export function toggleTerrain(map: SDKMap): void {
+  if (map.hasTerrain()) {
+    map.disableTerrain();
+  } else {
+    map.enableTerrain();
   }
 }

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -1,3 +1,5 @@
+export * from "./MaptilerCustomControl";
+export * from "./MaptilerExternalControl";
 export * from "./MaptilerGeolocateControl";
 export * from "./MaptilerLogoControl";
 export * from "./MaptilerTerrainControl";

--- a/test/__snapshots__/exports.test.ts.snap
+++ b/test/__snapshots__/exports.test.ts.snap
@@ -50,6 +50,8 @@ exports[`Module Exports > should match the snapshot of module exports 1`] = `
   "MapTouchEventMLGL",
   "MapWheelEvent",
   "MapWheelEventMLGL",
+  "MaptilerCustomControl",
+  "MaptilerExternalControl",
   "MaptilerGeolocateControl",
   "MaptilerLogoControl",
   "MaptilerNavigationControl",
@@ -139,6 +141,8 @@ exports[`Module Exports > should match the snapshot of module exports 1`] = `
   "str2xml",
   "styleToStyle",
   "toLanguageInfo",
+  "toggleProjection",
+  "toggleTerrain",
   "xml2str",
 ]
 `;

--- a/test/custom-control.test.ts
+++ b/test/custom-control.test.ts
@@ -1,0 +1,288 @@
+/* eslint-disable
+  @typescript-eslint/no-explicit-any,
+  @typescript-eslint/no-unsafe-member-access,
+  @typescript-eslint/no-unsafe-assignment,
+  @typescript-eslint/no-unsafe-call,
+  @typescript-eslint/no-unsafe-return,
+  @typescript-eslint/no-extraneous-class,
+  @typescript-eslint/no-empty-function,
+*/
+
+globalThis.WebGL2RenderingContext = class WebGL2RenderingContextMock {} as any;
+
+vi.mock("../src/Map", async () => {
+  const actual: any = await vi.importActual("../src/Map");
+  const maplibre: any = await vi.importActual("maplibre-gl");
+  return {
+    ...actual,
+    Map: class extends maplibre.default.Evented {
+      constructor(options: any) {
+        super();
+        this._container = options.container;
+        this._setupContainer(this);
+      }
+      _container: HTMLElement;
+      _setupContainer = actual.Map.prototype._setupContainer;
+      _controls: maplibregl.IControl[] = [];
+      addControl = actual.Map.prototype.addControl;
+      removeControl = actual.Map.prototype.removeControl;
+      _getUIString = (str: string) => str;
+      _containerDimensions = () => [0, 0];
+      _getClampedPixelRatio = () => 1;
+      _resizeCanvas = () => {};
+    },
+  };
+});
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Map as SDKMap } from "../src/Map";
+import { MaptilerCustomControl } from "../src/controls";
+
+describe("MaptilerCustomControl", () => {
+  let container: HTMLElement;
+  function createMapHelper() {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+
+    return new SDKMap({
+      container,
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  describe("element that is not part of DOM", () => {
+    it("should pick up the element", () => {
+      const element = document.createElement("button");
+
+      expect(() => {
+        new MaptilerCustomControl(element);
+      }).not.toThrow();
+    });
+
+    it("should move the element into the map DOM", () => {
+      const element = document.createElement("button");
+      const control = new MaptilerCustomControl(element);
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      expect(element.parentElement).not.toBeNull();
+    });
+
+    it("should detach the element from DOM when control is removed", () => {
+      const element = document.createElement("button");
+      const control = new MaptilerCustomControl(element);
+
+      const map = createMapHelper();
+      map.addControl(control);
+      map.removeControl(control);
+
+      expect(element.parentElement).toBeNull();
+    });
+  });
+
+  describe("element that is part of DOM", () => {
+    it("should pick up the element", () => {
+      const element = document.createElement("button");
+      document.body.appendChild(element);
+
+      expect(() => {
+        new MaptilerCustomControl(element);
+      }).not.toThrow();
+    });
+
+    it("should move the element into the map DOM", () => {
+      const element = document.createElement("button");
+      document.body.appendChild(element);
+      const control = new MaptilerCustomControl(element);
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      expect(element.parentElement).not.toBe(document.body);
+    });
+
+    it("should move the element to its original DOM place when control is removed", () => {
+      const element = document.createElement("button");
+      document.body.appendChild(element);
+      const control = new MaptilerCustomControl(element);
+
+      const map = createMapHelper();
+      map.addControl(control);
+      map.removeControl(control);
+
+      expect(element.parentElement).toBe(document.body);
+    });
+  });
+
+  describe("element that is looked up by its selector", () => {
+    it("should pick up the element if it exists", () => {
+      const element = document.createElement("button");
+      element.classList.add("my-control");
+      document.body.appendChild(element);
+
+      expect(() => {
+        new MaptilerCustomControl(".my-control");
+      }).not.toThrow();
+    });
+
+    it("should throw error if the element doesn't exist", () => {
+      expect(() => {
+        new MaptilerCustomControl(".not-found");
+      }).toThrow();
+    });
+
+    it("should move the element into the map DOM", () => {
+      const element = document.createElement("button");
+      element.classList.add("my-control");
+      document.body.appendChild(element);
+      const control = new MaptilerCustomControl(".my-control");
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      expect(element.parentElement).not.toBe(document.body);
+    });
+
+    it("should move the element to its original DOM place when control is removed", () => {
+      const element = document.createElement("button");
+      element.classList.add("my-control");
+      document.body.appendChild(element);
+      const control = new MaptilerCustomControl(".my-control");
+
+      const map = createMapHelper();
+      map.addControl(control);
+      map.removeControl(control);
+
+      expect(element.parentElement).toBe(document.body);
+    });
+
+    it("should use only the first found element", () => {
+      const element = document.createElement("button");
+      element.classList.add("my-control");
+      document.body.appendChild(element);
+
+      const otherElement = document.createElement("button");
+      otherElement.classList.add("my-control");
+      document.body.appendChild(otherElement);
+
+      const control = new MaptilerCustomControl(".my-control");
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      expect(element.parentElement).not.toBe(document.body);
+      expect(otherElement.parentElement).toBe(document.body);
+    });
+  });
+
+  describe("onClick callback", () => {
+    it("should not call callback before control is added", () => {
+      const element = document.createElement("button");
+      const onClickFn = vi.fn();
+      new MaptilerCustomControl(element, onClickFn);
+
+      expect(onClickFn).not.toHaveBeenCalled();
+    });
+
+    it("should not call callback unless element is clicked", () => {
+      const element = document.createElement("button");
+      const onClickFn = vi.fn();
+      const control = new MaptilerCustomControl(element, onClickFn);
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      expect(onClickFn).not.toHaveBeenCalled();
+    });
+
+    it("should call callback when element is clicked after control is added", () => {
+      const element = document.createElement("button");
+      const onClickFn = vi.fn();
+      const control = new MaptilerCustomControl(element, onClickFn);
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      element.click();
+
+      expect(onClickFn).toHaveBeenCalledExactlyOnceWith(map, element, expect.any(Event));
+
+      element.click();
+
+      expect(onClickFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should stop calling callback after control is removed", () => {
+      const element = document.createElement("button");
+      const onClickFn = vi.fn();
+      const control = new MaptilerCustomControl(element, onClickFn);
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      element.click();
+
+      expect(onClickFn).toHaveBeenCalledOnce();
+
+      map.removeControl(control);
+
+      element.click();
+
+      expect(onClickFn).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("onRender callback", () => {
+    it("should not call callback before control is added", () => {
+      const element = document.createElement("button");
+      const onRenderFn = vi.fn();
+      new MaptilerCustomControl(element, undefined, onRenderFn);
+
+      expect(onRenderFn).not.toHaveBeenCalled();
+    });
+
+    it("should call callback when map renders after control is added", () => {
+      const element = document.createElement("button");
+      const onRenderFn = vi.fn();
+      const control = new MaptilerCustomControl(element, undefined, onRenderFn);
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      map.fire("render");
+
+      expect(onRenderFn).toHaveBeenCalledExactlyOnceWith(map, element, expect.objectContaining({ type: "render" }));
+
+      map.fire("render");
+
+      expect(onRenderFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should stop calling callback after control is removed", () => {
+      const element = document.createElement("button");
+      const onRenderFn = vi.fn();
+      const control = new MaptilerCustomControl(element, undefined, onRenderFn);
+
+      const map = createMapHelper();
+      map.addControl(control);
+
+      map.fire("render");
+
+      expect(onRenderFn).toHaveBeenCalledOnce();
+
+      map.removeControl(control);
+
+      map.fire("render");
+
+      expect(onRenderFn).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/test/external-control.test.ts
+++ b/test/external-control.test.ts
@@ -1,0 +1,307 @@
+/* eslint-disable
+  @typescript-eslint/no-explicit-any,
+  @typescript-eslint/no-unsafe-member-access,
+  @typescript-eslint/no-unsafe-assignment,
+  @typescript-eslint/no-unsafe-call,
+  @typescript-eslint/no-unsafe-argument,
+  @typescript-eslint/no-extraneous-class,
+  @typescript-eslint/no-empty-function,
+  @typescript-eslint/unbound-method,
+*/
+
+globalThis.WebGL2RenderingContext = class WebGL2RenderingContextMock {} as any;
+
+vi.mock("maplibre-gl", async () => {
+  const actual: any = await vi.importActual("maplibre-gl");
+  return {
+    default: {
+      ...actual.default,
+      Map: class extends actual.default.Evented {
+        constructor(options: any) {
+          super();
+          this._container = options.container;
+          actual.default.Map.prototype._setupContainer.call(this);
+        }
+        _controls: maplibregl.IControl[] = [];
+        getCanvas = actual.default.Map.prototype.getCanvas;
+        addControl = vi.fn(actual.default.Map.prototype.addControl);
+        zoomIn = vi.fn();
+        remove() {
+          for (const control of this._controls) control.onRemove(this as any);
+        }
+        getCenter = () => ({ lng: 2, lat: 3 });
+        getZoom = () => 4;
+        getBearing = () => 5;
+        getPitch = () => 6;
+        getRoll = () => 7;
+        isGlobeProjection = () => 8;
+        hasTerrain = () => 9;
+        getStyle = () => ({ version: 8, sources: {}, layers: [] });
+        setStyle = () => {};
+        getLayersOrder = () => [];
+        _getUIString = (str: string) => str;
+        _containerDimensions = () => [0, 0];
+        _getClampedPixelRatio = () => 1;
+        _resizeCanvas = () => {};
+      },
+    },
+  };
+});
+
+vi.mock("../src/tools", async () => ({
+  ...(await vi.importActual("../src/tools")),
+  displayNoWebGlWarning: vi.fn(),
+}));
+
+vi.mock("../src/Telemetry", async () => ({
+  ...(await vi.importActual("../src/Telemetry")),
+  Telemetry: class {},
+}));
+
+vi.mock("../src/mapstyle", async () => ({
+  ...(await vi.importActual("../src/mapstyle")),
+  styleToStyle: () => ({
+    requiresUrlMonitoring: false,
+    isFallback: false,
+  }),
+}));
+
+vi.mock("../src/controls/MaptilerNavigationControl", () => ({
+  MaptilerNavigationControl: class {
+    onAdd = () => document.createElement("div");
+    onRemove = () => {};
+  },
+}));
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Map as SDKMap } from "../src/Map";
+import { MaptilerExternalControl } from "../src/controls";
+
+describe("MaptilerExternalControl & customControls option", () => {
+  async function createMapHelper() {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const map = new SDKMap({
+      container,
+      customControls: true,
+    });
+    map.fire("load");
+    await map.onReadyAsync();
+    return map;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  describe("autodetected controls", () => {
+    it("should detect control without data attribute value", async () => {
+      // <button data-maptiler-control></button>
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "");
+      document.body.appendChild(control);
+      const addEventListenerSpy = vi.spyOn(control, "addEventListener");
+
+      const map = await createMapHelper();
+
+      expect(map.addControl).toHaveBeenCalledWith(expect.any(MaptilerExternalControl), undefined);
+      expect(control.parentElement).not.toBe(document.body);
+      expect(addEventListenerSpy).not.toHaveBeenCalled();
+    });
+
+    it("should detect control without data attribute value set in React", async () => {
+      // <button data-maptiler-control="true"></button>
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "true");
+      document.body.appendChild(control);
+      const addEventListenerSpy = vi.spyOn(control, "addEventListener");
+
+      const map = await createMapHelper();
+
+      expect(map.addControl).toHaveBeenCalledWith(expect.any(MaptilerExternalControl), undefined);
+      expect(control.parentElement).not.toBe(document.body);
+      expect(addEventListenerSpy).not.toHaveBeenCalled();
+    });
+
+    it("should detect control with a known data attribute value", async () => {
+      // <button data-maptiler-control="zoom-in"></button>
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "zoom-in");
+      document.body.appendChild(control);
+      const addEventListenerSpy = vi.spyOn(control, "addEventListener");
+
+      const map = await createMapHelper();
+
+      expect(map.addControl).toHaveBeenCalledWith(expect.any(MaptilerExternalControl), undefined);
+      expect(control.parentElement).not.toBe(document.body);
+      expect(addEventListenerSpy).toHaveBeenCalledOnce();
+
+      control.click();
+
+      expect(map.zoomIn).toHaveBeenCalledOnce();
+
+      control.click();
+
+      expect(map.zoomIn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should detect control position", async () => {
+      // <button data-maptiler-control data-maptiler-position="top-left"></button>
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "");
+      control.setAttribute("data-maptiler-position", "top-left");
+      document.body.appendChild(control);
+
+      const map = await createMapHelper();
+
+      expect(map.addControl).toHaveBeenCalledWith(expect.any(MaptilerExternalControl), "top-left");
+    });
+
+    it("should move the control element to its original DOM place when map is removed", async () => {
+      // <button data-maptiler-control></button>
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "");
+      document.body.appendChild(control);
+
+      const map = await createMapHelper();
+      map.remove();
+
+      expect(control.parentElement).toBe(document.body);
+    });
+
+    it("should remove functionality from control when map is removed", async () => {
+      // <button data-maptiler-control="zoom-in"></button>
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "zoom-in");
+      document.body.appendChild(control);
+
+      const map = await createMapHelper();
+      control.click();
+
+      expect(map.zoomIn).toHaveBeenCalledOnce();
+
+      map.remove();
+      control.click();
+
+      expect(map.zoomIn).toHaveBeenCalledOnce();
+    });
+  });
+  describe("autodetected control groups", () => {
+    it("should detect control group with several controls", async () => {
+      // <div data-maptiler-control-group>
+      //   <button data-maptiler-control="zoom-in"></button>
+      //   <button data-maptiler-control="true"></button>
+      //   <button data-maptiler-control></button>
+      // </div>
+      const group = document.createElement("div");
+      group.setAttribute("data-maptiler-control-group", "");
+      document.body.appendChild(group);
+
+      const emptyControl = document.createElement("button");
+      emptyControl.setAttribute("data-maptiler-control", "");
+      group.appendChild(emptyControl);
+      const emptyControlAddEventListenerSpy = vi.spyOn(emptyControl, "addEventListener");
+
+      const trueControl = document.createElement("button");
+      trueControl.setAttribute("data-maptiler-control", "true");
+      group.appendChild(trueControl);
+      const trueControlAddEventListenerSpy = vi.spyOn(trueControl, "addEventListener");
+
+      const zoomInControl = document.createElement("button");
+      zoomInControl.setAttribute("data-maptiler-control", "zoom-in");
+      group.appendChild(zoomInControl);
+      const zoomInControlAddEventListenerSpy = vi.spyOn(zoomInControl, "addEventListener");
+
+      const map = await createMapHelper();
+
+      expect(map.addControl).toHaveBeenCalledWith(expect.any(MaptilerExternalControl), undefined);
+      expect(group.parentElement).not.toBe(document.body);
+      expect(emptyControl.parentElement).toBe(group);
+      expect(trueControl.parentElement).toBe(group);
+      expect(zoomInControl.parentElement).toBe(group);
+      expect(emptyControlAddEventListenerSpy).not.toHaveBeenCalled();
+      expect(trueControlAddEventListenerSpy).not.toHaveBeenCalled();
+      expect(zoomInControlAddEventListenerSpy).toHaveBeenCalledOnce();
+
+      zoomInControl.click();
+
+      expect(map.zoomIn).toHaveBeenCalledOnce();
+
+      map.remove();
+
+      expect(group.parentElement).toBe(document.body);
+      expect(emptyControl.parentElement).toBe(group);
+      expect(trueControl.parentElement).toBe(group);
+      expect(zoomInControl.parentElement).toBe(group);
+
+      zoomInControl.click();
+
+      expect(map.zoomIn).toHaveBeenCalledOnce();
+    });
+
+    it("should detect control position", async () => {
+      // <div data-maptiler-control-group data-maptiler-position="bottom-left">
+      //   <button data-maptiler-control="zoom-in"></button>
+      // </div>
+      const group = document.createElement("div");
+      group.setAttribute("data-maptiler-control-group", "");
+      group.setAttribute("data-maptiler-position", "top-left");
+      document.body.appendChild(group);
+
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "");
+      group.appendChild(control);
+
+      const map = await createMapHelper();
+
+      expect(map.addControl).toHaveBeenCalledWith(expect.any(MaptilerExternalControl), "top-left");
+    });
+
+    it("should move the control group element to its original DOM place when map is removed", async () => {
+      // <div data-maptiler-control-group>
+      //   <button data-maptiler-control=""></button>
+      // </div>
+      const group = document.createElement("div");
+      group.setAttribute("data-maptiler-control-group", "");
+      document.body.appendChild(group);
+
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "");
+      group.appendChild(control);
+
+      const map = await createMapHelper();
+      map.remove();
+
+      expect(group.parentElement).toBe(document.body);
+      expect(control.parentElement).toBe(group);
+    });
+
+    it("should remove functionality from control when map is removed", async () => {
+      // <div data-maptiler-control-group>
+      //   <button data-maptiler-control="zoom-in"></button>
+      // </div>
+      const group = document.createElement("div");
+      group.setAttribute("data-maptiler-control-group", "");
+      document.body.appendChild(group);
+
+      const control = document.createElement("button");
+      control.setAttribute("data-maptiler-control", "zoom-in");
+      group.appendChild(control);
+
+      const map = await createMapHelper();
+      control.click();
+
+      expect(map.zoomIn).toHaveBeenCalledOnce();
+
+      map.remove();
+      control.click();
+
+      expect(map.zoomIn).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/vite.config-test.ts
+++ b/vite.config-test.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     typecheck: {
       tsconfig: "./tsconfig.json",
     },
-    // environment: "jsdom",
+    environment: "happy-dom",
     globals: true,
     setupFiles: ["@vitest/web-worker", "./vitest-setup-tests.ts"],
   },


### PR DESCRIPTION
## Objective
Provide a way to add custom controls to map.

## Description
* `MaptilerCustomControl` class has been added that allows any element to become a map control, with shortcuts for click and map render event handlers.
* `customControls` map option that turns on auto-detection of custom control elements processed by `MaptilerExternalControl` class which provides some predefined click handlers too.

## Acceptance
* Unit tests
* Manual tests

## Checklist
- [x] I have added relevant info to the CHANGELOG.md