### PR TITLE
hotfix/spacebox-should-return-early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### 🐛 Bug Fixes
 - Passes `options.canvasContextAttributes` to WebGL support check to ensure the check creates context with the same options that the real rendering context uses.
 - Fixes [RD-1903](https://maptiler.atlassian.net/browse/RD-1903), highway shield labels (and some other text) showing road names or no text instead of route numbers when language is explicitly set to "auto".
+- Fixes a bug where two Space layers are added when initialising the map, leading to erros being thrown when changing space config.
 
 ### ⚙️ Others
 - None

--- a/demos/src/07-spacebox.ts
+++ b/demos/src/07-spacebox.ts
@@ -132,6 +132,8 @@ function main() {
     const { value } = select;
     const config = configs.find((c) => c.name === value);
     if (config) {
+      // to avoid validation errors, `name` is not a valid space spec prop
+      delete (config as any).name;
       console.log("Setting spacebox config:", config);
       const currentConfig = map.getSpace()?.getConfig();
       map.setSpace({

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -481,6 +481,7 @@ export class Map extends maplibregl.Map {
     if (spaceOptionsFromStyleSpec) {
       this.space = new CubemapLayer(spaceOptionsFromStyleSpec);
       this.addLayer(this.space, before);
+      return;
     }
 
     if (this.options.space === true) {


### PR DESCRIPTION
## Objective
Fixes a bug where two Space layers are added when initialising the map, leading to erros being thrown when changing space config.

## Description
Returns early when one space layer is created in `Map.initSpace` method.

## Acceptance
Manually tested

## Checklist
- [x] I have added relevant info to the CHANGELOG.md