### PR TITLE
RD-1703 Fix addPolyline helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # MapTiler SDK Changelog
 
+## NEXT
+
+### 🐛 Bug Fixes
+- Fixes `helpers.addPolyline` string data handling
+  - It now correctly parses any string input (passed directly or fetched via URL) as GeoJSON, GPX, KML.
+  - It is no longer needed to provide URL with a supported filename extension, format is autodetected.
+
 ## 4.0.2
 
 ### ✨ Features and improvements

--- a/src/helpers/vectorlayerhelpers.ts
+++ b/src/helpers/vectorlayerhelpers.ts
@@ -19,7 +19,7 @@ import {
   radiusDrivenByPropertyHeatmap,
 } from "./stylehelper";
 
-import { gpx, gpxOrKml, kml } from "../converters";
+import { gpxOrKml } from "../converters";
 import { ColorRampCollection, type ColorRamp } from "../ColorRamp";
 
 /**
@@ -541,34 +541,22 @@ export async function addPolyline(
   if (typeof data === "string") {
     // if options.data exists and is a uuid string, we consider that it points to a MapTiler Dataset
     if (isUUID(data)) {
-      data = `https://api.maptiler.com/data/${options.data}/features.json?key=${config.apiKey}`;
-    }
-
-    // options.data could be a url to a .gpx file
-    else if (data.split(".").pop()?.toLowerCase().trim() === "gpx") {
-      // fetch the file
-      const res = await fetch(data, fetchOptions);
-      const gpxStr = await res.text();
-      // Convert it to geojson. Will throw is invalid GPX content
-      data = gpx(gpxStr);
-    }
-
-    // options.data could be a url to a .kml file
-    else if (data.split(".").pop()?.toLowerCase().trim() === "kml") {
-      // fetch the file
-      const res = await fetch(data, fetchOptions);
-      const kmlStr = await res.text();
-      // Convert it to geojson. Will throw is invalid GPX content
-      data = kml(kmlStr);
+      data = `https://api.maptiler.com/data/${data}/features.json?key=${config.apiKey}`;
     } else {
-      // From this point, we consider that the string content provided could
+      // options.data could be absolute or relative url
+      if (/^(?:\w+:|\.|\/)/.test(data)) {
+        // fetch the file
+        const res = await fetch(data, fetchOptions);
+        if (!res.ok) throw new Error(`Failed to fetch polyline data: fetching URL ${data} failed with status ${String(res.status)}.`);
+        data = await res.text();
+      }
+      // From this point, we consider that the string content provided or fetched could
       // be the string content of one of the compatible format (GeoJSON, KML, GPX)
-      const tmpData = jsonParseNoThrow<FeatureCollection<Geometry, GeoJsonProperties>>(data) ?? gpxOrKml(data);
-      if (tmpData) data = tmpData;
+      data = jsonParseNoThrow<FeatureCollection<Geometry, GeoJsonProperties>>(data) ?? gpxOrKml(data) ?? "";
     }
 
     if (!data) {
-      throw new Error("Polyline data was provided as string but is incompatible with valid formats.");
+      throw new Error("Failed to parse polyline data: expected GeoJSON, GPX, or KML.");
     }
   }
 

--- a/test/helpers/vectorlayerhepers.test.ts
+++ b/test/helpers/vectorlayerhepers.test.ts
@@ -1,0 +1,176 @@
+/* eslint-disable @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+
+import type { Map as SDKMap } from "../../src/Map";
+import { addPolyline } from "../../src/helpers/vectorlayerhelpers";
+
+describe("addPolyline()", () => {
+  const mapMock: SDKMap = {
+    getSource: vi.fn(),
+    addSource: vi.fn(),
+    addLayer: vi.fn(),
+  } as any;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("throws when neither sourceId nor data is provided", async () => {
+    await expect(addPolyline(mapMock, {} as any)).rejects.toThrow(/requires an existing/);
+  });
+
+  it("treats UUID string as dataset URL", async () => {
+    await addPolyline(mapMock, { data: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6" });
+
+    expect(mapMock.addSource).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.stringMatching(/api\.maptiler\.com\/data\/f81d4fae-7dec-11d0-a765-00a0c91e6bf6\/features\.json/),
+      }),
+    );
+  });
+
+  it("fetches URL if provided", async () => {
+    (global.fetch as Mock).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(`<gpx></gpx>`),
+    });
+
+    await addPolyline(mapMock, { data: "https://example.com/file.gpx" });
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("throws when fetching URL fails", async () => {
+    (global.fetch as Mock).mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    await expect(addPolyline(mapMock, { data: "https://example.com/file.gpx" })).rejects.toThrow(/Failed to fetch polyline data/);
+  });
+
+  it("parses fetched data as GeoJSON", async () => {
+    (global.fetch as Mock).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(`{"type":"FeatureCollection","features":[]}`),
+    });
+
+    await addPolyline(mapMock, { data: "https://example.com/file.geojson" });
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+    expect(mapMock.addSource).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          type: "FeatureCollection",
+          features: expect.any(Array),
+        },
+      }),
+    );
+  });
+
+  it("parses fetched data as GPX", async () => {
+    (global.fetch as Mock).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(`<gpx></gpx>`),
+    });
+
+    await addPolyline(mapMock, { data: "https://example.com/file.gpx" });
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+    expect(mapMock.addSource).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          type: "FeatureCollection",
+          features: expect.any(Array),
+        },
+      }),
+    );
+  });
+
+  it("parses fetched data as KML", async () => {
+    (global.fetch as Mock).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(`<kml></kml>`),
+    });
+
+    await addPolyline(mapMock, { data: "https://example.com/file.kml" });
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+    expect(mapMock.addSource).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          type: "FeatureCollection",
+          features: expect.any(Array),
+        },
+      }),
+    );
+  });
+
+  it("throws when fetched data cannot be parsed", async () => {
+    (global.fetch as Mock).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(`<foo></foo>`),
+    });
+
+    await expect(addPolyline(mapMock, { data: "https://example.com/file.foo" })).rejects.toThrow(/Failed to parse polyline data/);
+  });
+
+  it("parses provided string data as GeoJSON", async () => {
+    await addPolyline(mapMock, { data: `{"type":"FeatureCollection","features":[]}` });
+
+    expect(mapMock.addSource).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          type: "FeatureCollection",
+          features: expect.any(Array),
+        },
+      }),
+    );
+  });
+
+  it("parses provided string data as GPX", async () => {
+    await addPolyline(mapMock, { data: `<gpx></gpx>` });
+
+    expect(mapMock.addSource).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          type: "FeatureCollection",
+          features: expect.any(Array),
+        },
+      }),
+    );
+  });
+
+  it("parses provided string data as KML", async () => {
+    await addPolyline(mapMock, { data: `<kml></kml>` });
+
+    expect(mapMock.addSource).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          type: "FeatureCollection",
+          features: expect.any(Array),
+        },
+      }),
+    );
+  });
+
+  it("throws when string data cannot be parsed", async () => {
+    await expect(addPolyline(mapMock, { data: "not valid" })).rejects.toThrow(/Failed to parse polyline data/);
+  });
+
+  it("passes through non-string data unchanged", async () => {
+    const data = { type: "FeatureCollection" as const, features: [] };
+
+    await addPolyline(mapMock, { data });
+
+    expect(mapMock.addSource).toHaveBeenCalledExactlyOnceWith(expect.anything(), expect.objectContaining({ data }));
+  });
+});


### PR DESCRIPTION
## Objective
Fix discrepancies in `helpers.addPolyline` and add functionality that is advertised in TSDoc but not implemented.

## Description
- `addPolyline` now correctly parses any string input (passed directly or fetched via URL) as GeoJSON, GPX, KML.
- It is no longer needed to provide URL with a supported filename extension, format is autodetected.

## Acceptance
Unit tests added

## Checklist
- [x] I have added relevant info to the CHANGELOG.md