### PR TITLE
RD-1903 fix language rendering in streets v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### 🐛 Bug Fixes
 - Passes `options.canvasContextAttributes` to WebGL support check to ensure the check creates context with the same options that the real rendering context uses.
+- Fixes [RD-1903](https://maptiler.atlassian.net/browse/RD-1903), highway shield labels (and some other text) showing road names or no text instead of route numbers when language is explicitly set to "auto".
 
 ### ⚙️ Others
 - None

--- a/demos/public/01-simple.html
+++ b/demos/public/01-simple.html
@@ -30,6 +30,7 @@
   <div id="map"></div>
   <div id="style-picker-container">
     <select name="mapstyles" id="mapstyles-picker"></select>
+    <select name="languages" id="languages-picker"></select>
   </div>
   <script type="module" src="/src/01-simple.ts"></script>
 

--- a/demos/src/01-simple.ts
+++ b/demos/src/01-simple.ts
@@ -1,4 +1,4 @@
-import { Map, MapStyle, StyleSpecificationWithMetaData, config } from "../../src/index";
+import { Language, Map, MapStyle, StyleSpecification, config } from "../../src/index";
 import { addPerformanceStats, setupMapTilerApiKey } from "./demo-utils";
 
 addPerformanceStats();
@@ -9,28 +9,34 @@ const container = document.getElementById("map")!;
 async function main() {
   const map = new Map({
     container,
-    style: MapStyle.OUTDOOR.DARK,
+    style: MapStyle.STREETS.DEFAULT,
     hash: true,
-    geolocate: false,
+    geolocate: true,
+    language: Language.AUTO,
     scaleControl: true,
     fullscreenControl: true,
     terrainControl: true,
     projectionControl: true,
     projection: "globe",
-    // space: true,
-    // halo: true,
-    zoom: 1,
+    zoom: 14,
   });
 
   const styleDropDown = document.getElementById("mapstyles-picker") as HTMLOptionElement;
+  const languageDropdown = document.getElementById("languages-picker") as HTMLOptionElement;
 
   styleDropDown.onchange = () => {
     if (styleDropDown.value === "json") {
-      // @ts-expect-error we know that `id` is private.
-      map.setStyle(getRandomJSON() as StyleSpecificationWithMetaData);
+      map.setStyle(getRandomJSON() as StyleSpecification);
       return;
     }
     map.setStyle(styleDropDown.value);
+  };
+
+  languageDropdown.onchange = () => {
+    const key = languageDropdown.value as keyof typeof Language;
+    const newLanguage = Language[key];
+    console.log(newLanguage, key);
+    map.setLanguage(newLanguage);
   };
 
   await map.onReadyAsync();
@@ -54,6 +60,13 @@ async function main() {
   anotherStyleOption.value = "d87d6c74-d29c-4cdd-87d8-b69ae7340dd6";
   anotherStyleOption.innerHTML = "Custom Style 1";
   styleDropDown.appendChild(anotherStyleOption);
+
+  Object.entries(Language).forEach(([key, l]) => {
+    const languageOption = document.createElement("option");
+    languageOption.value = key;
+    languageOption.innerHTML = l.name;
+    languageDropdown.appendChild(languageOption);
+  });
 }
 
 void main();
@@ -110,7 +123,6 @@ function getRandomJSON() {
     sprite: "https://api.maptiler.com/maps/satellite/sprite",
     bearing: 0,
     pitch: 0,
-    center: [0, 0],
     zoom: 1,
   };
 }

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1709,7 +1709,11 @@ export class Map extends maplibregl.Map {
 
       // The value of text-field is an object
       else {
-        this.setLayoutProperty(id, "text-field", languageReplacementExpression);
+        // Check if the original expression references "name" fields
+        const originalStr = JSON.stringify(textFieldLayoutProp);
+        if (originalStr.includes('"name"') || originalStr.includes('"name:')) {
+          this.setLayoutProperty(id, "text-field", languageReplacementExpression);
+        }
       }
     }
 


### PR DESCRIPTION
## Objective
Fixes [RD-1903](https://maptiler.atlassian.net/browse/RD-1903), highway shield labels (and some other text) showing road names or no text instead of route numbers when language is explicitly set to "auto".

## Description
Adds a check to ensure that string expressions labels aren't overwritten in `setLanguage`

## Acceptance
Manually

## Checklist
- [x] I have added relevant info to the CHANGELOG.md

[RD-1903]: https://maptiler.atlassian.net/browse/RD-1903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ