### PR TITLE
RD-1083 refactor rtl text plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixes a bug where `map.getProjection()` did not return a value when default projection was used
 
 ### ⚙️ Others
+- Right to left text is now opt-out. `rtlTextPlugin` can be passed in the constructor options to opt-out of installing the rtl text-plugin or install a different RTL text-plugin. Without this option the behaviour will remain the same.
 
 ## 3.8.0
 

--- a/README.md
+++ b/README.md
@@ -930,6 +930,9 @@ Here is a sample of some compatible languages:
 ## Built-in support for right-to-left languages
 Languages that are written right-to-left such as Arabic and Hebrew are fully supported by default. No need to install any plugins!
 
+If you wish to opt of applying the rtl plugin or wish to use a different compatible rtl text plugin, you can pass the `rtlTextPlugin`
+constructor option as either `false` (disable the rtl plugin) or a url.
+
 <p align="center">
   <img src="images/screenshots/lang-arabic.jpeg" width="48%"></img>
   <img src="images/screenshots/lang-hebrew.jpeg" width="48%"></img>

--- a/demos/public/XX-scratch-pad.html
+++ b/demos/public/XX-scratch-pad.html
@@ -3,15 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href='https://cdn.maptiler.com/maptiler-sdk-js/v3.8.0/maptiler-sdk.css' rel='stylesheet' />
+
   <title>Document</title>
   <style>
         body { margin: 0; padding: 0; }
     #map { position: absolute; top: 0; bottom: 0; width: 100%; }
-    button { position: absolute; top: 10px; left: 10px; z-index: 10; }
+    .button { position: absolute; top: 10px; left: 10px; z-index: 10; }
   </style>
 </head>
 <body>
-    <button>Set style & Fly</button>
+    <button class="button">change language</button>
   <div id="map"></div>
   <script type="module" src="/src/XX-scratch-pad.ts"></script>
 </body>

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1,5 +1,7 @@
 import maplibregl from "maplibre-gl";
 import { Base64 } from "js-base64";
+import { enableRTL } from "./tools";
+
 import type {
   StyleSpecification,
   MapOptions as MapOptionsML,
@@ -208,6 +210,12 @@ export type MapOptions = Omit<MapOptionsML, "style" | "maplibreLogo"> & {
    */
   space?: CubemapLayerConstructorOptions | boolean;
   halo?: RadialGradientLayerConstructorOptions | boolean;
+
+  /**
+   * Whether to enable the RTL plugin or import a different one.
+   * Default is undefined, which means the plugin is enabled by default.
+   */
+  rtlTextPlugin?: boolean | string;
 };
 
 /**
@@ -568,6 +576,12 @@ export class Map extends maplibregl.Map {
 
     this.on("style.load", () => {
       this.styleInProcess = false;
+      // If the rtlTextPlugin option is a string, we assume it is a url and enable the plugin
+      // If the rtlTextPlugin option is undefined, it is enabled by default and will override the default url
+      // If the rtlTextPlugin option is false (ot anything else), we don't enable the plugin
+      if (typeof options.rtlTextPlugin === "string" || typeof options.rtlTextPlugin === "undefined") {
+        void enableRTL(options.rtlTextPlugin);
+      }
     });
 
     // Safeguard for distant styles at non-http 2xx status URLs

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { enableRTL } from "./tools";
-
 import maplibregl from "maplibre-gl";
 
 // Types from MapLibre are not re-exported one by one
@@ -9,8 +7,6 @@ export type * from "maplibre-gl";
 // to avoid breaking our module we export it as ColorRampML
 export type { ColorRamp as ColorRampML } from "maplibre-gl";
 
-// Enabling the right-to-left text compatibility plugin early to avoid blinking
-enableRTL();
 
 /**
  * Get the version of MapTiler SDK, this is declared in the vite config

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ export type * from "maplibre-gl";
 // to avoid breaking our module we export it as ColorRampML
 export type { ColorRamp as ColorRampML } from "maplibre-gl";
 
-
 /**
  * Get the version of MapTiler SDK, this is declared in the vite config
  * to avoid importing the entire package.json

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,7 +9,7 @@ import type { Map as MapSDK } from "./Map";
 // TODO These function should gradually be moved to
 // to utils directory
 
-export function enableRTL() {
+export async function enableRTL(customPluginURL?: string) {
   // Prevent this from running server side
   if (typeof window === "undefined") return;
 
@@ -17,9 +17,9 @@ export function enableRTL() {
 
   if (status === "unavailable" || status === "requested") {
     try {
-      maplibregl.setRTLTextPlugin(defaults.rtlPluginURL, true);
+      await maplibregl.setRTLTextPlugin(customPluginURL ?? defaults.rtlPluginURL, true);
     } catch (_e) {
-      // nothing
+      console.error("Error enabling RTL plugin", _e);
     }
   }
 }


### PR DESCRIPTION
## Objective
To allow users to opt out of installing the rtl text plugin _or_ use a different rtl text plugin.

## Description
- adds the `rtlTextPlugin` option to the constructor options.

## Acceptance
- Manually

## Checklist
- [x] I have added relevant info to the CHANGELOG.md