### PR TITLE
RD-2013 Switch from using `crypto.randomUUID` to `uuid` lib in `Mapti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Passes `options.canvasContextAttributes` to WebGL support check to ensure the check creates context with the same options that the real rendering context uses.
 - Fixes [RD-1903](https://maptiler.atlassian.net/browse/RD-1903), highway shield labels (and some other text) showing road names or no text instead of route numbers when language is explicitly set to "auto".
 - Fixes a bug where two Space layers are added when initialising the map, leading to erros being thrown when changing space config.
+- Switches from using `crypto.randomUUID` to `uuid` lib in `MaptilerAnimation`
 
 ### ⚙️ Others
 - None

--- a/src/MaptilerAnimation/MaptilerAnimation.ts
+++ b/src/MaptilerAnimation/MaptilerAnimation.ts
@@ -2,6 +2,7 @@ import { lerp, lerpArrayValues } from "./animation-helpers";
 import AnimationManager from "./AnimationManager";
 import { AnimationEventCallback, AnimationEventListenersRecord, AnimationEventTypes, AnimationEventTypesArray, EasingFunctionName, Keyframe } from "./types";
 import EasingFunctions from "./easing";
+import { v4 as uuidv4 } from "uuid";
 
 /**
  * Configuration options for creating an animation.
@@ -206,7 +207,7 @@ export default class MaptilerAnimation {
           return props;
         }, {}),
         easing: keyframe.easing ?? "Linear",
-        id: crypto.randomUUID(),
+        id: uuidv4(),
       } as InterpolatedKeyFrame;
     });
 


### PR DESCRIPTION
## Objective
Fixes [RD-2013](https://maptiler.atlassian.net/browse/RD-2013

## Description
- Switches from using `crypto.randomUUID` to `uuid` lib in `MaptilerAnimation`

## Acceptance
Manually tested.

## Checklist
- [x] I have added relevant info to the CHANGELOG.md

[RD-2013]: https://maptiler.atlassian.net/browse/RD-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ