### PR TITLE
RD-1502 RD-1515 RD-1516 Update maplibregl to latest version, move types removed from ML public API, fix ImageViewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # MapTiler SDK Changelog
 
+## NEXT
+
+### ✨ Features and improvements
+- MapLibre GL dependency was updated to `5.14`
+  - Types that were removed in a minor version of MapLibre GL, breaking semver, were moved into MapTiler SDK to not break compatibility for MapTiler SDK users
+  - Overpanning and underzooming patch for `ImageViewer` was updated to use a new standard MapLibre GL approach instead of monkey-patching it
+
 ## 3.9.1
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "3.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@maplibre/maplibre-gl-style-spec": "~23.3.0",
+        "@maplibre/maplibre-gl-style-spec": "~24.3.1",
         "@maptiler/client": "~2.6.0",
         "events": "^3.3.0",
-        "gl-matrix": "^3.4.3",
+        "gl-matrix": "^3.4.4",
         "js-base64": "^3.7.7",
-        "maplibre-gl": "~5.6.0",
+        "maplibre-gl": "~5.14.0",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -856,9 +856,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.3.0.tgz",
-      "integrity": "sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.3.1.tgz",
+      "integrity": "sha512-TUM5JD40H2mgtVXl5IwWz03BuQabw8oZQLJTmPpJA0YTYF+B+oZppy5lNMO6bMvHzB+/5mxqW9VLG3wFdeqtOw==",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
@@ -873,6 +873,15 @@
         "gl-style-format": "dist/gl-style-format.mjs",
         "gl-style-migrate": "dist/gl-style-migrate.mjs",
         "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.2.tgz",
+      "integrity": "sha512-SQKdJ909VGROkA6ovJgtHNs9YXV4YXUPS+VaZ50I2Mt951SLlUm2Cv34x5Xwc1HiFlsd3h2Yrs5cn7xzqBmENw==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
       }
     },
     "node_modules/@maplibre/vt-pbf": {
@@ -3935,9 +3944,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.6.2.tgz",
-      "integrity": "sha512-SEqYThhUCFf6Lm0TckpgpKnto5u4JsdPYdFJb6g12VtuaFsm3nYdBO+fOmnUYddc8dXihgoGnuXvPPooUcRv5w==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.14.0.tgz",
+      "integrity": "sha512-O2ok6N/bQ9NA9nJ22r/PRQQYkUe9JwfDMjBPkQ+8OwsVH4TpA5skIAM2wc0k+rni5lVbAVONVyBvgi1rF2vEPA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -3947,14 +3956,15 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^23.3.0",
-        "@maplibre/vt-pbf": "^4.0.3",
+        "@maplibre/maplibre-gl-style-spec": "^24.3.1",
+        "@maplibre/mlt": "^1.1.2",
+        "@maplibre/vt-pbf": "^4.1.0",
         "@types/geojson": "^7946.0.16",
         "@types/geojson-vt": "3.2.5",
         "@types/supercluster": "^7.1.3",
         "earcut": "^3.0.2",
         "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.3",
+        "gl-matrix": "^3.4.4",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
         "pbf": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -92,12 +92,12 @@
     "vitest": "^3.0.9"
   },
   "dependencies": {
-    "@maplibre/maplibre-gl-style-spec": "~23.3.0",
+    "@maplibre/maplibre-gl-style-spec": "~24.3.1",
     "@maptiler/client": "~2.6.0",
     "events": "^3.3.0",
-    "gl-matrix": "^3.4.3",
+    "gl-matrix": "^3.4.4",
     "js-base64": "^3.7.7",
-    "maplibre-gl": "~5.6.0",
+    "maplibre-gl": "~5.14.0",
     "uuid": "^11.0.5"
   }
 }

--- a/src/ImageViewer/ImageViewer.ts
+++ b/src/ImageViewer/ImageViewer.ts
@@ -21,7 +21,7 @@ import { Map } from "../Map";
 import { ImageViewerEvent, setupGlobalMapEventForwarder } from "./events";
 import { FetchError } from "../utils/errors";
 import { config } from "..";
-import { monkeyPatchMapTransformInstance } from "./monkeyPatchML";
+import { overpanningUnderzoomingTransformConstrain } from "./monkeyPatchML";
 import { NavigationControl } from "../MLAdapters/NavigationControl";
 import { ImageViewerFitImageToBoundsControl } from "../controls/ImageViewerFitImageToBoundsControl";
 import { lngLatToPxInternalSymbolKey, pxToLngLatInternalSymbolKey } from "./symbols";
@@ -110,6 +110,7 @@ const overrideOptions: Partial<MapOptions> = {
   terrain: false,
   space: false,
   halo: false,
+  transformConstrain: overpanningUnderzoomingTransformConstrain,
 };
 
 //#region imageViewerDefaultOptions
@@ -323,9 +324,6 @@ export default class ImageViewer extends Evented {
         viewer: this,
         lngLatToPx: (lngLat: LngLat) => this.lngLatToPx(lngLat),
       });
-
-      // this is a monkey patch to allow for overpanning and underzooming
-      monkeyPatchMapTransformInstance(this.sdk);
 
       const { center, zoom, bearing } = this.options;
       const initCenter = center ?? [(this.imageMetadata?.width ?? 0) / 2, (this.imageMetadata?.height ?? 0) / 2];

--- a/src/ImageViewer/monkeyPatchML.ts
+++ b/src/ImageViewer/monkeyPatchML.ts
@@ -1,4 +1,4 @@
-import { LngLat, Marker, Point, PositionAnchor } from "../index";
+import { LngLat, Marker, Point, PositionAnchor, TransformConstrainFunction } from "../index";
 import { Map } from "../Map";
 import { MercatorCoordinate } from "..";
 
@@ -49,105 +49,103 @@ function projectToWorldCoordinates(worldSize: number, lnglat: LngLat): Point {
   return new Point(mercatorXfromLng(lnglat.lng) * worldSize, mercatorYfromLat(lat) * worldSize);
 }
 
-export function monkeyPatchMapTransformInstance(instance: Map) {
-  instance.transform.getConstrained = function (lngLat: LngLat, zoom: number): { center: LngLat; zoom: number } {
-    zoom = clamp(zoom, this.minZoom, this.maxZoom);
-    const result = {
-      center: new LngLat(lngLat.lng, lngLat.lat),
-      zoom,
-    };
-
-    // @ts-expect-error we're monkey patching the maplibre-gl transform
-    let lngRange = this._helper._lngRange;
-
-    if (lngRange === null) {
-      const almost180 = 180 - 1e-10;
-      lngRange = [-almost180, almost180];
-    }
-
-    const worldSize = this.tileSize * zoomScale(result.zoom); // A world size for the requested zoom level, not the current world size
-    let minY = 0;
-    let maxY = worldSize;
-    let minX = 0;
-    let maxX = worldSize;
-    let scaleY = 0;
-    let scaleX = 0;
-    const { x: screenWidth, y: screenHeight } = this.size;
-
-    const underzoom = 0.5;
-
-    // @ts-expect-error we're monkey patching the maplibre-gl transform
-    if (this._helper._latRange) {
-      // @ts-expect-error we're monkey patching the maplibre-gl transform
-      const latRange = this._helper._latRange;
-      minY = mercatorYfromLat(latRange[1]) * worldSize;
-      maxY = mercatorYfromLat(latRange[0]) * worldSize;
-      const shouldZoomIn = maxY - minY < underzoom * screenHeight;
-      if (shouldZoomIn) scaleY = (underzoom * screenHeight) / (maxY - minY);
-    }
-
-    if (lngRange) {
-      minX = wrap(mercatorXfromLng(lngRange[0]) * worldSize, 0, worldSize);
-      maxX = wrap(mercatorXfromLng(lngRange[1]) * worldSize, 0, worldSize);
-
-      if (maxX < minX) maxX += worldSize;
-
-      const shouldZoomIn = maxX - minX < underzoom * screenWidth;
-      if (shouldZoomIn) scaleX = (underzoom * screenWidth) / (maxX - minX);
-    }
-
-    const { x: originalX, y: originalY } = projectToWorldCoordinates(worldSize, lngLat);
-    let modifiedX, modifiedY;
-
-    const scale = Math.min(scaleX || 0, scaleY || 0);
-
-    if (scale) {
-      // zoom in to exclude all beyond the given lng/lat ranges
-      result.zoom += scaleZoom(scale);
-      return result;
-    }
-
-    // Panning up and down in latitude is externally limited by project() with MAX_VALID_LATITUDE.
-    // This limit prevents panning the top and bottom bounds farther than the center of the viewport.
-    // Due to the complexity and consequence of altering project() or MAX_VALID_LATITUDE, we'll simply limit
-    // the overpan.
-    let lngOverpan = 0.0;
-    let latOverpan = 0.0;
-
-    const overpan = 1.0;
-    const latUnderzoomMinimumPan = 1.0 - (maxY - minY) / screenHeight;
-    const lngUnderzoomMinimumPan = 1.0 - (maxX - minX) / screenWidth;
-    lngOverpan = Math.max(lngUnderzoomMinimumPan, overpan);
-    latOverpan = Math.max(latUnderzoomMinimumPan, overpan);
-
-    const lngPanScale = 1.0 - lngOverpan;
-    const latPanScale = 1.0 - latOverpan;
-
-    // @ts-expect-error we're monkey patching the maplibre-gl transform
-    if (this._helper._latRange) {
-      const h2 = (latPanScale * screenHeight) / 2;
-      if (originalY - h2 < minY) modifiedY = minY + h2;
-      if (originalY + h2 > maxY) modifiedY = maxY - h2;
-    }
-
-    if (lngRange) {
-      const wrappedX = originalX;
-
-      const w2 = (lngPanScale * screenWidth) / 2;
-
-      if (wrappedX - w2 < minX) modifiedX = minX + w2;
-      if (wrappedX + w2 > maxX) modifiedX = maxX - w2;
-    }
-
-    // pan the map if the screen goes off the range
-    if (modifiedX !== undefined || modifiedY !== undefined) {
-      const newPoint = new Point(modifiedX ?? originalX, modifiedY ?? originalY);
-      result.center = unprojectFromWorldCoordinates(worldSize, newPoint).wrap();
-    }
-
-    return result;
+export const overpanningUnderzoomingTransformConstrain: TransformConstrainFunction = function (
+  this: Map["transform"],
+  lngLat: LngLat,
+  zoom: number,
+): { center: LngLat; zoom: number } {
+  zoom = clamp(zoom, this.minZoom, this.maxZoom);
+  const result = {
+    center: new LngLat(lngLat.lng, lngLat.lat),
+    zoom,
   };
-}
+
+  let lngRange = this.lngRange as [number, number] | null;
+  const latRange = this.latRange as [number, number] | null;
+
+  if (lngRange === null) {
+    const almost180 = 180 - 1e-10;
+    lngRange = [-almost180, almost180];
+  }
+
+  const worldSize = this.tileSize * zoomScale(result.zoom); // A world size for the requested zoom level, not the current world size
+  let minY = 0;
+  let maxY = worldSize;
+  let minX = 0;
+  let maxX = worldSize;
+  let scaleY = 0;
+  let scaleX = 0;
+  const { x: screenWidth, y: screenHeight } = this.size;
+
+  const underzoom = 0.5;
+
+  if (latRange) {
+    minY = mercatorYfromLat(latRange[1]) * worldSize;
+    maxY = mercatorYfromLat(latRange[0]) * worldSize;
+    const shouldZoomIn = maxY - minY < underzoom * screenHeight;
+    if (shouldZoomIn) scaleY = (underzoom * screenHeight) / (maxY - minY);
+  }
+
+  if (lngRange) {
+    minX = wrap(mercatorXfromLng(lngRange[0]) * worldSize, 0, worldSize);
+    maxX = wrap(mercatorXfromLng(lngRange[1]) * worldSize, 0, worldSize);
+
+    if (maxX < minX) maxX += worldSize;
+
+    const shouldZoomIn = maxX - minX < underzoom * screenWidth;
+    if (shouldZoomIn) scaleX = (underzoom * screenWidth) / (maxX - minX);
+  }
+
+  const { x: originalX, y: originalY } = projectToWorldCoordinates(worldSize, lngLat);
+  let modifiedX, modifiedY;
+
+  const scale = Math.min(scaleX || 0, scaleY || 0);
+
+  if (scale) {
+    // zoom in to exclude all beyond the given lng/lat ranges
+    result.zoom += scaleZoom(scale);
+    return result;
+  }
+
+  // Panning up and down in latitude is externally limited by project() with MAX_VALID_LATITUDE.
+  // This limit prevents panning the top and bottom bounds farther than the center of the viewport.
+  // Due to the complexity and consequence of altering project() or MAX_VALID_LATITUDE, we'll simply limit
+  // the overpan.
+  let lngOverpan = 0.0;
+  let latOverpan = 0.0;
+
+  const overpan = 1.0;
+  const latUnderzoomMinimumPan = 1.0 - (maxY - minY) / screenHeight;
+  const lngUnderzoomMinimumPan = 1.0 - (maxX - minX) / screenWidth;
+  lngOverpan = Math.max(lngUnderzoomMinimumPan, overpan);
+  latOverpan = Math.max(latUnderzoomMinimumPan, overpan);
+
+  const lngPanScale = 1.0 - lngOverpan;
+  const latPanScale = 1.0 - latOverpan;
+
+  if (latRange) {
+    const h2 = (latPanScale * screenHeight) / 2;
+    if (originalY - h2 < minY) modifiedY = minY + h2;
+    if (originalY + h2 > maxY) modifiedY = maxY - h2;
+  }
+
+  if (lngRange) {
+    const wrappedX = originalX;
+
+    const w2 = (lngPanScale * screenWidth) / 2;
+
+    if (wrappedX - w2 < minX) modifiedX = minX + w2;
+    if (wrappedX + w2 > maxX) modifiedX = maxX - w2;
+  }
+
+  // pan the map if the screen goes off the range
+  if (modifiedX !== undefined || modifiedY !== undefined) {
+    const newPoint = new Point(modifiedX ?? originalX, modifiedY ?? originalY);
+    result.center = unprojectFromWorldCoordinates(worldSize, newPoint).wrap();
+  }
+
+  return result;
+};
 
 export const anchorTranslate: Record<PositionAnchor, string> = {
   center: "translate(-50%,-50%)",

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -757,7 +757,7 @@ export class Map extends maplibregl.Map {
       let tileJsonContent = { logo: null };
 
       try {
-        const possibleSources = Object.keys(this.style.sourceCaches)
+        const possibleSources = Object.keys(this.style.tileManagers)
           .map((sourceName) => this.getSource(sourceName))
           .filter((s: Source | undefined) => s && "url" in s && typeof s.url === "string" && s.url.includes("tiles.json"));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,9 @@ export { MapWheelEvent } from "./MLAdapters/MapWheelEvent";
 export { MapTouchEvent } from "./MLAdapters/MapTouchEvent";
 export { MapMouseEvent } from "./MLAdapters/MapMouseEvent";
 
+// types changed to internal since MapLibre 5.7.0
+export * from "./ml-types";
+
 // SDK specific
 export { Map, GeolocationType, type MapOptions, type LoadWithTerrainEvent } from "./Map";
 export * from "./controls";

--- a/src/ml-types.ts
+++ b/src/ml-types.ts
@@ -1,0 +1,950 @@
+/* eslint-disable
+  @typescript-eslint/consistent-indexed-object-style,
+  @typescript-eslint/no-deprecated,
+  @typescript-eslint/no-empty-object-type,
+  @typescript-eslint/no-explicit-any,
+  @typescript-eslint/no-invalid-void-type,
+  @typescript-eslint/no-namespace,
+  @typescript-eslint/no-unsafe-function-type,
+*/
+import maplibregl from "maplibre-gl";
+
+import type {
+  CompositeExpression,
+  Event,
+  ErrorEvent as ErrorEvent$1,
+  GlyphPosition,
+  ICanonicalTileID,
+  Map as Map$1,
+  Point,
+  PropertyValueSpecification,
+  SourceExpression,
+  StylePropertyExpression,
+  StylePropertySpecification,
+  Tile,
+  Complete,
+  MapOptions,
+  CollisionBoxArray,
+  QueryRenderedFeaturesOptions,
+  AlphaImage,
+  FeatureIndex,
+  MessageType,
+  RequestResponseMessageMap,
+  Handler,
+  Bucket,
+  Style,
+  StyleImageData,
+  StyleLayer,
+  RasterDEMTileSource,
+  GeoJSONSource,
+  Actor,
+  WebGLContextAttributesWithType,
+} from "maplibre-gl";
+
+// types removed from public API in MapLibre 5.8.0, compatible with 5.14.0
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type Config = typeof maplibregl.config;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SerializedObject<S extends Serialized = any> = {
+  [_: string]: S;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type Serialized = Exclude<MessageData["data"], undefined>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ViewType = StructArrayMember["type"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type StructArrayMember = StructArray["members"][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SerializedStructArray = {
+  length: number;
+  arrayBuffer: ArrayBuffer;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SymbolInstance = SymbolInstanceStruct;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TextAnchorOffset = TextAnchorOffsetStruct;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ErrorLike = ErrorEvent$1["error"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CrossfadeParameters = NonNullable<Parameters<ProgramConfiguration["updatePaintBuffers"]>[0]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TimePoint = TransitionParameters["now"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CrossFaded<T> = {
+  to: T;
+  from: T;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface Property<T, R> {
+  specification: StylePropertySpecification;
+  possiblyEvaluate(value: PropertyValue<T, R>, parameters: EvaluationParameters, canonical?: CanonicalTileID, availableImages?: Array<string>): R;
+  interpolate(a: R, b: R, t: number): R;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TransitionParameters = Parameters<StyleLayer["updateTransitions"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PossiblyEvaluatedValue<T> =
+  | {
+      kind: "constant";
+      value: T;
+    }
+  | SourceExpression
+  | CompositeExpression;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type Size = Parameters<AlphaImage["resize"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SpriteOnDemandStyleImage = NonNullable<StyleImageData["spriteData"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PreparedShader = Projection["shaderPreludeCode"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SerializedFeaturePositionMap = {
+  ids: Float64Array;
+  positions: Uint32Array;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FeaturePosition = {
+  index: number;
+  start: number;
+  end: number;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type $ObjMap<T extends {}, F extends (v: any) => any> = {
+  [K in keyof T]: F extends (v: T[K]) => infer R ? R : never;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type UniformValues<Us extends {}> = $ObjMap<Us, <V>(u: Uniform<V>) => V>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type UniformLocations = Parameters<ProgramConfiguration["getUniforms"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type UniformBindings = {
+  [_: string]: Uniform<any>;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type Segment = SegmentVector["segments"][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type HeatmapPaintProps = __ExtractProps<HeatmapStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type HeatmapPaintPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<HeatmapStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type BlendFuncConstant = BlendFuncType[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type BlendFuncType = ColorMode$1["blendFunction"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type BlendEquationType = ReturnType<BlendEquation["getDefault"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ColorMaskType = ColorMode$1["mask"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CompareFuncType = DepthFuncType;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type DepthMaskType = DepthMode$1["mask"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type DepthRangeType = DepthMode$1["range"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type DepthFuncType = DepthMode$1["func"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type StencilFuncType = ReturnType<StencilFunc["getDefault"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type StencilOpConstant = StencilOpType[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type StencilOpType = ReturnType<StencilOp["getDefault"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TextureUnitType = ReturnType<ActiveTextureUnit["getDefault"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ViewportType = ReturnType<Viewport["getDefault"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type StencilTestGL = StencilMode["test"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CullFaceModeType = CullFaceMode$1["mode"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FrontFaceType = CullFaceMode$1["frontFace"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface IValue<T> {
+  current: T;
+  default: T;
+  dirty: boolean;
+  get(): T;
+  setDefault(): void;
+  set(value: T): void;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SerializedGrid = {
+  buffer: ArrayBuffer;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type IntersectionResult = ReturnType<Aabb["intersectsFrustum"]>;
+export namespace IntersectionResult {
+  export type None = 0;
+  export type Partial = 1;
+  export type Full = 2;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type IBoundingVolume = Pick<Frustum["aabb"], "intersectsFrustum" | "intersectsPlane">;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TileResult = ReturnType<TileManager["tilesIn"]>[number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GlyphMetrics = GlyphPosition["metrics"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type Rect = GlyphPosition["rect"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SymbolLayoutProps = __ExtractProps<SymbolStyleLayer["layout"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SymbolLayoutPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<SymbolStyleLayer["layout"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SymbolPaintProps = __ExtractProps<SymbolStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SymbolPaintPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<SymbolStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SymbolQuad = Parameters<SymbolBucket["addSymbols"]>[1][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SizeData = SymbolBucket["textSizeData"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SingleCollisionBox = NonNullable<CollisionArrays["textBox"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CollisionArrays = SymbolBucket["collisionArrays"][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SymbolFeature = SymbolBucket["features"][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SortKeyRange = SymbolBucket["sortKeyRanges"][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type Entry = GlyphManager["entries"][string];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PoolObject = ReturnType<RenderPool["getObjectForId"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type RenderPass = "offscreen" | "opaque" | "translucent";
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PainterOptions = Painter["options"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type RenderOptions = Parameters<RenderToTexture["renderLayer"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TerrainData = ReturnType<Terrain["getTerrainData"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PointProjection = ReturnType<IReadonlyTransform["projectTileCoordinates"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type IndexToPointCache = {
+  [lineIndex: number]: Point;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ProjectionCache = SymbolProjectionContext["projectionCache"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SymbolProjectionContext = Parameters<CollisionIndex["projectPathToScreenSpace"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ProjectionDataParams = Parameters<IReadonlyTransform["getProjectionData"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CoveringTilesDetailsProvider = ReturnType<IReadonlyTransform["getCoveringTilesDetailsProvider"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ITransformGetters = Pick<
+  IReadonlyTransform,
+  keyof IReadonlyTransform &
+    (
+      | "tileSize"
+      | "tileZoom"
+      | "scale"
+      | "worldSize"
+      | "width"
+      | "height"
+      | "lngRange"
+      | "latRange"
+      | "minZoom"
+      | "maxZoom"
+      | "zoom"
+      | "center"
+      | "minPitch"
+      | "maxPitch"
+      | "roll"
+      | "rollInRadians"
+      | "pitch"
+      | "pitchInRadians"
+      | "bearing"
+      | "bearingInRadians"
+      | "fov"
+      | "fovInRadians"
+      | "elevation"
+      | "minElevationForCurrentTile"
+      | "padding"
+      | "unmodified"
+      | "renderWorldCopies"
+      | "cameraToCenterDistance"
+      | "nearZ"
+      | "farZ"
+      | "autoCalculateNearFarZ"
+    )
+>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ITransformMutators = Pick<
+  ITransform,
+  keyof ITransform &
+    (
+      | "clone"
+      | "apply"
+      | "setMinZoom"
+      | "setMaxZoom"
+      | "setMinPitch"
+      | "setMaxPitch"
+      | "setRenderWorldCopies"
+      | "setBearing"
+      | "setPitch"
+      | "setRoll"
+      | "setFov"
+      | "setZoom"
+      | "setCenter"
+      | "setElevation"
+      | "setMinElevationForCurrentTile"
+      | "setPadding"
+      | "overrideNearFarZ"
+      | "clearNearFarZOverride"
+      | "resize"
+      | "interpolatePadding"
+      | "recalculateZoomAndCenter"
+      | "setLocationAtPoint"
+      | "setMaxBounds"
+      | "populateCache"
+      | "setTransitionState"
+    )
+>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type IReadonlyTransform = Painter["transform"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ITransform = TileManager["transform"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type QueryParameters = Parameters<FeatureIndex["query"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type QueryResults = ReturnType<FeatureIndex["query"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type QueryResultsItem = QueryResults[string][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type DEMEncoding = RasterDEMTileSource["encoding"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CircleGranularity = NonNullable<Parameters<CircleBucket["addFeature"]>[4]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TileParameters = RequestResponseMessageMap[MessageType.removeTile][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type WorkerTileParameters = RequestResponseMessageMap[MessageType.loadTile][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type WorkerDEMTileParameters = RequestResponseMessageMap[MessageType.loadDEMTile][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type OverlapMode = Parameters<CollisionIndex["placeCollisionCircles"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type QueryResult<T> = {
+  key: T;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GridKey = {
+  overlapMode?: OverlapMode;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PlacedCircles = Parameters<Placement["storeCollisionData"]>[5];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PlacedBox = Parameters<Placement["storeCollisionData"]>[4];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FeatureKey = CollisionIndex["grid"]["boxKeys"][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TextAnchor = Parameters<Placement["markUsedJustification"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CollisionGroup = TileLayerParameters["collisionGroup"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type VariableOffset = Placement["variableOffsets"][string];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TileLayerParameters = BucketPart["parameters"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type BucketPart = Parameters<Placement["placeLayerBucketPart"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CrossTileID = string | number;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type QueryRenderedFeaturesOptionsStrict = Omit<QueryRenderedFeaturesOptions, "layers"> & {
+  layers: Set<string> | null;
+  globalState?: Record<string, any>;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TileState = Tile["state"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FeatureStates = LayerFeatureStates[string];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LayerFeatureStates = Parameters<Tile["setFeatureState"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CircleLayoutProps = __ExtractProps<CircleStyleLayer["layout"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CircleLayoutPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<CircleStyleLayer["layout"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CirclePaintProps = __ExtractProps<CircleStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CirclePaintPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<CircleStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FillLayoutProps = __ExtractProps<FillStyleLayer["layout"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FillLayoutPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<FillStyleLayer["layout"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FillPaintProps = __ExtractProps<FillStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FillPaintPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<FillStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FillExtrusionPaintProps = __ExtractProps<FillExtrusionStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FillExtrusionPaintPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<FillExtrusionStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type HillshadePaintProps = __ExtractProps<HillshadeStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type HillshadePaintPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<HillshadeStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ColorReliefPaintProps = __ExtractProps<ColorReliefStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ColorReliefPaintPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<ColorReliefStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ColorRampTextures = ColorReliefStyleLayer["colorRampTextures"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LineClips = NonNullable<LineBucket["lineClips"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GradientTexture = LineBucket["gradients"][string];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LineLayoutProps = __ExtractProps<LineStyleLayer["layout"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LineLayoutPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<LineStyleLayer["layout"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LinePaintProps = __ExtractProps<LineStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LinePaintPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<LineStyleLayer["paint"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TypedStyleLayer = Parameters<ProgramConfiguration["updatePaintArrays"]>[3];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type BinderUniform = ReturnType<ProgramConfiguration["getUniforms"]>[number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type AttributeBinder = Extract<ProgramConfiguration["binders"][string], { populatePaintArray: Function }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type UniformBinder = Extract<ProgramConfiguration["binders"][string], { setUniform: Function }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SkyProps = __ExtractProps<Sky["properties"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type SkyPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<Sky["properties"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TerrainPreludeUniformsType = Program$1["terrainUniforms"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ProjectionPreludeUniformsType = Program$1["projectionUniforms"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type DrawMode = Parameters<Program$1["draw"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ClearArgs = Parameters<Context["clear"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TextureFormat = Texture["format"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TextureFilter = Texture["filter"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TextureWrap = Texture["wrap"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type EmptyImage = Extract<TextureImage, { data: null }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type DataTextureImage = RGBAImage | AlphaImage | EmptyImage;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TextureImage = Parameters<Texture["update"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type Pattern = ImageManager["patterns"][string];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LightPosition = LightPropsPossiblyEvaluated["position"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LightProps = __ExtractProps<Light["properties"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LightPropsPossiblyEvaluated = __ExtractPropsPossiblyEvaluated<Light["properties"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ProjectionGPUContext = Parameters<Projection["updateGPUdependent"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type TileMeshUsage = Parameters<Projection["getMeshFromTileID"]>[4];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type Projection = NonNullable<Style["projection"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type BucketParameters<Layer extends TypedStyleLayer> = {
+  index: number;
+  layers: Array<Layer>;
+  zoom: number;
+  pixelRatio: number;
+  overscaling: number;
+  collisionBoxArray: CollisionBoxArray;
+  sourceLayerIndex: number;
+  sourceID: string;
+  globalState: Record<string, any>;
+};
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PopulateParameters = Parameters<Bucket["populate"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type IndexedFeature = Parameters<Bucket["populate"]>[0][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type BucketFeature = FillBucket["patternFeatures"][number];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type QueryIntersectsFeatureParams = Parameters<NonNullable<StyleLayer["queryIntersectsFeature"]>>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GeoJSONWorkerOptions = GeoJSONSource["workerOptions"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type LoadGeoJSONParameters = RequestResponseMessageMap[MessageType.loadData][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type RTLPluginStatus = PluginState["pluginStatus"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type PluginState = RequestResponseMessageMap[MessageType.syncRTLPluginState][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ClusterIDAndSource = RequestResponseMessageMap[MessageType.getClusterChildren][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GetClusterLeavesParams = RequestResponseMessageMap[MessageType.getClusterLeaves][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GeoJSONWorkerSourceLoadDataResult = RequestResponseMessageMap[MessageType.loadData][1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type RemoveSourceParams = RequestResponseMessageMap[MessageType.removeSource][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type UpdateLayersParameters = RequestResponseMessageMap[MessageType.updateLayers][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GetImagesParameters = RequestResponseMessageMap[MessageType.getImages][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GetGlyphsParameters = RequestResponseMessageMap[MessageType.getGlyphs][0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GetGlyphsResponse = RequestResponseMessageMap[MessageType.getGlyphs][1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GetImagesResponse = RequestResponseMessageMap[MessageType.getImages][1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ActorTarget = Actor["target"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type MessageData = Actor["tasks"][string];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ResolveReject = Actor["resolveRejects"][string];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type MessageHandler<T extends MessageType> = (
+  mapId: string | number,
+  params: RequestResponseMessageMap[T][0],
+  abortController?: AbortController,
+) => Promise<RequestResponseMessageMap[T][1]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface DragMovementResult {
+  bearingDelta?: number;
+  pitchDelta?: number;
+  rollDelta?: number;
+  around?: Point;
+  panDelta?: Point;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface DragPanResult extends DragMovementResult {
+  around: Point;
+  panDelta: Point;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface DragRotateResult extends DragMovementResult {
+  bearingDelta: number;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface DragPitchResult extends DragMovementResult {
+  pitchDelta: number;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface DragRollResult extends DragMovementResult {
+  rollDelta: number;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface DragMoveHandler<T extends DragMovementResult, E extends Event> extends Handler {
+  dragStart: (e: E, point: Point) => void;
+  dragMove: (e: E, point: Point) => T | void;
+  dragEnd: (e: E) => void;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface MousePanHandler extends DragMoveHandler<DragPanResult, MouseEvent> {}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface MouseRotateHandler extends DragMoveHandler<DragRotateResult, MouseEvent> {}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface MousePitchHandler extends DragMoveHandler<DragPitchResult, MouseEvent> {}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export interface MouseRollHandler extends DragMoveHandler<DragRollResult, MouseEvent> {}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type MapControlsDeltas = Parameters<ICameraHelper["handleMapControlsPan"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CameraForBoxAndBearingHandlerResult = ReturnType<ICameraHelper["cameraForBoxAndBearing"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type EaseToHandlerOptions = Parameters<ICameraHelper["handleEaseTo"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type EaseToHandlerResult = ReturnType<ICameraHelper["handleEaseTo"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FlyToHandlerOptions = Parameters<ICameraHelper["handleFlyTo"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type FlyToHandlerResult = ReturnType<ICameraHelper["handleFlyTo"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type ICameraHelper = Map$1["cameraHelper"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type EventInProgress = NonNullable<EventsInProgress["zoom"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type EventsInProgress = Parameters<HandlerManager["mergeHandlerResult"]>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type DragRotateHandlerOptions = ConstructorParameters<typeof maplibregl.DragRotateHandler>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type WebGLSupportedVersions = WebGLContextAttributesWithType["contextType"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type CompleteMapOptions = Complete<MapOptions>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type GeoJSONSourceOptions = ConstructorParameters<typeof maplibregl.GeoJSONSource>[1];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+export type VectorTileSourceOptions = ConstructorParameters<typeof maplibregl.VectorTileSource>[1];
+
+// helper types for extracting Prop types
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type __ExtractProps<T> = T extends { _properties: { properties: infer P } } ? P : never;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type __ExtractPropsPossiblyEvaluated<T> = T extends { _values: infer P } ? P : never;
+
+// other MapLibre types needed for the exports above
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Terrain = Map$1["terrain"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Painter = Terrain["painter"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type TerrainTileManager = Terrain["tileManager"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type TileManager = TerrainTileManager["tileManager"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Frustum = ReturnType<IReadonlyTransform["getCameraFrustum"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Aabb = Frustum["aabb"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Framebuffer = ReturnType<Terrain["getFramebuffer"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Texture = ReturnType<Terrain["getCoordsTexture"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Placement = Style["placement"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type GlyphManager = Painter["glyphManager"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type RenderToTexture = Painter["renderToTexture"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type RenderPool = RenderToTexture["pool"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type CollisionIndex = Placement["collisionIndex"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type RGBAImage = StyleImageData["data"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Context = Framebuffer["context"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Program$1 = ReturnType<Painter["useProgram"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type ImageManager = Style["imageManager"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type HandlerManager = Map$1["handlers"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type CircleStyleLayer = Extract<TypedStyleLayer, { paint: { get(name: "circle-color"): any } }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type FillStyleLayer = Extract<TypedStyleLayer, { paint: { get(name: "fill-color"): any } }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type FillExtrusionStyleLayer = Extract<TypedStyleLayer, { paint: { get(name: "fill-extrusion-color"): any } }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type HeatmapStyleLayer = Extract<TypedStyleLayer, { paint: { get(name: "heatmap-color"): any } }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type HillshadeStyleLayer = Extract<TypedStyleLayer, { paint: { get(name: "hillshade-shadow-color"): any } }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type ColorReliefStyleLayer = Extract<TypedStyleLayer, { paint: { get(name: "color-relief-color"): any } }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type LineStyleLayer = Extract<TypedStyleLayer, { paint: { get(name: "line-color"): any } }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type SymbolStyleLayer = Extract<TypedStyleLayer, { paint: { get(name: "icon-color"): any } }>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type CircleBucket = ReturnType<CircleStyleLayer["createBucket"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type FillBucket = ReturnType<FillStyleLayer["createBucket"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type LineBucket = ReturnType<LineStyleLayer["createBucket"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type SymbolBucket = ReturnType<SymbolStyleLayer["createBucket"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Light = Style["light"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Sky = Style["sky"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type CullFaceMode$1 = Parameters<Context["setCullFace"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type DepthMode$1 = Parameters<Context["setDepthMode"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type ColorMode$1 = Parameters<Context["setColorMode"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type StencilMode = Painter["stencilClearMode"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type Viewport = Context["viewport"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type ActiveTextureUnit = Context["activeTexture"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type BlendEquation = Context["blendEquation"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type StencilFunc = Context["stencilFunc"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type StencilOp = Context["stencilOp"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type SymbolInstanceArray = SymbolBucket["symbolInstances"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type TextAnchorOffsetArray = SymbolBucket["textAnchorOffsets"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type SymbolInstanceStruct = ReturnType<SymbolInstanceArray["get"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type TextAnchorOffsetStruct = ReturnType<TextAnchorOffsetArray["get"]>;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type EvaluationParameters = Parameters<Style["update"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type CanonicalTileID = ICanonicalTileID;
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type VertexBuffer = Map$1["painter"]["viewportBuffer"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type SegmentVector = Map$1["painter"]["viewportSegments"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type ProgramConfiguration = Map$1["painter"]["emptyProgramConfiguration"];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+type StructArray = Parameters<VertexBuffer["updateData"]>[0];
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+interface PropertyValue<T, R> {
+  property: Property<T, R>;
+  value: PropertyValueSpecification<T> | void;
+  expression: StylePropertyExpression;
+  isDataDriven(): boolean;
+  getGlobalStateRefs(): Set<string>;
+  possiblyEvaluate(parameters: EvaluationParameters, canonical?: CanonicalTileID, availableImages?: Array<string>): R;
+}
+
+/** @deprecated Will be removed from public API in MapTiler SDK v4 */
+interface Uniform<T> {
+  gl: WebGLRenderingContext | WebGL2RenderingContext;
+  location: WebGLUniformLocation;
+  current: T;
+  set(v: T): void;
+}


### PR DESCRIPTION
## Objective
Update MapLibre GL to latest version (5.14) and solve all problems related to breaking changes introduced by this update.

## Description
- MapLibre GL is now in version 5.14
- Types that were removed in a minor version of ML, breaking semver, were moved into MapTiler SDK to not break compatibility for our users
- Overpanning and underzooming patch for `ImageViewer` was updated to use a new standard ML approach instead of monkey-patching ML

## Acceptance
Manual testing, typescript types compatibility checks

## Checklist
- [x] I have added relevant info to the CHANGELOG.md