### PR TITLE
#334 Cleanup polluted NPM package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,11 +108,11 @@ e2e/test-results
 .DS_Store
 
 .vscode
+.idea
 demos/tmp_*
 dist
 docs
 docsmd
 build
-e2e/playwright-report
 playwright-report
 test-results

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,13 @@
 docs
 docsmd
+typedoc.*
 images
 demos
 scripts
 test
+test-results
+e2e
+playwright.config.*
 demos
 CHANGELOG.md
 colorramp.md
@@ -11,7 +15,11 @@ src
 !dist/src
 *.tgz
 .github
+.editorconfig
+.husky
+.idea
 .vscode
 build
 vite.config-*
-vite-setup-tests.ts
+vitest-setup-tests.ts
+eslint.config.*


### PR DESCRIPTION
## Objective
Reduce amount of unneeded files uploaded to NPM, see #334 

## Description
Added mentioned files and folder to `.npmignore` to avoid publishing

## Acceptance
On local, load this branch, then:
1. `npm run build`
2. `npm pack` to generate a tgz
3. In another project run `npm install /path/to/file/maptiler-sdk-3.11.1.tgz`
4. Validate that files are now excluded

<img width="1768" height="445" alt="image" src="https://github.com/user-attachments/assets/e662fb96-7de5-47fa-a3d8-9b9e19e7c206" />


## Checklist
- [ ] I have added relevant info to the CHANGELOG.md