### PR TITLE
RD-532 fix map.getProjection() failing on default projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ✨ Features and improvements
 
 ### 🐛 Bug fixes
+- fixes a bug where `map.getProjection()` did not return a value when default projection was used
 
 ### ⚙️ Others
 

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -19,6 +19,7 @@ import type {
   ExpressionSpecification,
   SymbolLayerSpecification,
   AttributionControlOptions,
+  ProjectionSpecification,
 } from "maplibre-gl";
 import type { ReferenceMapStyle, MapStyleVariant } from "@maptiler/client";
 import { config, MAPTILER_SESSION_ID, type SdkConfig } from "./config";
@@ -1949,6 +1950,23 @@ export class Map extends maplibregl.Map {
   override setTransformRequest(transformRequest: RequestTransformFunction): this {
     super.setTransformRequest(combineTransformRequest(transformRequest));
     return this;
+  }
+
+  /**
+   * Gets the {@link ProjectionSpecification}.
+   * @returns the projection specification.
+   * @example
+   * ```ts
+   * let projection = map.getProjection();
+   * ```
+   */
+  override getProjection(): ProjectionSpecification {
+    const projection = this.style.getProjection();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!projection === undefined && this.style.projection) {
+      return { type: this.style.projection.name };
+    }
+    return projection;
   }
 
   /**


### PR DESCRIPTION
## Objective
* Fix a bug

## Description
* Projection is not set in stylesheet when default projection is used, patched `getProjection()` method to detect that case and return the correct projection

## Acceptance
* Manual tests

## Checklist
- [x] I have added relevant info to the CHANGELOG.md