### PR TITLE
RD-1410 implement designs

### DIFF
--- a/demos/public/16-maptiler-markers.html
+++ b/demos/public/16-maptiler-markers.html
@@ -312,7 +312,7 @@
       <div class="ctrl-label">Content mode</div>
       <div class="shape-grid">
         <button class="size-btn" data-content-mode="text">text</button>
-        <button class="size-btn" data-content-mode="type">type: star</button>
+        <button class="size-btn" data-content-mode="icon">icon: star (TODO)</button>
         <button class="size-btn" data-content-mode="url">url: image</button>
         <button class="size-btn" data-content-mode="template">template</button>
         <button class="size-btn" data-content-mode="element">element</button>

--- a/demos/public/16-maptiler-markers.html
+++ b/demos/public/16-maptiler-markers.html
@@ -55,6 +55,17 @@
       gap: 4px;
     }
 
+    .shape-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 4px;
+    }
+
+    .shape-grid .size-btn {
+      font-size: 10px;
+      padding: 0 2px;
+    }
+
     .size-btn {
       flex: 1;
       height: 28px;
@@ -179,6 +190,19 @@
       border-color: hsl(223, 100%, 65%);
     }
 
+    .debug-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+      color: rgba(0, 0, 0, 0.6);
+      cursor: pointer;
+    }
+
+    .debug-row input[type="checkbox"] {
+      accent-color: hsl(223, 100%, 65%);
+    }
+
     #status {
       font-size: 10px;
       color: rgba(0, 0, 0, 0.45);
@@ -196,13 +220,41 @@
 
   <div id="panel">
     <div class="ctrl-group">
+      <div class="ctrl-label">Map style</div>
+      <div class="shape-grid">
+        <button class="size-btn" data-map-style="streets">streets</button>
+        <button class="size-btn" data-map-style="streets-dark">streets-dark</button>
+        <button class="size-btn" data-map-style="base">base</button>
+        <button class="size-btn" data-map-style="base-dark">base-dark</button>
+        <button class="size-btn" data-map-style="dataviz">dataviz</button>
+        <button class="size-btn" data-map-style="dataviz-dark">dataviz-dark</button>
+        <button class="size-btn" data-map-style="hybrid">hybrid</button>
+        <button class="size-btn" data-map-style="topo">topo</button>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Shape</div>
+      <div class="shape-grid">
+        <button class="size-btn" data-shape="rounded">rounded</button>
+        <button class="size-btn" data-shape="circle">circle</button>
+        <button class="size-btn" data-shape="bubble-circle">bubble-circle</button>
+        <button class="size-btn" data-shape="bubble-square">bubble-square</button>
+        <button class="size-btn" data-shape="square">square</button>
+        <button class="size-btn" data-shape="bulb">bulb</button>
+        <button class="size-btn" data-shape="squircle">squircle</button>
+        <button class="size-btn" data-shape="shield">shield</button>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
       <div class="ctrl-label">Size</div>
       <div class="size-row">
         <button class="size-btn" data-size="xs">xs</button>
         <button class="size-btn" data-size="s">s</button>
         <button class="size-btn" data-size="m">m</button>
-        <button class="size-btn" data-size="L">L</button>
-        <button class="size-btn" data-size="XL">XL</button>
+        <button class="size-btn" data-size="l">L</button>
+        <button class="size-btn" data-size="xl">XL</button>
       </div>
     </div>
 
@@ -213,6 +265,16 @@
         <button class="shadow-btn" data-shadow="soft">soft</button>
         <button class="shadow-btn" data-shadow="medium">medium</button>
         <button class="shadow-btn" data-shadow="strong">strong</button>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Adaptive color</div>
+      <div class="size-row">
+        <button class="size-btn" data-adaptive-color="">off</button>
+        <button class="size-btn" data-adaptive-color="blue">blue</button>
+        <button class="size-btn" data-adaptive-color="red">red</button>
+        <button class="size-btn" data-adaptive-color="green">green</button>
       </div>
     </div>
 
@@ -247,8 +309,20 @@
     </div>
 
     <div class="ctrl-group">
-      <div class="ctrl-label">Title</div>
-      <input id="title-input" class="text-input" type="text" value="1" />
+      <div class="ctrl-label">Content mode</div>
+      <div class="shape-grid">
+        <button class="size-btn" data-content-mode="text">text</button>
+        <button class="size-btn" data-content-mode="type">type: star</button>
+        <button class="size-btn" data-content-mode="url">url: image</button>
+        <button class="size-btn" data-content-mode="template">template</button>
+        <button class="size-btn" data-content-mode="element">element</button>
+        <button class="size-btn" data-content-mode="none">none</button>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Content</div>
+      <input id="content-input" class="text-input" type="text" value="1" />
     </div>
 
     <div class="ctrl-group">
@@ -271,6 +345,19 @@
         <input id="scale-y" type="range" min="0.25" max="3" step="0.05" value="1" />
         <span class="scale-val" id="scale-y-val">1.00</span>
       </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Animation</div>
+      <button id="anim-toggle" class="size-btn">Pause</button>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Debug</div>
+      <label class="debug-row">
+        <input id="debug-toggle" type="checkbox" />
+        <span>Bounding box + center</span>
+      </label>
     </div>
 
     <div class="ctrl-group">

--- a/demos/src/16-maptiler-markers.ts
+++ b/demos/src/16-maptiler-markers.ts
@@ -1,6 +1,22 @@
-import { Map, MapStyle, Marker, config } from "../../src/index";
+import { Map, MapStyle, Marker, config, registerMarkerTemplate } from "../../src/index";
 import { setupMapTilerApiKey } from "./demo-utils";
-import type { MapTilerMarkerOptions } from "../../src/Marker";
+import type { MapTilerMarkerBaseOptions, MapTilerMarkerOptions, MapTilerMarkerSVGOptions } from "../../src/Marker";
+
+// demo template: dark round badge with a label
+registerMarkerTemplate("badge", (params) => {
+  const div = document.createElement("div");
+  div.style.width = "100%";
+  div.style.height = "100%";
+  div.style.borderRadius = "50%";
+  div.style.background = "#1a1a2e";
+  div.style.color = "#ffd166";
+  div.style.display = "flex";
+  div.style.alignItems = "center";
+  div.style.justifyContent = "center";
+  div.style.font = "700 16px system-ui";
+  div.textContent = String(params?.label ?? "?");
+  return div;
+});
 
 setupMapTilerApiKey({ config });
 
@@ -10,36 +26,262 @@ function el<T extends HTMLElement = HTMLElement>(id: string): T {
   return found as T;
 }
 
+const zoom = 12;
+
 async function main() {
   const map = new Map({
     container: el("map"),
     style: MapStyle.STREETS.DEFAULT,
     projection: "globe",
-    zoom: 5,
+    zoom,
     center: [10, 50],
+    pitch: 45,
   });
 
   await map.onLoadAsync();
 
-  const marker = new Marker({
+  // cross drawn over the marker's lngLat so the anchor point is easy to eyeball;
+  // re-added after every style switch (setStyle wipes sources/layers)
+  const [centerLng, centerLat] = [10, 50];
+  const armLat = 0.01;
+  const armLng = armLat / Math.cos((centerLat * Math.PI) / 180); // visually square arms
+
+  function addCenterCross() {
+    if (map.getSource("center-cross")) return;
+
+    map.addSource("center-cross", {
+      type: "geojson",
+      data: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [centerLng - armLng, centerLat],
+                [centerLng + armLng, centerLat],
+              ],
+            },
+          },
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [centerLng, centerLat - armLat],
+                [centerLng, centerLat + armLat],
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    map.addLayer({
+      id: "center-cross",
+      type: "line",
+      source: "center-cross",
+      paint: {
+        "line-color": "#ff00ff",
+        "line-width": 2,
+      },
+    });
+  }
+
+  addCenterCross();
+
+  map.on("styledata", () => {
+    try {
+      addCenterCross();
+    } catch {
+      // style still transitioning — the next styledata event will succeed
+    }
+    syncStatus();
+  });
+
+  let i = 0;
+  let animating = false;
+
+  function loop() {
+    if (!animating) return;
+    i += 0.75;
+    requestAnimationFrame(loop);
+    map.setBearing(i);
+    map.setZoom(zoom + Math.sin(i / 50) * 2);
+  }
+
+  const animToggle = el<HTMLButtonElement>("anim-toggle");
+
+  animToggle.addEventListener("click", () => {
+    animating = !animating;
+    animToggle.textContent = animating ? "Pause" : "Resume";
+    if (animating) loop();
+  });
+  // Single source of truth for the marker configuration.
+  // Control handlers write here as well as calling the setter.
+  const markerOptions: MapTilerMarkerSVGOptions = {
     draggable: true,
-    rotation: 45,
-    scale: [4, 4],
+    scale: [1, 1],
     shape: "bubble-square",
     size: "m",
-    innerColor: "hsl(223, 100%, 65%)",
+    color: "blue", // adaptive — resolves against the current map style
     outerColor: "#ffffff",
     contentColor: "#ffffff",
     shadow: "medium",
-    title: "1",
+    content: "1",
+    title: "Marker 1",
     subpixelPositioning: true,
+    priority: 100,
+  };
+
+  // Content mode — content variants are constructor-only, so switching
+  // modes rebuilds the marker from markerOptions + the selected variant.
+  type ContentMode = "text" | "type" | "url" | "template" | "element" | "none";
+  let contentMode: ContentMode = "text";
+
+  function createConfiguredMarker(): Marker {
+    // widen away the SVG-options `never` variant keys and drop the maplibre
+    // `element` key so any content variant can be attached
+    const widened: MapTilerMarkerBaseOptions = { ...markerOptions, content: undefined };
+    delete widened.element;
+    const base = widened as Omit<MapTilerMarkerBaseOptions, "element">;
+
+    switch (contentMode) {
+      case "text":
+        return new Marker({ ...markerOptions });
+      case "none":
+        return new Marker(base);
+      case "type":
+        return new Marker({ ...base, contentType: "star" });
+      case "url":
+        return new Marker({ ...base, url: "https://picsum.photos/128" });
+      case "template":
+        return new Marker({ ...base, template: "badge", templateParams: { label: markerOptions.content ?? "?" } });
+      case "element": {
+        const pin = document.createElement("div");
+        pin.textContent = "📍";
+        pin.style.fontSize = "40px";
+        pin.style.cursor = "pointer";
+        const { shape, size, ...behaviour } = base;
+        void shape;
+        void size;
+        return new Marker({ ...behaviour, element: pin });
+      }
+    }
+  }
+
+  function mountMarker(m: Marker, lngLat: [number, number]) {
+    m.on("click", console.log);
+    m.setLngLat(lngLat);
+    map.addMarker(m);
+  }
+
+  let marker = createConfiguredMarker();
+  mountMarker(marker, [10, 50]);
+  marker.setDebug(true);
+
+  const contentModeButtons = document.querySelectorAll<HTMLButtonElement>("[data-content-mode]");
+
+  function syncContentModeButtons(active: string) {
+    contentModeButtons.forEach((b) => b.classList.toggle("active", b.dataset.contentMode === active));
+  }
+
+  contentModeButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      contentMode = btn.dataset.contentMode as ContentMode;
+      const lngLat = marker.getLngLat();
+      marker.remove();
+      marker = createConfiguredMarker();
+      mountMarker(marker, [lngLat.lng, lngLat.lat]);
+      marker.setDebug(el<HTMLInputElement>("debug-toggle").checked);
+      syncContentModeButtons(contentMode);
+      syncStatus();
+    });
   });
 
-  marker.on("click", console.log)
+  syncContentModeButtons(contentMode);
 
-  marker.setLngLat([10, 50]);
-  map.addMarker(marker);
+  for (let i = 0; i < 4; i++) {
+    const otherMarker = new Marker({ ...markerOptions, content: String(i + 2), title: `Marker ${String(i + 2)}`, priority: 1 + i });
+    otherMarker.on("click", console.log);
+    const offsetLat = Math.sin((i / 4) * Math.PI * 2) / 20;
+    const offsetLon = Math.cos((i / 4) * Math.PI * 2) / 20;
+    otherMarker.setLngLat([10 + offsetLon, 50 + offsetLat]);
+    map.addMarker(otherMarker);
+  }
 
+  // Shape
+  const shapeButtons = document.querySelectorAll<HTMLButtonElement>("[data-shape]");
+
+  function syncShapeButtons(active: string) {
+    shapeButtons.forEach((b) => b.classList.toggle("active", b.dataset.shape === active));
+  }
+
+  shapeButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const shape = btn.dataset.shape as MapTilerMarkerOptions["shape"];
+      markerOptions.shape = shape;
+      marker.setShape(shape);
+      syncShapeButtons(btn.dataset.shape ?? "");
+      syncStatus();
+    });
+  });
+
+  syncShapeButtons(marker.getShape() ?? "bubble-square");
+
+  // Map style — exercises adaptive colour re-resolution on style change
+  const mapStyles = {
+    streets: MapStyle.STREETS.DEFAULT,
+    "streets-dark": MapStyle.STREETS.DARK,
+    base: MapStyle.BASE.DEFAULT,
+    "base-dark": MapStyle.BASE.DARK,
+    dataviz: MapStyle.DATAVIZ.DEFAULT,
+    "dataviz-dark": MapStyle.DATAVIZ.DARK,
+    hybrid: MapStyle.HYBRID.DEFAULT,
+    topo: MapStyle.TOPO.DEFAULT,
+  } as const;
+
+  const styleButtons = document.querySelectorAll<HTMLButtonElement>("[data-map-style]");
+
+  function syncStyleButtons(active: string) {
+    styleButtons.forEach((b) => b.classList.toggle("active", b.dataset.mapStyle === active));
+  }
+
+  styleButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const key = btn.dataset.mapStyle as keyof typeof mapStyles;
+      map.setStyle(mapStyles[key]);
+      syncStyleButtons(key);
+    });
+  });
+
+  syncStyleButtons("streets");
+
+  // Adaptive color
+  const adaptiveButtons = document.querySelectorAll<HTMLButtonElement>("[data-adaptive-color]");
+
+  function syncAdaptiveButtons(active: string) {
+    adaptiveButtons.forEach((b) => b.classList.toggle("active", b.dataset.adaptiveColor === active));
+  }
+
+  adaptiveButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const key = btn.dataset.adaptiveColor ?? "";
+      const color = (key === "" ? undefined : key) as MapTilerMarkerOptions["color"];
+      markerOptions.color = color;
+      if (color) markerOptions.innerColor = undefined; // adaptive takes over from explicit inner
+      marker.setColor(color);
+      syncAdaptiveButtons(key);
+      syncStatus();
+    });
+  });
+
+  syncAdaptiveButtons(typeof markerOptions.color === "string" ? markerOptions.color : "");
+
+  // Size
   const sizeButtons = document.querySelectorAll<HTMLButtonElement>("[data-size]");
 
   function syncSizeButtons(active: string) {
@@ -49,14 +291,16 @@ async function main() {
   sizeButtons.forEach((btn) => {
     btn.addEventListener("click", () => {
       const size = btn.dataset.size as MapTilerMarkerOptions["size"];
+      markerOptions.size = size;
       marker.setSize(size);
       syncSizeButtons(btn.dataset.size ?? "m");
       syncStatus();
     });
   });
 
-  syncSizeButtons(marker.getSize() ?? "m");
+  syncSizeButtons(markerOptions.size ?? "m");
 
+  // Shadow
   const shadowButtons = document.querySelectorAll<HTMLButtonElement>("[data-shadow]");
 
   function syncShadowButtons(active: string) {
@@ -65,14 +309,15 @@ async function main() {
 
   shadowButtons.forEach((btn) => {
     btn.addEventListener("click", () => {
-      const shadow = btn.dataset.shadow as MapTilerMarkerOptions["shadow"] | undefined;
-      marker.setShadow(shadow ?? undefined);
+      const shadow = (btn.dataset.shadow === "" ? undefined : btn.dataset.shadow) as MapTilerMarkerOptions["shadow"];
+      markerOptions.shadow = shadow;
+      marker.setShadow(shadow);
       syncShadowButtons(btn.dataset.shadow ?? "");
       syncStatus();
     });
   });
 
-  syncShadowButtons(marker.getShadow() ?? "medium");
+  syncShadowButtons(markerOptions.shadow ?? "");
 
   // Colors
   function colorToHex(color: string): string {
@@ -89,24 +334,29 @@ async function main() {
   const contentColorInput = el<HTMLInputElement>("content-color");
   const outlineColorInput = el<HTMLInputElement>("outline-color");
 
-  outerColorInput.value = colorToHex(marker.getOuterColor() ?? "#ffffff");
+  outerColorInput.value = colorToHex(markerOptions.outerColor ?? "#ffffff");
   innerColorInput.value = colorToHex(marker.getInnerColor() ?? "#ffffff");
-  contentColorInput.value = colorToHex(marker.getContentColor() ?? "#ffffff");
-  outlineColorInput.value = colorToHex(marker.getOutlineColor() ?? "#ffffff");
+  contentColorInput.value = colorToHex(markerOptions.contentColor ?? "#ffffff");
+  outlineColorInput.value = colorToHex(markerOptions.outlineColor ?? "#ffffff");
 
   outerColorInput.addEventListener("input", () => {
+    markerOptions.outerColor = outerColorInput.value;
     marker.setOuterColor(outerColorInput.value);
     syncStatus();
   });
   innerColorInput.addEventListener("input", () => {
+    // explicit innerColor pins the colour and pauses adaptation
+    markerOptions.innerColor = innerColorInput.value;
     marker.setInnerColor(innerColorInput.value);
     syncStatus();
   });
   contentColorInput.addEventListener("input", () => {
+    markerOptions.contentColor = contentColorInput.value;
     marker.setContentColor(contentColorInput.value);
     syncStatus();
   });
   outlineColorInput.addEventListener("input", () => {
+    markerOptions.outlineColor = outlineColorInput.value;
     marker.setOutlineColor(outlineColorInput.value);
     syncStatus();
   });
@@ -117,21 +367,18 @@ async function main() {
 
   outlineWidthInput.addEventListener("input", () => {
     const w = parseFloat(outlineWidthInput.value);
-    if (w === 0) {
-      marker.setOutline(undefined);
-      outlineWidthVal.textContent = "off";
-    } else {
-      marker.setOutline(w);
-      outlineWidthVal.textContent = `${String(w)}px`;
-    }
+    markerOptions.outline = w === 0 ? undefined : w;
+    marker.setOutline(markerOptions.outline);
+    outlineWidthVal.textContent = w === 0 ? "off" : `${String(w)}px`;
     syncStatus();
   });
 
-  // Title
-  const titleInput = el<HTMLInputElement>("title-input");
+  // Content
+  const contentInput = el<HTMLInputElement>("content-input");
 
-  titleInput.addEventListener("input", () => {
-    marker.setTitle(titleInput.value);
+  contentInput.addEventListener("input", () => {
+    markerOptions.content = contentInput.value;
+    marker.setContent(contentInput.value);
     syncStatus();
   });
 
@@ -141,43 +388,64 @@ async function main() {
 
   rotationInput.addEventListener("input", () => {
     const deg = parseInt(rotationInput.value, 10);
+    markerOptions.rotation = deg;
     marker.setRotation(deg);
     rotationVal.textContent = `${String(deg)}°`;
     syncStatus();
   });
 
+  // Scale
   const scaleXInput = el<HTMLInputElement>("scale-x");
   const scaleYInput = el<HTMLInputElement>("scale-y");
   const scaleXVal = el("scale-x-val");
   const scaleYVal = el("scale-y-val");
 
   function getScale(): [number, number] {
-    return marker.getScale() ?? [1, 1];
+    return markerOptions.scale ?? [1, 1];
   }
 
   scaleXInput.addEventListener("input", () => {
     const x = parseFloat(scaleXInput.value);
-    marker.setScale([x, getScale()[1]]);
+    markerOptions.scale = [x, getScale()[1]];
+    marker.setScale(markerOptions.scale);
     scaleXVal.textContent = x.toFixed(2);
     syncStatus();
   });
 
   scaleYInput.addEventListener("input", () => {
     const y = parseFloat(scaleYInput.value);
-    marker.setScale([getScale()[0], y]);
+    markerOptions.scale = [getScale()[0], y];
+    marker.setScale(markerOptions.scale);
     scaleYVal.textContent = y.toFixed(2);
     syncStatus();
+  });
+
+  // Debug overlay
+  const debugToggle = el<HTMLInputElement>("debug-toggle");
+  debugToggle.checked = marker.getDebug();
+
+  debugToggle.addEventListener("change", () => {
+    markerOptions.debug = debugToggle.checked;
+    marker.setDebug(debugToggle.checked);
   });
 
   const statusEl = el("status");
 
   function syncStatus() {
-    const size = marker.getSize() ?? "m";
+    const shape = marker.getShape() ?? "bubble-square";
+    const size = markerOptions.size ?? "m";
     const [sx, sy] = getScale();
-    statusEl.textContent = `getSize() → "${size}"  |  getScale() → [${sx.toFixed(2)}, ${sy.toFixed(2)}]`;
+    const color = marker.getColor();
+    const colorLabel = color === undefined ? "off" : typeof color === "string" ? `"${color}"` : color.name;
+    const innerColor = marker.getInnerColor() ?? "default";
+    statusEl.textContent =
+      `getShape() → "${shape}"  |  getSize() → "${size}"  |  getScale() → [${sx.toFixed(2)}, ${sy.toFixed(2)}]` +
+      `  |  getColor() → ${colorLabel}  |  getInnerColor() → ${innerColor}`;
   }
 
   syncStatus();
+
+  loop();
 }
 
-main();
+void main();

--- a/demos/src/16-maptiler-markers.ts
+++ b/demos/src/16-maptiler-markers.ts
@@ -22,6 +22,9 @@ async function main() {
   await map.onLoadAsync();
 
   const marker = new Marker({
+    draggable: true,
+    rotation: 45,
+    scale: [4, 4],
     shape: "bubble-square",
     size: "m",
     innerColor: "hsl(223, 100%, 65%)",
@@ -31,6 +34,8 @@ async function main() {
     title: "1",
     subpixelPositioning: true,
   });
+
+  marker.on("click", console.log)
 
   marker.setLngLat([10, 50]);
   map.addMarker(marker);

--- a/demos/src/16-maptiler-markers.ts
+++ b/demos/src/16-maptiler-markers.ts
@@ -139,7 +139,7 @@ async function main() {
 
   // Content mode — content variants are constructor-only, so switching
   // modes rebuilds the marker from markerOptions + the selected variant.
-  type ContentMode = "text" | "type" | "url" | "template" | "element" | "none";
+  type ContentMode = "text" | "icon" | "url" | "template" | "element" | "none";
   let contentMode: ContentMode = "text";
 
   function createConfiguredMarker(): Marker {
@@ -154,8 +154,9 @@ async function main() {
         return new Marker({ ...markerOptions });
       case "none":
         return new Marker(base);
-      case "type":
-        return new Marker({ ...base, contentType: "star" });
+      case "icon":
+        // TODO(icons): renders nothing until icon content is implemented
+        return new Marker({ ...base, icon: "star" });
       case "url":
         return new Marker({ ...base, url: "https://picsum.photos/128" });
       case "template":

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -32,7 +32,7 @@ import { defaults } from "./constants/defaults";
 import { MaptilerLogoControl } from "./controls/MaptilerLogoControl";
 import { checkNamePattern, combineTransformRequest, computeLabelsLocalizationMetrics, displayNoWebGlWarning, enableRTL, replaceLanguage } from "./tools";
 import { getBrowserLanguage, Language, type LanguageInfo } from "./language";
-import { styleToStyle } from "./mapstyle";
+import { styleToStyle, styleToStyleId } from "./mapstyle";
 import { MaptilerTerrainControl } from "./controls/MaptilerTerrainControl";
 import { MaptilerNavigationControl } from "./controls/MaptilerNavigationControl";
 import { MapStyle, geolocation, getLanguageInfoFromFlag, toLanguageInfo } from "@maptiler/client";
@@ -580,6 +580,7 @@ export class Map extends maplibregl.Map {
   private terrainAnimationDuration = 1000;
   private monitoredStyleUrls!: Set<string>;
   private styleInProcess = false;
+  private currentStyleId?: string;
   private curentProjection: ProjectionTypes = undefined;
   private originalLabelStyle = new window.Map<string, ExpressionSpecification | string>();
   private isStyleLocalized = false;
@@ -1275,6 +1276,10 @@ export class Map extends maplibregl.Map {
       );
     }
 
+    // remember the requested style id ("streets-v4-dark") — used by markers
+    // to resolve adaptive colours; not recoverable from the parsed stylesheet
+    this.currentStyleId = styleToStyleId(styleInfo.isFallback ? null : style);
+
     this.spaceboxLoadingState.styleLoadedCallbackFired = false;
     this.spaceboxLoadingState.styleLoadCallbackSet = false;
 
@@ -1384,6 +1389,16 @@ export class Map extends maplibregl.Map {
     styleLoadCallbackSet: false,
     styleLoadedCallbackFired: false,
   };
+
+  /**
+   * Returns the id of the current MapTiler style (e.g. `"streets-v4-dark"`),
+   * derived from the value passed to the constructor or `setStyle`.
+   * `undefined` when the style is a custom `StyleSpecification` or a URL that
+   * doesn't follow the MapTiler Cloud `/maps/<id>/style.json` shape.
+   */
+  getStyleId(): string | undefined {
+    return this.currentStyleId;
+  }
 
   /**
    * Adds a [MapLibre style layer](https://maplibre.org/maplibre-style-spec/layers)

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -214,6 +214,8 @@ export class Marker extends maplibregl.Marker {
 
   //#region Getters & Setters
 
+  //#region Scale
+
   /**
    * Sets the 2-D scale of the marker as `[x, y]`.
    * @param scaleVector - Scale factors for the x and y axes.
@@ -226,6 +228,10 @@ export class Marker extends maplibregl.Marker {
   getScale() {
     return this.props.scale;
   }
+
+  //#endregion
+
+  //#region Shape
 
   /**
    * Sets the marker shape. Rebuilds the marker SVG in place, migrating the
@@ -246,6 +252,10 @@ export class Marker extends maplibregl.Marker {
     return this.props.shape;
   }
 
+  //#endregion
+
+  //#region Size
+
   /**
    * Sets the marker size.
    * @param size - T-shirt size key (`xs` | `s` | `m` | `l` | `xl`).
@@ -259,6 +269,10 @@ export class Marker extends maplibregl.Marker {
   getSize() {
     return this.props.size;
   }
+
+  //#endregion
+
+  //#region Shadow
 
   /**
    * Sets the drop-shadow intensity.
@@ -274,6 +288,10 @@ export class Marker extends maplibregl.Marker {
     return this.props.shadow;
   }
 
+  //#endregion
+
+  //#region Outer Color
+
   /**
    * Sets the fill colour of the outer body of the marker.
    * @param color - Any valid CSS colour string.
@@ -286,6 +304,10 @@ export class Marker extends maplibregl.Marker {
   getOuterColor() {
     return this.props.outerColor;
   }
+
+  //#endregion
+
+  //#region Adaptive Color
 
   /**
    * Sets the adaptive colour of the marker. The inner (background) colour is
@@ -305,6 +327,10 @@ export class Marker extends maplibregl.Marker {
   getColor() {
     return this.props.color;
   }
+
+  //#endregion
+
+  //#region Inner Color
 
   /**
    * Sets an explicit fill colour for the inner area of the marker.
@@ -335,6 +361,10 @@ export class Marker extends maplibregl.Marker {
     return undefined;
   }
 
+  //#endregion
+
+  //#region Content Color
+
   /**
    * Sets the colour applied to the marker content (icon, text, etc.).
    * @param color - Any valid CSS colour string.
@@ -347,6 +377,10 @@ export class Marker extends maplibregl.Marker {
   getContentColor() {
     return this.props.contentColor;
   }
+
+  //#endregion
+
+  //#region Outline Color
 
   /**
    * Sets the stroke colour of the marker outline.
@@ -362,6 +396,10 @@ export class Marker extends maplibregl.Marker {
     return this.props.outlineColor;
   }
 
+  //#endregion
+
+  //#region Outline
+
   /**
    * Sets the outline stroke width on the marker body.
    * @param outline - `true` for the default width, a positive `number` for an
@@ -376,6 +414,10 @@ export class Marker extends maplibregl.Marker {
     return this.props.outline;
   }
 
+  //#endregion
+
+  //#region Title
+
   /**
    * Sets the `title` attribute on the marker's root element (native tooltip).
    * @param title - Tooltip string, or `undefined` to remove the attribute.
@@ -389,6 +431,10 @@ export class Marker extends maplibregl.Marker {
     return this.props.title;
   }
 
+  //#endregion
+
+  //#region Content
+
   /**
    * Sets the text content displayed inside the marker body.
    * @param content - Label string, or `undefined` to clear.
@@ -401,6 +447,10 @@ export class Marker extends maplibregl.Marker {
   getContent() {
     return this.props.content;
   }
+
+  //#endregion
+
+  //#region Priority
 
   /**
    * Sets the rendering priority. Numeric values are applied as `z-index` on
@@ -419,6 +469,10 @@ export class Marker extends maplibregl.Marker {
     return this.props.priority;
   }
 
+  //#endregion
+
+  //#region Debug
+
   /**
    * Shows or hides the debug overlay, which renders the marker's bounding
    * box and center point on top of the marker element.
@@ -432,6 +486,10 @@ export class Marker extends maplibregl.Marker {
   getDebug() {
     return this.props.debug ?? false;
   }
+
+  //#endregion
+
+  //#region Rotation
 
   /**
    * Rotates the marker's inner shell element in degrees.
@@ -453,6 +511,8 @@ export class Marker extends maplibregl.Marker {
   override getRotation(): number {
     return this.props.rotation ?? 0;
   }
+
+  //#endregion
 
   //#endregion
 

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -1,14 +1,14 @@
 import maplibregl from "maplibre-gl";
 import type { MarkerOptions } from "maplibre-gl";
 import type { Map as SDKMap } from "../Map";
-import { HTMLElementUpdateCue, MapTilerMarkerElementProps, MapTilerMarkerElementOptions, MapTilerMarkerSVGOptions, Vector2, type MapTilerMarkerOptions } from "./types";
+import type { MapTilerMarkerElementProps, MapTilerMarkerElementOptions, MapTilerMarkerSVGOptions, PendingMarkerUpdates, Vector2, MapTilerMarkerOptions } from "./types";
 import { omit } from "../utils/object";
 import { v4 as uuid } from "uuid";
-import { createMarkerElement, updateMarkerElement, wrap } from "./marker-dom-utils";
-import { DEFAULT_OFFSET_Y, DEFAULT_SIZE } from "./marker-svg-config";
+import { applyMarkerStyleVariables, createMarkerElement, updateMarkerElement } from "./marker-dom-utils";
+import { DEFAULT_SHAPE, DEFAULT_SIZE, getShapeAnchorOffset } from "./marker-svg-config";
+import { getAdaptiveBgColor, resolveAdaptiveColor } from "./marker-adaptive-colors";
 import { MarkerManager } from "./MarkerManager";
-import { CuedUpdatesSymbol, DetachFromDOMSymbol, FlushDOMUpdatesSymbol, MarkerElementSymbol } from "./marker-symbols";
-export * from "./types";
+import { PendingUpdatesSymbol, DetachFromDOMSymbol, FlushDOMUpdatesSymbol, MarkerElementSymbol, RefreshAdaptiveColorSymbol } from "./marker-symbols";
 
 const maplibreMarkerConstructorOverrides: MarkerOptions = {
   scale: 1, // scale in our class will be a 2D vector.
@@ -17,6 +17,7 @@ const maplibreMarkerConstructorOverrides: MarkerOptions = {
 const maptilerBaseOptionsKeys = [
   "shape",
   "size",
+  "color",
   "innerColor",
   "outerColor",
   "contentColor",
@@ -27,6 +28,7 @@ const maptilerBaseOptionsKeys = [
   "opacityWhenCovered",
   "name",
   "title",
+  "content",
   "htmlAttributes",
   "scale",
   "visible",
@@ -35,58 +37,42 @@ const maptilerBaseOptionsKeys = [
   "collisionBehaviour",
   "collisionRadius",
   "rotation",
+  "debug",
 ] as const;
 
 /**
  * A MapTiler marker with extended styling and batched DOM update support.
  *
  * Extends MapLibre's `Marker` with 2-D scale, named shapes, colour tokens,
- * and a cued-update system that defers all DOM writes to the next animation
+ * and a batched-update system that defers all DOM writes to the next animation
  * frame so that multiple property changes in the same tick cost only one
  * layout pass.
  */
 export class Marker extends maplibregl.Marker {
-  /** The resolved options used to construct this marker. */
-  options: MapTilerMarkerOptions;
+  /**
+   * The options used to construct this marker.
+   * A construction-time snapshot — not updated by setters; use the getters
+   * for current values.
+   */
+  readonly options: MapTilerMarkerOptions;
   readonly _scale = 1; // ML only allows scaling in 1 dimension, we want to add scaling in 2D so this is ignored.
 
   //#region Marker Properties
 
-  /** The size catetogry of the marker */
-  private size: MapTilerMarkerOptions["size"];
+  /** Current values of all element-affecting properties. Written only via {@link setProp}. */
+  private readonly props: MapTilerMarkerElementProps;
 
-  /** The scale vector of the marker [x, y] */
-  private scaleVector: MapTilerMarkerOptions["scale"];
-
-  /** The shadow option "soft" | "medium" | "strong" */
-  private shadow: MapTilerMarkerOptions["shadow"];
-
-  /** The color of the outermost part of the marker */
-  private outerColor: MapTilerMarkerOptions["outerColor"];
-
-  /** The color of the inner part of the marker */
-  private innerColor: MapTilerMarkerOptions["innerColor"];
-
-  /** The color of the inner part of the content */
-  private contentColor: MapTilerMarkerOptions["contentColor"];
-
-  /*& The color of the outline of the marker */
-  private outlineColor: MapTilerMarkerOptions["outlineColor"];
-
-  /** The width of the outline */
-  private outline: MapTilerMarkerOptions["outline"];
-
-  /** The value applied to the 'title' attribute of the marker */
-  private title: MapTilerMarkerOptions["title"];
-
-  /** The rotation of the marker in degrees */
-  private markerRotation: number | undefined;
+  /**
+   * Whether the shape anchor offset is managed automatically.
+   * `false` when the user supplied an explicit `offset` or a custom `element`.
+   */
+  private readonly managesOffset: boolean;
 
   /** The DOM element **/
   [MarkerElementSymbol]: HTMLElement;
 
-  /** A Map used to store updates needed */
-  [CuedUpdatesSymbol]: HTMLElementUpdateCue = new Map();
+  /** Property updates waiting to be flushed to the DOM on the next animation frame. */
+  [PendingUpdatesSymbol]: PendingMarkerUpdates = {};
 
   /** UUID that uniquely identifies this marker instance. */
   public readonly id = uuid();
@@ -100,8 +86,8 @@ export class Marker extends maplibregl.Marker {
    *
    * SVG-layout fields (`shape`, `size`) are not available in this signature —
    * they only affect the built-in SVG generator.  Color and shadow options
-   * are still accepted and applied as CSS custom properties on the wrapper so
-   * that the supplied element can inherit them.
+   * are still accepted and applied as CSS custom properties on the supplied
+   * element so that its styles can consume them.
    *
    * TODO: this will affect collision behaviour.
    */
@@ -116,7 +102,8 @@ export class Marker extends maplibregl.Marker {
     const sizeKey = options.size ?? DEFAULT_SIZE;
     const superOptions = {
       ...omit(options, maptilerBaseOptionsKeys),
-      offset: options.offset ?? [0, DEFAULT_OFFSET_Y[sizeKey]],
+      // custom-element markers get no automatic offset — their geometry is unknown
+      offset: options.offset ?? (options.element ? undefined : getShapeAnchorOffset(options.shape ?? DEFAULT_SHAPE, sizeKey)),
     } as MarkerOptions;
 
     const element = options.element ?? createMarkerElement(options);
@@ -129,14 +116,32 @@ export class Marker extends maplibregl.Marker {
 
     this[MarkerElementSymbol] = element;
 
-    this.scaleVector = Array.from(options.scale ?? [1, 1]) as Vector2;
-    this.outerColor = options.outerColor;
-    this.innerColor = options.innerColor;
-    this.contentColor = options.contentColor;
-    this.outlineColor = options.outlineColor;
-    this.outline = options.outline;
-    this.title = options.title;
-    this.markerRotation = options.rotation;
+    // custom elements skip createMarkerElement, so seed their style variables here
+    if (options.element) applyMarkerStyleVariables(options.element, options);
+
+    this.managesOffset = !options.offset && !options.element;
+
+    this.props = {
+      shape: options.shape,
+      size: options.size,
+      scale: Array.from(options.scale ?? [1, 1]) as Vector2,
+      shadow: options.shadow,
+      color: options.color,
+      outerColor: options.outerColor,
+      innerColor: options.innerColor,
+      contentColor: options.contentColor,
+      outlineColor: options.outlineColor,
+      outline: options.outline,
+      opacity: options.opacity,
+      title: options.title,
+      content: options.content,
+      htmlAttributes: options.htmlAttributes,
+      rotation: options.rotation,
+      debug: options.debug,
+      priority: options.priority,
+    };
+
+    if (typeof options.priority === "number") element.style.zIndex = String(options.priority);
 
     this.options = options;
   }
@@ -156,24 +161,53 @@ export class Marker extends maplibregl.Marker {
   }
 
   /**
-   * Enqueues a single property update and schedules a DOM flush on the next
+   * Recomputes the shape anchor offset on the parent MapLibre marker so the
+   * shape's visual tip stays on the lngLat. No-op when the user supplied an
+   * explicit `offset` or a custom `element`.
+   */
+  private applyShapeAnchorOffset(): void {
+    if (!this.managesOffset) return;
+    this.setOffset(getShapeAnchorOffset(this.props.shape ?? DEFAULT_SHAPE, this.props.size ?? DEFAULT_SIZE));
+  }
+
+  /**
+   * Records a property's new value and schedules a DOM flush on the next
    * animation frame via {@link MarkerManager}.
    * @param prop - The element property to update.
    * @param value - The new value for the property.
    */
-  private cueMarkerElementUpdate(prop: keyof MapTilerMarkerElementProps, value: MapTilerMarkerElementProps[keyof MapTilerMarkerElementProps]) {
-    this[CuedUpdatesSymbol].set(prop, value);
+  private setProp<K extends keyof MapTilerMarkerElementProps>(prop: K, value: MapTilerMarkerElementProps[K]): void {
+    this.props[prop] = value;
+    this[PendingUpdatesSymbol][prop] = value;
     MarkerManager.addMarkerUpdateToQueue(this);
   }
 
   /**
-   * Applies all cued property updates to the marker element and clears the
-   * queue. Called by {@link MarkerManager} on the next animation frame.
+   * Applies all pending property updates to the marker element and clears
+   * the batch. Called by {@link MarkerManager} on the next animation frame.
    */
   [FlushDOMUpdatesSymbol](): void {
-    if (this[CuedUpdatesSymbol].size === 0) return;
-    updateMarkerElement(this[MarkerElementSymbol], this[CuedUpdatesSymbol]);
-    this[CuedUpdatesSymbol].clear();
+    const pending = this[PendingUpdatesSymbol];
+    if (Object.keys(pending).length === 0) return;
+    updateMarkerElement(this[MarkerElementSymbol], pending, this.getCurrentStyleId());
+    this[PendingUpdatesSymbol] = {};
+  }
+
+  /** Returns the style id of the map this marker is on, or `undefined` when detached. */
+  private getCurrentStyleId(): string | undefined {
+    const map = MarkerManager.getMap(this);
+    return map ? MarkerManager.getMapStyleId(map) : undefined;
+  }
+
+  /**
+   * Queues a re-resolution of the adaptive `color` against the current map
+   * style. Called by {@link MarkerManager} when the marker is registered and
+   * whenever the map style changes. No-op when the marker has no adaptive
+   * colour, or when an explicit `innerColor` pins the colour.
+   */
+  [RefreshAdaptiveColorSymbol](): void {
+    if (this.props.color === undefined || this.props.innerColor !== undefined) return;
+    this.setProp("color", this.props.color);
   }
 
   //#endregion
@@ -184,14 +218,32 @@ export class Marker extends maplibregl.Marker {
    * Sets the 2-D scale of the marker as `[x, y]`.
    * @param scaleVector - Scale factors for the x and y axes.
    */
-  setScale(scaleVector: [number, number]) {
-    this.cueMarkerElementUpdate("scale", scaleVector);
-    this.scaleVector = scaleVector;
+  setScale(scaleVector: Vector2) {
+    this.setProp("scale", scaleVector);
   }
 
-  /** Returns the current 2-D scale, or `undefined` if never set. */
+  /** Returns the current 2-D scale. Defaults to `[1, 1]`. */
   getScale() {
-    return this.scaleVector;
+    return this.props.scale;
+  }
+
+  /**
+   * Sets the marker shape. Rebuilds the marker SVG in place, migrating the
+   * current content (title / image / element) to the new shape's geometry.
+   *
+   * Has no visible effect on markers constructed with a custom `element`,
+   * or while the size is `xs` (the dot rendering has no shape) — in the
+   * latter case the shape is applied when the size next changes.
+   * @param shape - Shape key (`rounded` | `circle` | `bubble-circle` | `bubble-square` | `square` | `bulb` | `squircle` | `shield`).
+   */
+  setShape(shape: MapTilerMarkerOptions["shape"]) {
+    this.setProp("shape", shape);
+    this.applyShapeAnchorOffset();
+  }
+
+  /** Returns the current shape, or `undefined` if never set. */
+  getShape() {
+    return this.props.shape;
   }
 
   /**
@@ -199,13 +251,13 @@ export class Marker extends maplibregl.Marker {
    * @param size - T-shirt size key (`xs` | `s` | `m` | `l` | `xl`).
    */
   setSize(size: MapTilerMarkerOptions["size"]) {
-    this.cueMarkerElementUpdate("size", size);
-    this.size = size;
+    this.setProp("size", size);
+    this.applyShapeAnchorOffset();
   }
 
   /** Returns the current size, or `undefined` if never explicitly set. */
   getSize() {
-    return this.size;
+    return this.props.size;
   }
 
   /**
@@ -214,13 +266,12 @@ export class Marker extends maplibregl.Marker {
    *   `undefined` to remove the shadow.
    */
   setShadow(shadow: MapTilerMarkerOptions["shadow"]) {
-    this.cueMarkerElementUpdate("shadow", shadow);
-    this.shadow = shadow;
+    this.setProp("shadow", shadow);
   }
 
   /** Returns the current shadow preset, or `undefined` if none is set. */
   getShadow() {
-    return this.shadow;
+    return this.props.shadow;
   }
 
   /**
@@ -228,27 +279,60 @@ export class Marker extends maplibregl.Marker {
    * @param color - Any valid CSS colour string.
    */
   setOuterColor(color: MapTilerMarkerOptions["outerColor"]) {
-    this.cueMarkerElementUpdate("outerColor", color);
-    this.outerColor = color;
+    this.setProp("outerColor", color);
   }
 
   /** Returns the current outer body colour. */
   getOuterColor() {
-    return this.outerColor;
+    return this.props.outerColor;
   }
 
   /**
-   * Sets the fill colour of the inner area of the marker.
+   * Sets the adaptive colour of the marker. The inner (background) colour is
+   * resolved against the current map style and re-resolved on style changes.
+   * Clears any explicit `innerColor` so adaptation takes effect immediately.
+   * @param color - Built-in palette name (`"blue"` | `"red"` | `"green"`), a
+   *   custom `AdaptiveColor` definition, or `undefined` to remove.
+   */
+  setColor(color: MapTilerMarkerOptions["color"]) {
+    this.props.innerColor = undefined;
+    // an innerColor queued earlier in the same tick would override this batch
+    delete this[PendingUpdatesSymbol].innerColor;
+    this.setProp("color", color);
+  }
+
+  /** Returns the current adaptive colour (name or definition), or `undefined` if none is set. */
+  getColor() {
+    return this.props.color;
+  }
+
+  /**
+   * Sets an explicit fill colour for the inner area of the marker.
+   * Takes precedence over the adaptive `color` and disables adaptation while
+   * set; passing `undefined` re-enables the adaptive colour if one exists.
    * @param color - Any valid CSS colour string.
    */
   setInnerColor(color: MapTilerMarkerOptions["innerColor"]) {
-    this.cueMarkerElementUpdate("innerColor", color);
-    this.innerColor = color;
+    if (color === undefined && this.props.color !== undefined) {
+      this.props.innerColor = undefined;
+      this.setProp("color", this.props.color); // resume adaptation
+      return;
+    }
+    this.setProp("innerColor", color);
   }
 
-  /** Returns the current inner area colour. */
+  /**
+   * Returns the inner area colour currently in effect: the explicit
+   * `innerColor` when set, otherwise the adaptive `color` resolved against
+   * the current map style, otherwise `undefined` (default colour applies).
+   */
   getInnerColor() {
-    return this.innerColor;
+    if (this.props.innerColor !== undefined) return this.props.innerColor;
+    if (this.props.color !== undefined) {
+      const adaptive = resolveAdaptiveColor(this.props.color);
+      if (adaptive) return getAdaptiveBgColor(adaptive, this.getCurrentStyleId() ?? "");
+    }
+    return undefined;
   }
 
   /**
@@ -256,13 +340,12 @@ export class Marker extends maplibregl.Marker {
    * @param color - Any valid CSS colour string.
    */
   setContentColor(color: MapTilerMarkerOptions["contentColor"]) {
-    this.cueMarkerElementUpdate("contentColor", color);
-    this.contentColor = color;
+    this.setProp("contentColor", color);
   }
 
   /** Returns the current content colour. */
   getContentColor() {
-    return this.contentColor;
+    return this.props.contentColor;
   }
 
   /**
@@ -271,13 +354,12 @@ export class Marker extends maplibregl.Marker {
    * @param color - Any valid CSS colour string.
    */
   setOutlineColor(color: MapTilerMarkerOptions["outlineColor"]) {
-    this.cueMarkerElementUpdate("outlineColor", color);
-    this.outlineColor = color;
+    this.setProp("outlineColor", color);
   }
 
   /** Returns the current outline stroke colour. */
   getOutlineColor() {
-    return this.outlineColor;
+    return this.props.outlineColor;
   }
 
   /**
@@ -286,27 +368,69 @@ export class Marker extends maplibregl.Marker {
    *   explicit pixel width, or `undefined` to remove the outline.
    */
   setOutline(outline: MapTilerMarkerOptions["outline"]) {
-    this.cueMarkerElementUpdate("outline", outline);
-    this.outline = outline;
+    this.setProp("outline", outline);
   }
 
   /** Returns the current outline value (`true`, a pixel width, or `undefined`). */
   getOutline() {
-    return this.outline;
+    return this.props.outline;
   }
 
   /**
-   * Sets the text content displayed inside the marker.
-   * @param title - Label string, or `undefined` to clear.
+   * Sets the `title` attribute on the marker's root element (native tooltip).
+   * @param title - Tooltip string, or `undefined` to remove the attribute.
    */
   setTitle(title: MapTilerMarkerOptions["title"]) {
-    this.cueMarkerElementUpdate("title", title);
-    this.title = title;
+    this.setProp("title", title);
   }
 
   /** Returns the current title string. */
   getTitle() {
-    return this.title;
+    return this.props.title;
+  }
+
+  /**
+   * Sets the text content displayed inside the marker body.
+   * @param content - Label string, or `undefined` to clear.
+   */
+  setContent(content: MapTilerMarkerOptions["content"]) {
+    this.setProp("content", content);
+  }
+
+  /** Returns the current content string. */
+  getContent() {
+    return this.props.content;
+  }
+
+  /**
+   * Sets the rendering priority. Numeric values are applied as `z-index` on
+   * the marker element, so higher-priority markers stack above lower ones.
+   * Expression-form priorities are stored but only take effect once the
+   * collision engine resolves them.
+   * @param priority - Numeric priority, a MapLibre-style expression, or
+   *   `undefined` to restore DOM-order stacking.
+   */
+  setPriority(priority: MapTilerMarkerOptions["priority"]) {
+    this.setProp("priority", priority);
+  }
+
+  /** Returns the current rendering priority, or `undefined` if never set. */
+  getPriority() {
+    return this.props.priority;
+  }
+
+  /**
+   * Shows or hides the debug overlay, which renders the marker's bounding
+   * box and center point on top of the marker element.
+   * @param debug - `true` to show the overlay, `false`/`undefined` to hide it.
+   */
+  setDebug(debug: MapTilerMarkerOptions["debug"]) {
+    this.setProp("debug", debug);
+  }
+
+  /** Returns whether the debug overlay is currently enabled. */
+  getDebug() {
+    return this.props.debug ?? false;
   }
 
   /**
@@ -318,8 +442,7 @@ export class Marker extends maplibregl.Marker {
    * @param rotation - Clockwise rotation in degrees.
    */
   override setRotation(rotation: number): this {
-    this.cueMarkerElementUpdate("rotation", rotation);
-    this.markerRotation = rotation;
+    this.setProp("rotation", rotation);
     return this;
   }
 
@@ -328,7 +451,7 @@ export class Marker extends maplibregl.Marker {
    * @returns Rotation in degrees; `0` if never set.
    */
   override getRotation(): number {
-    return this.markerRotation ?? 0;
+    return this.props.rotation ?? 0;
   }
 
   //#endregion
@@ -351,7 +474,12 @@ export class Marker extends maplibregl.Marker {
    * @returns `this` for chaining.
    */
   override remove(): this {
-    MarkerManager.deregister(this);
+    if (MarkerManager.getMap(this)) {
+      MarkerManager.deregister(this);
+    } else {
+      // never registered (added via addTo() directly) — plain MapLibre removal
+      super.remove();
+    }
     return this;
   }
 

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -34,6 +34,7 @@ const maptilerBaseOptionsKeys = [
   "userData",
   "collisionBehaviour",
   "collisionRadius",
+  "rotation",
 ] as const;
 
 /**
@@ -121,7 +122,7 @@ export class Marker extends maplibregl.Marker {
     const element = options.element ?? createMarkerElement(options);
 
     super({
-      element: options.element ?? wrap(element),
+      element,
       ...superOptions,
       ...maplibreMarkerConstructorOverrides,
     });

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -1,15 +1,15 @@
 import type { Marker } from "./Marker";
 import type { Map as SDKMap } from "../Map";
-import { DetachFromDOMSymbol, FlushDOMUpdatesSymbol } from "./marker-symbols";
+import { DetachFromDOMSymbol, FlushDOMUpdatesSymbol, RefreshAdaptiveColorSymbol } from "./marker-symbols";
 
 /**
- * @class MarkerManagerFactory
+ * @class MarkerManagerImpl
  * @description This singleton is used to batch marker updates and flush them to the DOM in a
  * single animation frame to avoid multiple separate attribute writes
  * It is not exposed as a public API and only used internally in the `Map` and `Marker` classes.
  * It _may_ be used by multiple Maps.
  */
-class MarkerManagerFactory {
+class MarkerManagerImpl {
   //#region State
 
   // the markers that require updates
@@ -25,6 +25,10 @@ class MarkerManagerFactory {
   // Lookup in the opposite direction, gets the markers for a given map.
   // When a map is removed from the page the WeakMap clears the state, so no manual clean up needed.
   private readonly mapIndex = new WeakMap<SDKMap, Map<string, Marker>>();
+
+  // Last style id seen per map — used to skip redundant adaptive-colour
+  // refreshes, since `styledata` fires many times per style load.
+  private readonly lastStyleId = new WeakMap<SDKMap, string | undefined>();
 
   //#endregion
 
@@ -47,9 +51,28 @@ class MarkerManagerFactory {
     if (!index) {
       index = new Map();
       this.mapIndex.set(map, index);
+      // re-resolve adaptive marker colours whenever the map's style changes.
+      // The listener lives on the map itself, so it is released with the map.
+      map.on("styledata", () => {
+        this.refreshAdaptiveColors(map);
+      });
     }
 
     return index;
+  }
+
+  // queues an adaptive-colour re-resolution for every marker of a map,
+  // skipping when the style id has not actually changed
+  private refreshAdaptiveColors(map: SDKMap): void {
+    const styleId = this.getMapStyleId(map);
+    if (this.lastStyleId.get(map) === styleId) return;
+    this.lastStyleId.set(map, styleId);
+
+    const index = this.mapIndex.get(map);
+    if (!index) return;
+    for (const marker of index.values()) {
+      marker[RefreshAdaptiveColorSymbol]();
+    }
   }
 
   //#endregion
@@ -63,6 +86,10 @@ class MarkerManagerFactory {
     this.getOrCreateIndex(map).set(marker.id, marker);
 
     marker.addTo(map);
+
+    // adaptive colours could only resolve to `base` before the marker had a
+    // map — re-resolve against this map's style
+    marker[RefreshAdaptiveColorSymbol]();
   }
 
   // unregisters a Marker that no longer needs to be managed.
@@ -84,22 +111,14 @@ class MarkerManagerFactory {
     if (marker) this.deregister(marker);
   }
 
-  // removes all markers or a specified list of markers with IDs from a map
+  // removes all markers, or a specified list of markers by ID, from a map
   deregisterAll(map: SDKMap, ids?: string[]): void {
     const index = this.mapIndex.get(map);
     if (!index) return;
-    if (ids) {
-      for (const id of ids) {
-        const marker = index.get(id);
-        if (marker) this.deregister(marker);
-      }
-    } else {
-      for (const marker of index.values()) {
-        this.markerMap.delete(marker);
-        this.cancelCuedUpdatesForMarker(marker);
-        marker[DetachFromDOMSymbol]();
-      }
-      index.clear();
+    // copy before iterating — deregister mutates the index
+    const markers = ids ? ids.map((id) => index.get(id)) : [...index.values()];
+    for (const marker of markers) {
+      if (marker) this.deregister(marker);
     }
   }
 
@@ -110,6 +129,20 @@ class MarkerManagerFactory {
   // gets the map a marker belongs to
   getMap(marker: Marker): SDKMap | undefined {
     return this.markerMap.get(marker);
+  }
+
+  /**
+   * Returns the id of the map's current style (e.g. `"streets-v4-dark"`), or
+   * `undefined` when it cannot be determined (custom style spec / URL).
+   * Falls back to the raw stylesheet's `id` field, since the id is not part
+   * of the serialized `StyleSpecification` returned by `map.getStyle()`.
+   */
+  getMapStyleId(map: SDKMap): string | undefined {
+    const requestedId = map.getStyleId();
+    if (requestedId) return requestedId;
+
+    const stylesheet = map.style.stylesheet as { id?: unknown } | undefined;
+    return typeof stylesheet?.id === "string" ? stylesheet.id : undefined;
   }
 
   // gets the markers for a given map
@@ -153,4 +186,4 @@ class MarkerManagerFactory {
   //#endregion
 }
 
-export const MarkerManager = new MarkerManagerFactory();
+export const MarkerManager = new MarkerManagerImpl();

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -18,7 +18,7 @@ class MarkerManagerFactory {
   // the current rAF ID
   private animationFrameID: number | null = null;
 
-  // A WeakMap to store which Marker belongs to whcih Map.
+  // A WeakMap to store which Marker belongs to which Map.
   // When a map is removed from the page the WeakMap clears the state, so no manual clean up needed.
   private readonly markerMap = new WeakMap<Marker, SDKMap>();
 

--- a/src/Marker/index.ts
+++ b/src/Marker/index.ts
@@ -1,1 +1,4 @@
 export * from "./Marker";
+export * from "./types";
+export * from "./marker-content-registry";
+export * from "./marker-adaptive-colors";

--- a/src/Marker/marker-adaptive-colors.ts
+++ b/src/Marker/marker-adaptive-colors.ts
@@ -108,6 +108,7 @@ function normalizeStyleKey(styleId: string): string {
 export function getAdaptiveBgColor(color: AdaptiveColor, styleId: string): string {
   const bgColors: Record<string, string | undefined> = color.bgColors;
   const key = normalizeStyleKey(styleId);
+  // this is dirty but it's the only way to implement it for now...
   const referenceKey = key.split("-")[0];
   return bgColors[key] ?? bgColors[referenceKey] ?? color.bgColors.base;
 }

--- a/src/Marker/marker-adaptive-colors.ts
+++ b/src/Marker/marker-adaptive-colors.ts
@@ -1,0 +1,115 @@
+import { defaultReferenceStyleMap } from "@maptiler/client";
+
+//#region Types
+
+/**
+ * Unversioned reference-style key, matching the reference styles of
+ * `MapStyle` from `@maptiler/client` (e.g. `MapStyle.STREETS` → `"streets"`).
+ */
+export type ReferenceStyleKey = Lowercase<keyof typeof defaultReferenceStyleMap>;
+
+/**
+ * Style key an adaptive colour can target: an unversioned reference-style id,
+ * optionally with a variant suffix (e.g. `"streets"`, `"streets-dark"`).
+ * Versioned style ids (`"streets-v4-dark"`) are normalised to this form by
+ * {@link getAdaptiveBgColor}.
+ */
+export type AdaptiveStyleKey = ReferenceStyleKey | `${ReferenceStyleKey}-${string}`;
+
+/** A named colour with per-map-style background variants. */
+export type AdaptiveColor = {
+  /** Human-readable display name. */
+  name: string;
+  /**
+   * Background colour per map style. `base` doubles as the fallback for
+   * styles without a dedicated entry.
+   */
+  bgColors: { base: string } & Partial<Record<AdaptiveStyleKey, string>>;
+};
+
+//#endregion
+
+//#region Palette
+
+export const ADAPTIVE_COLORS = {
+  blue: {
+    name: "Blue",
+    bgColors: {
+      base: "hsl(223, 100%, 65%)",
+      "base-dark": "hsl(223, 100%, 75%)",
+      streets: "hsl(215, 100%, 45%)",
+      "streets-dark": "hsl(215, 100%, 65%)",
+      hybrid: "hsl(210, 100%, 45%)",
+      dataviz: "hsl(208, 100%, 55%)",
+      "dataviz-dark": "hsl(208, 100%, 65%)",
+      topo: "hsl(215, 100%, 55%)",
+    },
+  },
+  red: {
+    name: "Red",
+    bgColors: {
+      base: "hsl(358, 100%, 65%)",
+      "base-dark": "hsl(358, 100%, 75%)",
+      streets: "hsl(350, 100%, 45%)",
+      "streets-dark": "hsl(350, 100%, 55%)",
+      hybrid: "hsl(0, 100%, 45%)",
+      dataviz: "hsl(3, 100%, 55%)",
+      "dataviz-dark": "hsl(3, 100%, 65%)",
+      topo: "hsl(5, 100%, 45%)",
+    },
+  },
+  green: {
+    name: "Green",
+    bgColors: {
+      base: "hsl(145, 100%, 30%)",
+      "base-dark": "hsl(145, 100%, 40%)",
+      streets: "hsl(149, 100%, 35%)",
+      "streets-dark": "hsl(149, 100%, 45%)",
+      hybrid: "hsl(155, 100%, 40%)",
+      dataviz: "hsl(160, 100%, 35%)",
+      "dataviz-dark": "hsl(160, 100%, 45%)",
+      topo: "hsl(145, 100%, 25%)",
+    },
+  },
+} satisfies Record<string, AdaptiveColor>;
+
+/** Name of a built-in adaptive colour. */
+export type AdaptiveColorName = keyof typeof ADAPTIVE_COLORS;
+
+//#endregion
+
+//#region Resolution
+
+/**
+ * Resolves a marker `color` option value to its {@link AdaptiveColor}
+ * definition: built-in palette names are looked up, definitions pass through.
+ * Returns `undefined` for names unknown at runtime (untyped callers).
+ */
+export function resolveAdaptiveColor(color: AdaptiveColorName | AdaptiveColor): AdaptiveColor | undefined {
+  return typeof color === "string" ? (ADAPTIVE_COLORS[color] as AdaptiveColor | undefined) : color;
+}
+
+/**
+ * Normalises a style id to an {@link AdaptiveStyleKey} by dropping the
+ * version segment — e.g. `"streets-v4-dark"` → `"streets-dark"`.
+ */
+function normalizeStyleKey(styleId: string): string {
+  return styleId.toLowerCase().replace(/-v\d+/, "");
+}
+
+/**
+ * Resolves the background colour of an adaptive colour for a given map style.
+ *
+ * Lookup order: exact style key (version stripped, variant kept) → reference
+ * style without variant → `base`.
+ * @param color - Adaptive colour definition.
+ * @param styleId - Style id, versioned (`"streets-v4-dark"`) or not (`"streets-dark"`).
+ */
+export function getAdaptiveBgColor(color: AdaptiveColor, styleId: string): string {
+  const bgColors: Record<string, string | undefined> = color.bgColors;
+  const key = normalizeStyleKey(styleId);
+  const referenceKey = key.split("-")[0];
+  return bgColors[key] ?? bgColors[referenceKey] ?? color.bgColors.base;
+}
+
+//#endregion

--- a/src/Marker/marker-content-registry.ts
+++ b/src/Marker/marker-content-registry.ts
@@ -1,14 +1,6 @@
 //#region Types
 
 /**
- * Produces the SVG glyph for a built-in content type.
- * The returned element must be designed in a {@link GLYPH_VIEWBOX_SIZE}-unit
- * square — it is scaled and centered into the shape's content circle.
- * Leave `fill` unset to inherit the marker content color.
- */
-export type MarkerContentTypeFactory = () => SVGElement;
-
-/**
  * Produces marker content from template parameters.
  * May return a string (rendered as marker text), an `HTMLElement` (rendered
  * in a foreignObject sized to the content circle), or an `SVGElement`
@@ -21,43 +13,12 @@ export type MarkerTemplateFactory = (params?: Record<string, number | string>) =
 
 //#region Registries
 
-/** Design-space size (units) for content-type and SVG template glyphs. */
+/** Design-space size (units) for SVG template glyphs. */
 export const GLYPH_VIEWBOX_SIZE = 24;
 
-const SVG_NS = "http://www.w3.org/2000/svg";
-
-function glyphPath(d: string): SVGElement {
-  const path = document.createElementNS(SVG_NS, "path");
-  path.setAttribute("d", d);
-  return path;
-}
-
-const CONTENT_TYPES = new Map<string, MarkerContentTypeFactory>([
-  ["star", () => glyphPath("M12 2 L14.9 8.6 L22 9.2 L16.6 13.9 L18.2 21 L12 17.3 L5.8 21 L7.4 13.9 L2 9.2 L9.1 8.6 Z")],
-  [
-    "heart",
-    () => glyphPath("M12 21 C 5 14, 2 10.5, 2 7.5 C 2 4.5, 4.5 3, 6.75 3 C 8.75 3, 10.75 4, 12 6 C 13.25 4, 15.25 3, 17.25 3 C 19.5 3, 22 4.5, 22 7.5 C 22 10.5, 19 14, 12 21 Z"),
-  ],
-  ["plus", () => glyphPath("M10 4 H14 V10 H20 V14 H14 V20 H10 V14 H4 V10 H10 Z")],
-  ["dot", () => glyphPath("M12 5 A7 7 0 1 0 12 19 A7 7 0 1 0 12 5 Z")],
-]);
+// TODO(icons): built-in icon registry backing the marker `icon` option.
 
 const TEMPLATES = new Map<string, MarkerTemplateFactory>();
-
-/**
- * Registers (or overrides) a built-in content type usable via the marker
- * `contentType` option.
- * @param name - Identifier passed as `contentType`.
- * @param factory - Glyph factory, see {@link MarkerContentTypeFactory}.
- */
-export function registerMarkerContentType(name: string, factory: MarkerContentTypeFactory): void {
-  CONTENT_TYPES.set(name, factory);
-}
-
-/** Returns the factory for a content type, or `undefined` when unknown. */
-export function getMarkerContentType(name: string): MarkerContentTypeFactory | undefined {
-  return CONTENT_TYPES.get(name);
-}
 
 /**
  * Registers (or overrides) a template factory usable via the marker

--- a/src/Marker/marker-content-registry.ts
+++ b/src/Marker/marker-content-registry.ts
@@ -1,0 +1,77 @@
+//#region Types
+
+/**
+ * Produces the SVG glyph for a built-in content type.
+ * The returned element must be designed in a {@link GLYPH_VIEWBOX_SIZE}-unit
+ * square — it is scaled and centered into the shape's content circle.
+ * Leave `fill` unset to inherit the marker content color.
+ */
+export type MarkerContentTypeFactory = () => SVGElement;
+
+/**
+ * Produces marker content from template parameters.
+ * May return a string (rendered as marker text), an `HTMLElement` (rendered
+ * in a foreignObject sized to the content circle), or an `SVGElement`
+ * (treated like a content-type glyph, designed in a
+ * {@link GLYPH_VIEWBOX_SIZE}-unit square).
+ */
+export type MarkerTemplateFactory = (params?: Record<string, number | string>) => string | HTMLElement | SVGElement;
+
+//#endregion
+
+//#region Registries
+
+/** Design-space size (units) for content-type and SVG template glyphs. */
+export const GLYPH_VIEWBOX_SIZE = 24;
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function glyphPath(d: string): SVGElement {
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute("d", d);
+  return path;
+}
+
+const CONTENT_TYPES = new Map<string, MarkerContentTypeFactory>([
+  ["star", () => glyphPath("M12 2 L14.9 8.6 L22 9.2 L16.6 13.9 L18.2 21 L12 17.3 L5.8 21 L7.4 13.9 L2 9.2 L9.1 8.6 Z")],
+  [
+    "heart",
+    () => glyphPath("M12 21 C 5 14, 2 10.5, 2 7.5 C 2 4.5, 4.5 3, 6.75 3 C 8.75 3, 10.75 4, 12 6 C 13.25 4, 15.25 3, 17.25 3 C 19.5 3, 22 4.5, 22 7.5 C 22 10.5, 19 14, 12 21 Z"),
+  ],
+  ["plus", () => glyphPath("M10 4 H14 V10 H20 V14 H14 V20 H10 V14 H4 V10 H10 Z")],
+  ["dot", () => glyphPath("M12 5 A7 7 0 1 0 12 19 A7 7 0 1 0 12 5 Z")],
+]);
+
+const TEMPLATES = new Map<string, MarkerTemplateFactory>();
+
+/**
+ * Registers (or overrides) a built-in content type usable via the marker
+ * `contentType` option.
+ * @param name - Identifier passed as `contentType`.
+ * @param factory - Glyph factory, see {@link MarkerContentTypeFactory}.
+ */
+export function registerMarkerContentType(name: string, factory: MarkerContentTypeFactory): void {
+  CONTENT_TYPES.set(name, factory);
+}
+
+/** Returns the factory for a content type, or `undefined` when unknown. */
+export function getMarkerContentType(name: string): MarkerContentTypeFactory | undefined {
+  return CONTENT_TYPES.get(name);
+}
+
+/**
+ * Registers (or overrides) a template factory usable via the marker
+ * `template` / `templateParams` options.
+ * @param name - Identifier passed as `template`.
+ * @param factory - Template factory, see {@link MarkerTemplateFactory}.
+ */
+export function registerMarkerTemplate(name: string, factory: MarkerTemplateFactory): void {
+  TEMPLATES.set(name, factory);
+}
+
+/** Returns the factory for a template, or `undefined` when unknown. */
+export function getMarkerTemplate(name: string): MarkerTemplateFactory | undefined {
+  return TEMPLATES.get(name);
+}
+
+//#endregion

--- a/src/Marker/marker-dom-utils.ts
+++ b/src/Marker/marker-dom-utils.ts
@@ -1,4 +1,4 @@
-import type { MapTilerMarkerBaseOptions, MapTilerMarkerOptions, HTMLElementUpdateCue, MapTilerMarkerSize } from "./types";
+import type { MapTilerMarkerBaseOptions, MapTilerMarkerOptions, PendingMarkerUpdates, MapTilerMarkerSize } from "./types";
 import {
   DEFAULT_CONTENT_COLOR,
   DEFAULT_INNER_COLOR,
@@ -11,6 +11,8 @@ import {
   SIZE_PX,
   type ShapeDescriptor,
 } from "./marker-svg-config";
+import { getMarkerContentType, getMarkerTemplate, GLYPH_VIEWBOX_SIZE } from "./marker-content-registry";
+import { getAdaptiveBgColor, resolveAdaptiveColor } from "./marker-adaptive-colors";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -28,10 +30,30 @@ function svgEl<K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameM
 const CUSTOM_ELEMENT_CLASSNAME = "marker-transform-wrapper";
 
 /**
+ * Seeds the CSS custom properties that drive marker colors and shadow.
+ * Used on the generated wrapper, and on user-supplied custom elements so
+ * their styles can consume the same variables.
+ * @param element - Element to receive the custom properties.
+ * @param options - Resolved marker options.
+ */
+export function applyMarkerStyleVariables(element: HTMLElement | SVGElement, options: MapTilerMarkerOptions): void {
+  // the adaptive `color` can only resolve to its `base` value here — the
+  // marker has no map yet; MarkerManager re-resolves on registration
+  const adaptive = options.color !== undefined ? resolveAdaptiveColor(options.color) : undefined;
+  const innerColor = options.innerColor ?? (adaptive ? getAdaptiveBgColor(adaptive, "") : undefined) ?? DEFAULT_INNER_COLOR;
+
+  element.style.setProperty("--marker-outer-color", options.outerColor ?? DEFAULT_OUTER_COLOR);
+  element.style.setProperty("--marker-inner-color", innerColor);
+  element.style.setProperty("--marker-content-color", options.contentColor ?? DEFAULT_CONTENT_COLOR);
+  element.style.setProperty("--marker-outline-color", options.outlineColor ?? "transparent");
+  element.style.setProperty("--marker-shadow", options.shadow ? SHADOW_FILTER[options.shadow] : "none");
+}
+
+/**
  * Creates the root wrapper `div` for a marker, seeding all CSS custom
  * properties and the initial `data-*` attributes used by {@link applyTransform}.
  * @param options - Resolved marker options.
- * @returns The wrapper element, ready to be passed to {@link wrap}.
+ * @returns The outer root element, ready to be handed to MapLibre.
  */
 export function createMarkerElement(options: MapTilerMarkerOptions): HTMLDivElement {
   const shapeKey = options.shape ?? DEFAULT_SHAPE;
@@ -40,16 +62,12 @@ export function createMarkerElement(options: MapTilerMarkerOptions): HTMLDivElem
   // wrapper: carries transform, opacity, and all CSS custom properties
   const wrapper = document.createElement("div");
   wrapper.className = CUSTOM_ELEMENT_CLASSNAME;
-  wrapper.style.transformOrigin = "center bottom";
+  // scale/rotate around the shape's anchor point so it stays on the lngLat
+  wrapper.style.transformOrigin = SHAPES[shapeKey].anchor === "center" ? "center" : "center bottom";
   wrapper.dataset.markerShape = shapeKey;
   wrapper.dataset.markerSize = sizeKey;
 
-  // First pass CSS custom properties used for styling internally
-  wrapper.style.setProperty("--marker-outer-color", options.outerColor ?? DEFAULT_OUTER_COLOR);
-  wrapper.style.setProperty("--marker-inner-color", options.innerColor ?? DEFAULT_INNER_COLOR);
-  wrapper.style.setProperty("--marker-content-color", options.contentColor ?? DEFAULT_CONTENT_COLOR);
-  wrapper.style.setProperty("--marker-outline-color", options.outlineColor ?? "transparent");
-  wrapper.style.setProperty("--marker-shadow", options.shadow ? SHADOW_FILTER[options.shadow] : "none");
+  applyMarkerStyleVariables(wrapper, options);
 
   const [sx, sy] = options.scale ?? [1, 1];
 
@@ -64,17 +82,21 @@ export function createMarkerElement(options: MapTilerMarkerOptions): HTMLDivElem
   if (options.opacity !== undefined) wrapper.style.opacity = String(options.opacity);
   if (options.name) wrapper.classList.add(options.name);
 
+  wrapper.appendChild(sizeKey === "xs" ? buildDotSvg() : buildShapeSvg(shapeKey, sizeKey, options));
+
+  if (options.debug) applyDebug(wrapper, true);
+
+  const outer = wrap(wrapper);
+  if (options.title) outer.setAttribute("title", options.title);
+
   if (options.htmlAttributes) {
     for (const [attr, val] of Object.entries(options.htmlAttributes)) {
-      wrapper.setAttribute(attr, String(val));
+      outer.setAttribute(attr, String(val));
     }
   }
 
-  wrapper.appendChild(sizeKey === "xs" ? buildDotSvg() : buildShapeSvg(shapeKey, sizeKey, options));
-
-  forwardPointerEvents(wrapper);
-
-  return wrap(wrapper);
+  forwardPointerEvents(outer);
+  return outer;
 }
 
 //#endregion
@@ -84,72 +106,160 @@ export function createMarkerElement(options: MapTilerMarkerOptions): HTMLDivElem
 /**
  * Commits a batch of pending property updates onto a live marker element.
  * Called by `Marker[FlushDOMUpdatesSymbol]()` when there are pending updates.
- * @param element - The marker wrapper element (`.marker-scale-wrapper`).
- * @param props - Map of property keys to their new values.
+ * A key being present in `props` (even with an `undefined` value) means
+ * "apply this property".
+ * @param element - The marker's outer root element.
+ * @param props - Pending property updates.
+ * @param styleId - Current map style id, used to resolve the adaptive `color`.
  */
-export function updateMarkerElement(element: HTMLElement, props: HTMLElementUpdateCue): void {
-  for (const [prop, value] of props) {
-    if (prop === "outerColor") {
-      element.style.setProperty("--marker-outer-color", value as string);
-    }
+export function updateMarkerElement(element: HTMLElement, props: PendingMarkerUpdates, styleId?: string): void {
+  // `element` is the outer MapLibre-positioned container; all marker state
+  // (CSS custom properties, transform dataset, the SVG itself) lives on the
+  // inner transform wrapper. Updates must target the wrapper — writing to the
+  // outer element either gets masked by the wrapper's inline values (CSS vars)
+  // or clobbered by MapLibre (transform).
+  const wrapper = element.classList.contains(CUSTOM_ELEMENT_CLASSNAME) ? element : (element.querySelector<HTMLElement>(`.${CUSTOM_ELEMENT_CLASSNAME}`) ?? element);
 
-    if (prop === "innerColor") {
-      element.style.setProperty("--marker-inner-color", value as string);
-    }
+  if ("outerColor" in props) {
+    wrapper.style.setProperty("--marker-outer-color", props.outerColor ?? DEFAULT_OUTER_COLOR);
+  }
 
-    if (prop === "contentColor") {
-      element.style.setProperty("--marker-content-color", value as string);
-      const contentEl = element.querySelector(".marker-content");
-      if (contentEl) contentEl.setAttribute("fill", `var(--marker-content-color)`);
-    }
+  // before `innerColor`: an explicit innerColor in the same batch wins
+  if ("color" in props) {
+    const adaptive = props.color !== undefined ? resolveAdaptiveColor(props.color) : undefined;
+    wrapper.style.setProperty("--marker-inner-color", adaptive ? getAdaptiveBgColor(adaptive, styleId ?? "") : DEFAULT_INNER_COLOR);
+  }
 
-    if (prop === "outlineColor") {
-      element.style.setProperty("--marker-outline-color", value as string);
-    }
+  if ("innerColor" in props) {
+    wrapper.style.setProperty("--marker-inner-color", props.innerColor ?? DEFAULT_INNER_COLOR);
+  }
 
-    if (prop === "outline") {
-      const width = value === true ? DEFAULT_OUTLINE_WIDTH : (value as number);
-      const outerPath = element.querySelector<SVGPathElement>(".marker-outer");
+  if ("contentColor" in props) {
+    wrapper.style.setProperty("--marker-content-color", props.contentColor ?? DEFAULT_CONTENT_COLOR);
+    const contentEl = wrapper.querySelector(".marker-content");
+    if (contentEl) contentEl.setAttribute("fill", "var(--marker-content-color)");
+  }
+
+  if ("outlineColor" in props) {
+    wrapper.style.setProperty("--marker-outline-color", props.outlineColor ?? "transparent");
+  }
+
+  if ("outline" in props) {
+    const outerPath = wrapper.querySelector<SVGPathElement>(".marker-outer");
+    if (props.outline) {
+      const width = props.outline === true ? DEFAULT_OUTLINE_WIDTH : props.outline;
       outerPath?.setAttribute("stroke-width", String(width));
-    }
-
-    if (prop === "shadow") {
-      const filter = value ? SHADOW_FILTER[value as NonNullable<MapTilerMarkerBaseOptions["shadow"]>] : "none";
-      element.style.setProperty("--marker-shadow", filter);
-    }
-
-    if (prop === "opacity") {
-      element.style.opacity = String(value as number);
-    }
-
-    if (prop === "title") {
-      const contentEl = element.querySelector(".marker-content");
-      if (contentEl) contentEl.textContent = value as string;
-    }
-
-    if (prop === "htmlAttributes") {
-      const attrs = value as Record<string, string | number>;
-      for (const [attr, attrVal] of Object.entries(attrs)) {
-        element.setAttribute(attr, String(attrVal));
-      }
-    }
-
-    if (prop === "rotation") {
-      element.dataset.rotation = String(value as number);
-      applyTransform(element);
-    }
-
-    if (prop === "scale") {
-      const [x, y] = value as [number, number];
-      element.dataset.scaleX = String(x);
-      element.dataset.scaleY = String(y);
-      applyTransform(element);
-    }
-
-    if (prop === "size") {
-      applySize(element, value as MapTilerMarkerSize);
+    } else {
+      outerPath?.removeAttribute("stroke-width");
     }
   }
+
+  if ("shadow" in props) {
+    wrapper.style.setProperty("--marker-shadow", props.shadow ? SHADOW_FILTER[props.shadow] : "none");
+  }
+
+  if ("opacity" in props) {
+    wrapper.style.opacity = props.opacity === undefined ? "" : String(props.opacity);
+  }
+
+  if ("title" in props) {
+    // native tooltip on the outer root element — not the rendered content
+    if (props.title) {
+      element.setAttribute("title", props.title);
+    } else {
+      element.removeAttribute("title");
+    }
+  }
+
+  if ("content" in props) {
+    applyContent(wrapper, props.content);
+  }
+
+  if ("htmlAttributes" in props && props.htmlAttributes) {
+    for (const [attr, attrVal] of Object.entries(props.htmlAttributes)) {
+      element.setAttribute(attr, String(attrVal));
+    }
+  }
+
+  if ("rotation" in props) {
+    wrapper.dataset.rotation = String(props.rotation ?? 0);
+    applyTransform(wrapper);
+  }
+
+  if ("scale" in props) {
+    const [x, y] = props.scale ?? [1, 1];
+    wrapper.dataset.scaleX = String(x);
+    wrapper.dataset.scaleY = String(y);
+    applyTransform(wrapper);
+  }
+
+  if ("size" in props) {
+    applySize(wrapper, props.size ?? DEFAULT_SIZE);
+  }
+
+  if ("shape" in props) {
+    applyShape(wrapper, props.shape ?? DEFAULT_SHAPE);
+  }
+
+  if ("debug" in props) {
+    applyDebug(wrapper, Boolean(props.debug));
+  }
+
+  if ("priority" in props) {
+    // z-index must sit on the outer MapLibre-positioned element (the
+    // stacking sibling), not the inner wrapper — unlike the other props.
+    // Expression-form priorities are resolved by the collision engine, not here.
+    if (typeof props.priority === "number") {
+      element.style.zIndex = String(props.priority);
+    } else {
+      element.style.removeProperty("z-index");
+    }
+  }
+}
+
+//#endregion
+
+//#region getShapeSvg
+
+const SHAPE_SVG_CLASSNAME = "marker-shape";
+
+/** Returns the shape SVG of a marker wrapper, or `null` when the marker was constructed at `xs` (dot only). */
+function getShapeSvg(wrapper: HTMLElement): SVGSVGElement | null {
+  return wrapper.querySelector<SVGSVGElement>(`svg.${SHAPE_SVG_CLASSNAME}`);
+}
+
+//#endregion
+
+//#region applyContent
+
+/**
+ * Applies a text-content update to a live marker.
+ * Only text content is managed here: an existing text label is updated or
+ * removed; non-text content (glyph / image / element) is replaced by a text
+ * label only when a non-empty value is given, never removed by a clear.
+ * @param wrapper - The marker wrapper element.
+ * @param value - Label string, or `undefined` to clear an existing text label.
+ */
+function applyContent(wrapper: HTMLElement, value: string | undefined): void {
+  const svg = getShapeSvg(wrapper);
+  if (!svg) return;
+
+  const existing = svg.querySelector(".marker-content");
+
+  if (existing instanceof SVGTextElement) {
+    if (value) {
+      existing.textContent = value;
+    } else {
+      existing.remove();
+    }
+    return;
+  }
+
+  if (!value) return;
+
+  existing?.remove();
+  const shapeKey = (wrapper.dataset.markerShape ?? DEFAULT_SHAPE) as NonNullable<MapTilerMarkerBaseOptions["shape"]>;
+  appendTextContent(svg, value, SHAPES[shapeKey]);
 }
 
 //#endregion
@@ -163,29 +273,33 @@ export function updateMarkerElement(element: HTMLElement, props: HTMLElementUpda
  * @param size - The new size key.
  */
 function applySize(wrapper: HTMLElement, size: MapTilerMarkerSize): void {
-  const existingSvg = wrapper.querySelector("svg");
-  const wasXs = existingSvg?.classList.contains("marker-dot") ?? false;
+  const shapeSvg = getShapeSvg(wrapper);
+  const dotSvg = wrapper.querySelector<SVGSVGElement>("svg.marker-dot");
 
   wrapper.dataset.markerSize = size;
 
   if (size === "xs") {
-    existingSvg?.remove();
-    wrapper.appendChild(buildDotSvg());
+    // hide (don't remove) the shape SVG so its content/outline survive the
+    // round-trip back out of xs
+    if (shapeSvg) shapeSvg.style.display = "none";
+    if (!dotSvg) wrapper.appendChild(buildDotSvg());
     return;
   }
 
-  if (wasXs) {
-    // XS → non-XS: rebuild shape SVG (content not reconstructed here)
+  dotSvg?.remove();
+
+  if (!shapeSvg) {
+    // marker was constructed at xs — no shape SVG to restore, build fresh
+    // (content not reconstructed here)
     const shapeKey = (wrapper.dataset.markerShape ?? DEFAULT_SHAPE) as NonNullable<MapTilerMarkerBaseOptions["shape"]>;
-    existingSvg?.remove();
     wrapper.appendChild(buildShapeSvg(shapeKey, size));
     return;
   }
 
-  // non-XS → non-XS: just resize the existing SVG
-  if (!existingSvg) return;
+  // restore (if hidden) and resize via the viewBox aspect ratio
+  shapeSvg.style.display = "block";
 
-  const viewBoxRaw = existingSvg.getAttribute("viewBox");
+  const viewBoxRaw = shapeSvg.getAttribute("viewBox");
 
   if (!viewBoxRaw) return;
   const parts = viewBoxRaw.split(" ").map(Number);
@@ -194,8 +308,170 @@ function applySize(wrapper: HTMLElement, size: MapTilerMarkerSize): void {
 
   const h = SIZE_PX[size];
   const w = h * (viewBoxW / viewBoxH);
-  existingSvg.setAttribute("width", String(w));
-  existingSvg.setAttribute("height", String(h));
+  shapeSvg.setAttribute("width", String(w));
+  shapeSvg.setAttribute("height", String(h));
+}
+
+//#endregion
+
+//#region applyDebug
+
+const DEBUG_COLOR = "#ff00ff";
+
+/**
+ * Attaches or removes the debug overlay: a dashed outline around the marker
+ * element's bounding box plus a crosshair and dot at its center. Lives
+ * inside the transform wrapper, so it follows scale and rotation.
+ * @param wrapper - The marker wrapper element.
+ * @param enabled - Whether the overlay should be shown.
+ */
+function applyDebug(wrapper: HTMLElement, enabled: boolean): void {
+  // may be called with either the inner transform wrapper (creation) or the
+  // outer MapLibre-positioned element (updates) — always attach to the inner
+  // wrapper, and never touch the outer element's positioning.
+  const target = wrapper.classList.contains(CUSTOM_ELEMENT_CLASSNAME) ? wrapper : wrapper.querySelector<HTMLElement>(`.${CUSTOM_ELEMENT_CLASSNAME}`);
+  if (!target) return;
+
+  const existing = target.querySelector(".marker-debug");
+
+  if (!enabled) {
+    existing?.remove();
+    return;
+  }
+
+  if (existing) return;
+
+  // anchor the absolutely-positioned overlay to the wrapper
+  target.style.position = "relative";
+  target.appendChild(buildDebugOverlay());
+}
+
+/**
+ * Builds the debug overlay SVG (bounding box, center crosshair, center dot).
+ * All strokes use `vector-effect: non-scaling-stroke`, so the overlay renders
+ * at a constant on-screen weight no matter how far the wrapper is CSS-scaled.
+ */
+function buildDebugOverlay(): SVGSVGElement {
+  const svg = svgEl("svg");
+  svg.classList.add("marker-debug");
+  svg.style.position = "absolute";
+  svg.style.inset = "0";
+  svg.style.width = "100%";
+  svg.style.height = "100%";
+  svg.style.overflow = "visible";
+  svg.style.pointerEvents = "none";
+
+  const box = svgEl("rect");
+  box.setAttribute("x", "0");
+  box.setAttribute("y", "0");
+  box.setAttribute("width", "100%");
+  box.setAttribute("height", "100%");
+  box.setAttribute("fill", "none");
+  box.setAttribute("stroke-dasharray", "0.1");
+  box.setAttribute("stroke-width", "0.1");
+  svg.appendChild(box);
+
+  const hLine = svgEl("line");
+  hLine.setAttribute("x1", "0");
+  hLine.setAttribute("y1", "50%");
+  hLine.setAttribute("x2", "100%");
+  hLine.setAttribute("y2", "50%");
+  hLine.setAttribute("opacity", "0.5");
+  hLine.setAttribute("stroke-width", "0.1");
+  svg.appendChild(hLine);
+
+  const vLine = svgEl("line");
+  vLine.setAttribute("x1", "50%");
+  vLine.setAttribute("y1", "0");
+  vLine.setAttribute("x2", "50%");
+  vLine.setAttribute("y2", "100%");
+  vLine.setAttribute("opacity", "0.5");
+  vLine.setAttribute("stroke-width", "0.1");
+  svg.appendChild(vLine);
+
+  // zero-length round-capped line renders as a fixed-size dot — unlike a
+  // filled circle, its stroke is exempt from scaling via non-scaling-stroke
+  const dot = svgEl("line");
+  dot.setAttribute("x1", "50%");
+  dot.setAttribute("y1", "50%");
+  dot.setAttribute("x2", "50%");
+  dot.setAttribute("y2", "50%");
+  dot.setAttribute("stroke-linecap", "round");
+  dot.setAttribute("stroke-width", "1");
+  svg.appendChild(dot);
+
+  for (const part of [box, hLine, vLine, dot]) {
+    part.setAttribute("stroke", DEBUG_COLOR);
+    if (!part.hasAttribute("stroke-width")) part.setAttribute("stroke-width", "1");
+    part.setAttribute("vector-effect", "non-scaling-stroke");
+  }
+
+  return svg;
+}
+
+//#endregion
+
+//#region applyShape
+
+/**
+ * Swaps the marker body to a new shape, rebuilding the SVG in place and
+ * migrating any existing content (text / image / element) to the new
+ * shape's content geometry.
+ * @param wrapper - The marker wrapper element.
+ * @param shape - The new shape key.
+ */
+function applyShape(wrapper: HTMLElement, shape: NonNullable<MapTilerMarkerBaseOptions["shape"]>): void {
+  wrapper.dataset.markerShape = shape;
+  wrapper.style.transformOrigin = SHAPES[shape].anchor === "center" ? "center" : "center bottom";
+
+  // the shape SVG exists even at xs size (hidden behind the dot); a marker
+  // constructed at xs has none, and gets its SVG built on the next size change
+  const existingSvg = getShapeSvg(wrapper);
+  if (!existingSvg) return;
+
+  // while hidden at xs the build size is nominal — restoring recomputes it
+  const sizeKey = (wrapper.dataset.markerSize ?? DEFAULT_SIZE) as MapTilerMarkerSize;
+  const newSvg = buildShapeSvg(shape, sizeKey === "xs" ? DEFAULT_SIZE : sizeKey);
+
+  // preserve outline width (stored as an attribute on the outer path)
+  const strokeWidth = existingSvg.querySelector(".marker-outer")?.getAttribute("stroke-width");
+  if (strokeWidth) newSvg.querySelector(".marker-outer")?.setAttribute("stroke-width", strokeWidth);
+
+  migrateContent(existingSvg, newSvg, SHAPES[shape]);
+  newSvg.style.display = existingSvg.style.display; // stay hidden while at xs
+  existingSvg.replaceWith(newSvg);
+}
+
+/**
+ * Re-creates the `.marker-content` layer from `oldSvg` inside `newSvg`,
+ * repositioned for the new shape's content geometry.
+ */
+function migrateContent(oldSvg: SVGSVGElement, newSvg: SVGSVGElement, shape: ShapeDescriptor): void {
+  const content = oldSvg.querySelector(".marker-content");
+  if (!content) return;
+
+  if (content instanceof SVGGElement) {
+    // contentType / SVG-template glyph: move it and refit to the new content circle
+    content.setAttribute("transform", glyphTransform(shape));
+    newSvg.appendChild(content);
+    return;
+  }
+
+  if (content instanceof SVGImageElement) {
+    const href = content.getAttribute("href");
+    if (href) appendImageContent(newSvg, href, shape);
+    return;
+  }
+
+  if (content instanceof SVGForeignObjectElement) {
+    const child = content.firstElementChild;
+    if (child instanceof HTMLElement || child instanceof SVGElement) appendElementContent(newSvg, child, shape);
+    return;
+  }
+
+  if (content instanceof SVGTextElement && content.textContent) {
+    appendTextContent(newSvg, content.textContent, shape);
+  }
 }
 
 //#endregion
@@ -217,7 +493,10 @@ function buildDotSvg(): SVGSVGElement {
   circle.setAttribute("cx", "2.5");
   circle.setAttribute("cy", "2.5");
   circle.setAttribute("r", "2.5");
+  circle.setAttribute("stroke-width", "1");
+  circle.setAttribute("vector-effect", "non-scaling-stroke");
   circle.style.fill = "var(--marker-inner-color)";
+  circle.style.stroke = "var(--marker-outer-color)";
   svg.appendChild(circle);
 
   return svg;
@@ -240,6 +519,7 @@ function buildShapeSvg(shapeKey: NonNullable<MapTilerMarkerBaseOptions["shape"]>
   const widthPx = heightPx * (viewBoxW / viewBoxH);
 
   const svg = svgEl("svg");
+  svg.classList.add(SHAPE_SVG_CLASSNAME);
   svg.setAttribute("viewBox", `0 0 ${String(viewBoxW)} ${String(viewBoxH)}`);
   svg.setAttribute("width", String(widthPx));
   svg.setAttribute("height", String(heightPx));
@@ -250,20 +530,44 @@ function buildShapeSvg(shapeKey: NonNullable<MapTilerMarkerBaseOptions["shape"]>
   const outerPath = svgEl("path");
   outerPath.classList.add("marker-outer");
   outerPath.setAttribute("d", shapeDesc.outerPath);
+  // stroke width in screen pixels — viewBox unit scales vary wildly between shapes
+  outerPath.setAttribute("vector-effect", "non-scaling-stroke");
   outerPath.style.fill = "var(--marker-outer-color)";
   outerPath.style.stroke = "var(--marker-outline-color)";
   if (options) applyOutlineToPath(outerPath, options);
   svg.appendChild(outerPath);
 
-  const innerPath = svgEl("path");
-  innerPath.classList.add("marker-inner");
-  innerPath.setAttribute("d", shapeDesc.innerPath);
-  innerPath.style.fill = "var(--marker-inner-color)";
-  svg.appendChild(innerPath);
+  const innerEl = buildInnerElement(shapeDesc.inner);
+  innerEl.classList.add("marker-inner");
+  innerEl.style.fill = "var(--marker-inner-color)";
+  svg.appendChild(innerEl);
 
   if (options) appendContent(svg, options, shapeDesc);
 
   return svg;
+}
+
+//#endregion
+
+//#region buildInnerElement
+
+/**
+ * Builds the inner (fill) element of a shape — a `<circle>` or a `<path>`
+ * depending on the shape descriptor.
+ * @param inner - Inner region descriptor.
+ */
+function buildInnerElement(inner: ShapeDescriptor["inner"]): SVGCircleElement | SVGPathElement {
+  if (inner.type === "circle") {
+    const circle = svgEl("circle");
+    circle.setAttribute("cx", String(inner.cx));
+    circle.setAttribute("cy", String(inner.cy));
+    circle.setAttribute("r", String(inner.r));
+    return circle;
+  }
+
+  const path = svgEl("path");
+  path.setAttribute("d", inner.d);
+  return path;
 }
 
 //#endregion
@@ -303,60 +607,207 @@ function applyOutlineToPath(path: SVGPathElement, options: MapTilerMarkerOptions
 
 //#region appendContent
 
+let clipIdCounter = 0;
+
 /**
- * Appends the content layer to a shape SVG. Priority: `url` → `element` → `title`.
- * Renders nothing when none of those fields is provided.
+ * Appends the content layer to a shape SVG.
+ * Priority: `contentType` → `url` → `template` → `element` → `content` text.
+ * Renders nothing when none of those fields is provided
+ * ({@link MarkerContentNone} without `content`).
  * @param svg - Target SVG element.
  * @param options - Marker options carrying the content variant.
- * @param shape - Shape descriptor supplying layout constants (`contentCenter`, `contentAreaHeight`).
+ * @param shape - Shape descriptor supplying the content circle and optional image clip region.
  */
 function appendContent(svg: SVGSVGElement, options: MapTilerMarkerOptions, shape: ShapeDescriptor): void {
-  const [cx, cy] = shape.contentCenter;
-  const fontSize = shape.contentAreaHeight * 0.53;
+  if ("contentType" in options && options.contentType) {
+    appendTypeContent(svg, options.contentType, shape);
+    return;
+  }
 
   if ("url" in options && options.url) {
-    const size = shape.contentAreaHeight * 0.6;
-    const img = svgEl("image");
-    img.classList.add("marker-content");
-    img.setAttribute("href", options.url);
-    img.setAttribute("x", String(cx - size / 2));
-    img.setAttribute("y", String(cy - size / 2));
-    img.setAttribute("width", String(size));
-    img.setAttribute("height", String(size));
-    img.setAttribute("preserveAspectRatio", "xMidYMid meet");
-    svg.appendChild(img);
+    appendImageContent(svg, options.url, shape);
+    return;
+  }
+
+  if ("template" in options && options.template) {
+    appendTemplateContent(svg, options.template, options.templateParams, shape);
     return;
   }
 
   if ("element" in options && options.element) {
-    const size = shape.contentAreaHeight * 0.7;
-    const fo = svgEl("foreignObject");
-    fo.classList.add("marker-content");
-    fo.setAttribute("x", String(cx - size / 2));
-    fo.setAttribute("y", String(cy - size / 2));
-    fo.setAttribute("width", String(size));
-    fo.setAttribute("height", String(size));
-    fo.appendChild(options.element);
-    svg.appendChild(fo);
+    appendElementContent(svg, options.element, shape);
     return;
   }
 
-  if (options.title) {
-    const text = svgEl("text");
-    text.classList.add("marker-content");
-    text.setAttribute("x", String(cx));
-    text.setAttribute("y", String(cy));
-    text.setAttribute("text-anchor", "middle");
-    text.setAttribute("dominant-baseline", "central");
-    text.setAttribute("font-family", "Inter, system-ui, sans-serif");
-    text.setAttribute("font-weight", "700");
-    text.setAttribute("font-size", String(fontSize));
-    text.style.fill = "var(--marker-content-color)";
-    text.style.userSelect = "none";
-    text.style.fontVariantNumeric = "tabular-nums";
-    text.textContent = options.title;
-    svg.appendChild(text);
+  if (options.content) {
+    appendTextContent(svg, options.content, shape);
   }
+}
+
+/**
+ * Appends a built-in content-type glyph, scaled into the content circle.
+ * Unknown identifiers warn and render nothing.
+ */
+function appendTypeContent(svg: SVGSVGElement, contentType: string, shape: ShapeDescriptor): void {
+  const factory = getMarkerContentType(contentType);
+
+  if (!factory) {
+    console.warn(`Unknown marker contentType "${contentType}" — register it with registerMarkerContentType().`);
+    return;
+  }
+
+  appendGlyphContent(svg, factory(), shape);
+}
+
+/**
+ * Appends content produced by a registered template factory. Strings render
+ * as marker text, HTML elements in a foreignObject, SVG elements as glyphs.
+ * Unknown identifiers warn and render nothing.
+ */
+function appendTemplateContent(svg: SVGSVGElement, template: string, params: Record<string, number | string> | undefined, shape: ShapeDescriptor): void {
+  const factory = getMarkerTemplate(template);
+
+  if (!factory) {
+    console.warn(`Unknown marker template "${template}" — register it with registerMarkerTemplate().`);
+    return;
+  }
+
+  const produced = factory(params);
+
+  if (typeof produced === "string") {
+    appendTextContent(svg, produced, shape);
+  } else if (produced instanceof SVGElement) {
+    appendGlyphContent(svg, produced, shape);
+  } else {
+    appendElementContent(svg, produced, shape);
+  }
+}
+
+/**
+ * Wraps an SVG glyph (designed in a {@link GLYPH_VIEWBOX_SIZE}-unit square)
+ * in a `<g>` scaled and centered on the shape's content circle.
+ */
+function appendGlyphContent(svg: SVGSVGElement, glyph: SVGElement, shape: ShapeDescriptor): void {
+  const g = svgEl("g");
+  g.classList.add("marker-content");
+  g.setAttribute("fill", "var(--marker-content-color)");
+  g.setAttribute("transform", glyphTransform(shape));
+  g.appendChild(glyph);
+  svg.appendChild(g);
+}
+
+/** Transform that fits the glyph design box into the shape's content circle. */
+function glyphTransform(shape: ShapeDescriptor): string {
+  const { cx, cy, r } = shape.content;
+  const scale = (r * 1.4) / GLYPH_VIEWBOX_SIZE;
+  const half = (GLYPH_VIEWBOX_SIZE / 2) * scale;
+  return `translate(${String(cx - half)}, ${String(cy - half)}) scale(${String(scale)})`;
+}
+
+/**
+ * Appends image content, clipped to the shape's `imageClip` region when
+ * defined (full-bleed) or to the circular content area otherwise.
+ */
+function appendImageContent(svg: SVGSVGElement, href: string, shape: ShapeDescriptor): void {
+  const img = svgEl("image");
+  img.classList.add("marker-content");
+  img.setAttribute("href", href);
+  img.setAttribute("preserveAspectRatio", "xMidYMid slice");
+
+  if (shape.imageClip) {
+    // full-bleed: image fills the inner body, clipped to its outline
+    const clipId = `maptiler-marker-clip-${String(++clipIdCounter)}`;
+    const clip = svgEl("clipPath");
+    clip.setAttribute("id", clipId);
+
+    const clipShape = svgEl("path");
+    clipShape.setAttribute("d", shape.imageClip.d);
+    clip.appendChild(clipShape);
+    svg.appendChild(clip);
+
+    img.setAttribute("clip-path", `url(#${clipId})`);
+    img.setAttribute("x", String(shape.imageClip.x));
+    img.setAttribute("y", String(shape.imageClip.y));
+    img.setAttribute("width", String(shape.imageClip.w));
+    img.setAttribute("height", String(shape.imageClip.h));
+  } else {
+    // no dedicated clip region: fill the circular content area
+    const { cx, cy, r } = shape.content;
+    img.setAttribute("clip-path", appendContentClip(svg, shape));
+    img.setAttribute("x", String(cx - r));
+    img.setAttribute("y", String(cy - r));
+    img.setAttribute("width", String(r * 2));
+    img.setAttribute("height", String(r * 2));
+  }
+
+  svg.appendChild(img);
+
+  // re-paint the pointer/tail over the image so it stays in the inner color
+  if (shape.pointerPath) {
+    const pointer = svgEl("path");
+    pointer.setAttribute("d", shape.pointerPath);
+    pointer.style.fill = "var(--marker-inner-color)";
+    svg.appendChild(pointer);
+  }
+}
+
+/**
+ * Appends a `<clipPath>` for the shape's content circle and returns its
+ * `url(#…)` reference — used to hide content that overflows the circle.
+ */
+function appendContentClip(svg: SVGSVGElement, shape: ShapeDescriptor): string {
+  const { cx, cy, r } = shape.content;
+
+  const clipId = `maptiler-marker-clip-${String(++clipIdCounter)}`;
+  const clip = svgEl("clipPath");
+  clip.setAttribute("id", clipId);
+
+  const clipShape = svgEl("circle");
+  clipShape.setAttribute("cx", String(cx));
+  clipShape.setAttribute("cy", String(cy));
+  clipShape.setAttribute("r", String(r));
+  clip.appendChild(clipShape);
+  svg.appendChild(clip);
+
+  return `url(#${clipId})`;
+}
+
+/** Appends a foreignObject wrapping `element`, sized to the content circle. */
+function appendElementContent(svg: SVGSVGElement, element: HTMLElement | SVGElement, shape: ShapeDescriptor): void {
+  const { cx, cy, r } = shape.content;
+  const size = r * 1.4;
+
+  const fo = svgEl("foreignObject");
+  fo.classList.add("marker-content");
+  fo.setAttribute("x", String(cx - size / 2));
+  fo.setAttribute("y", String(cy - size / 2));
+  fo.setAttribute("width", String(size));
+  fo.setAttribute("height", String(size));
+  fo.setAttribute("clip-path", appendContentClip(svg, shape));
+  fo.appendChild(element);
+  svg.appendChild(fo);
+}
+
+/** Appends a text label centred on the content circle. */
+function appendTextContent(svg: SVGSVGElement, title: string, shape: ShapeDescriptor): void {
+  const { cx, cy, r } = shape.content;
+  const fontSize = r * 1.4;
+
+  const text = svgEl("text");
+  text.classList.add("marker-content");
+  text.setAttribute("clip-path", appendContentClip(svg, shape));
+  text.setAttribute("x", String(cx));
+  text.setAttribute("y", String(cy));
+  text.setAttribute("text-anchor", "middle");
+  text.setAttribute("dominant-baseline", "central");
+  text.setAttribute("font-family", "Inter, system-ui, sans-serif");
+  text.setAttribute("font-weight", "700");
+  text.setAttribute("font-size", String(fontSize));
+  text.style.fill = "var(--marker-content-color)";
+  text.style.userSelect = "none";
+  text.style.fontVariantNumeric = "tabular-nums";
+  text.textContent = title;
+  svg.appendChild(text);
 }
 
 //#endregion
@@ -364,12 +815,11 @@ function appendContent(svg: SVGSVGElement, options: MapTilerMarkerOptions, shape
 //#region wrap
 
 /**
- * Wraps `element` in a new container element.
+ * Wraps `element` in a new container `div`.
  * MapLibre requires a single root element per marker; this outer wrapper
  * lets MapLibre apply its own transforms without interfering with the
  * inner wrapper's scale/rotation transform.
  * @param element - Element to wrap.
- * @param wrapperType - Tag name for the container. Defaults to `"div"`.
  */
 export function wrap(element: HTMLElement) {
   const div = document.createElement("div");
@@ -381,12 +831,13 @@ export function wrap(element: HTMLElement) {
 
 //#region forwardPointerEvents
 /**
- * @param parent: The top level marker element
- * @description Prevents maplibre element events from firing when the parent event is clicked but the child is not
- * eg whitespace withing the ML element.
+ * Prevents MapLibre element events from firing when the outer root element
+ * is clicked but the inner wrapper is not — e.g. whitespace within the
+ * MapLibre-positioned container.
+ * @param parent - The marker's outer root element.
  */
 export function forwardPointerEvents(parent: HTMLElement) {
-  const child = parent.querySelector(CUSTOM_ELEMENT_CLASSNAME) as HTMLElement | null;
+  const child = parent.querySelector<HTMLElement>(`.${CUSTOM_ELEMENT_CLASSNAME}`);
   if (child) {
     parent.style.pointerEvents = "none";
     child.style.pointerEvents = "auto";

--- a/src/Marker/marker-dom-utils.ts
+++ b/src/Marker/marker-dom-utils.ts
@@ -25,6 +25,8 @@ function svgEl<K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameM
 
 //#region createMarkerElement
 
+const CUSTOM_ELEMENT_CLASSNAME = "marker-transform-wrapper";
+
 /**
  * Creates the root wrapper `div` for a marker, seeding all CSS custom
  * properties and the initial `data-*` attributes used by {@link applyTransform}.
@@ -37,7 +39,7 @@ export function createMarkerElement(options: MapTilerMarkerOptions): HTMLDivElem
 
   // wrapper: carries transform, opacity, and all CSS custom properties
   const wrapper = document.createElement("div");
-  wrapper.className = "marker-scale-wrapper";
+  wrapper.className = CUSTOM_ELEMENT_CLASSNAME;
   wrapper.style.transformOrigin = "center bottom";
   wrapper.dataset.markerShape = shapeKey;
   wrapper.dataset.markerSize = sizeKey;
@@ -69,7 +71,10 @@ export function createMarkerElement(options: MapTilerMarkerOptions): HTMLDivElem
   }
 
   wrapper.appendChild(sizeKey === "xs" ? buildDotSvg() : buildShapeSvg(shapeKey, sizeKey, options));
-  return wrapper;
+
+  forwardPointerEvents(wrapper);
+
+  return wrap(wrapper);
 }
 
 //#endregion
@@ -366,10 +371,25 @@ function appendContent(svg: SVGSVGElement, options: MapTilerMarkerOptions, shape
  * @param element - Element to wrap.
  * @param wrapperType - Tag name for the container. Defaults to `"div"`.
  */
-export function wrap(element: HTMLElement, wrapperType: keyof HTMLElementTagNameMap = "div") {
-  const div = document.createElement(wrapperType);
+export function wrap(element: HTMLElement) {
+  const div = document.createElement("div");
   div.appendChild(element);
   return div;
 }
 
+//#endregion
+
+//#region forwardPointerEvents
+/**
+ * @param parent: The top level marker element
+ * @description Prevents maplibre element events from firing when the parent event is clicked but the child is not
+ * eg whitespace withing the ML element.
+ */
+export function forwardPointerEvents(parent: HTMLElement) {
+  const child = parent.querySelector(CUSTOM_ELEMENT_CLASSNAME) as HTMLElement | null;
+  if (child) {
+    parent.style.pointerEvents = "none";
+    child.style.pointerEvents = "auto";
+  }
+}
 //#endregion

--- a/src/Marker/marker-dom-utils.ts
+++ b/src/Marker/marker-dom-utils.ts
@@ -11,7 +11,7 @@ import {
   SIZE_PX,
   type ShapeDescriptor,
 } from "./marker-svg-config";
-import { getMarkerContentType, getMarkerTemplate, GLYPH_VIEWBOX_SIZE } from "./marker-content-registry";
+import { getMarkerTemplate, GLYPH_VIEWBOX_SIZE } from "./marker-content-registry";
 import { getAdaptiveBgColor, resolveAdaptiveColor } from "./marker-adaptive-colors";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
@@ -451,7 +451,7 @@ function migrateContent(oldSvg: SVGSVGElement, newSvg: SVGSVGElement, shape: Sha
   if (!content) return;
 
   if (content instanceof SVGGElement) {
-    // contentType / SVG-template glyph: move it and refit to the new content circle
+    // icon / SVG-template glyph: move it and refit to the new content circle
     content.setAttribute("transform", glyphTransform(shape));
     newSvg.appendChild(content);
     return;
@@ -611,16 +611,16 @@ let clipIdCounter = 0;
 
 /**
  * Appends the content layer to a shape SVG.
- * Priority: `contentType` → `url` → `template` → `element` → `content` text.
+ * Priority: `icon` → `url` → `template` → `element` → `content` text.
  * Renders nothing when none of those fields is provided
- * ({@link MarkerContentNone} without `content`).
+ * ({@link MarkerContentTypeNone} without `content`).
  * @param svg - Target SVG element.
  * @param options - Marker options carrying the content variant.
  * @param shape - Shape descriptor supplying the content circle and optional image clip region.
  */
 function appendContent(svg: SVGSVGElement, options: MapTilerMarkerOptions, shape: ShapeDescriptor): void {
-  if ("contentType" in options && options.contentType) {
-    appendTypeContent(svg, options.contentType, shape);
+  if ("icon" in options && options.icon) {
+    appendIconContent(svg, options.icon, shape);
     return;
   }
 
@@ -645,18 +645,15 @@ function appendContent(svg: SVGSVGElement, options: MapTilerMarkerOptions, shape
 }
 
 /**
- * Appends a built-in content-type glyph, scaled into the content circle.
- * Unknown identifiers warn and render nothing.
+ * Placeholder for built-in icon content.
+ * TODO(icons): resolve the identifier to an icon glyph and append it scaled
+ * into the content circle. Renders nothing for now.
  */
-function appendTypeContent(svg: SVGSVGElement, contentType: string, shape: ShapeDescriptor): void {
-  const factory = getMarkerContentType(contentType);
-
-  if (!factory) {
-    console.warn(`Unknown marker contentType "${contentType}" — register it with registerMarkerContentType().`);
-    return;
-  }
-
-  appendGlyphContent(svg, factory(), shape);
+function appendIconContent(svg: SVGSVGElement, icon: string, shape: ShapeDescriptor): void {
+  // intentionally empty — icons not implemented yet
+  void svg;
+  void icon;
+  void shape;
 }
 
 /**

--- a/src/Marker/marker-svg-config.ts
+++ b/src/Marker/marker-svg-config.ts
@@ -2,14 +2,43 @@ import type { MapTilerMarkerBaseOptions } from "./types";
 
 //#region Types
 
+/** Inner (fill) region of a shape — either a circle or an arbitrary path. */
+export type ShapeInner = { type: "circle"; cx: number; cy: number; r: number } | { type: "path"; d: string };
+
+/**
+ * Clip region used when rendering full-bleed image content.
+ * `x`/`y`/`w`/`h` describe the bounding box of the clip path, used to size and position the image.
+ */
+export type ShapeImageClip = {
+  type: "path";
+  d: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+/** Circular content area in viewBox coordinates — anchors text, icons and (when no `imageClip`) images. */
+export type ShapeContent = { cx: number; cy: number; r: number };
+
 export type ShapeDescriptor = {
   viewBox: [number, number];
+  /** Which point of the shape sits on the marker's geographic location. */
+  anchor: "bottom" | "center";
+  /**
+   * Y coordinate (viewBox units) of the shape's visual bottom — the anchor
+   * point. Differs from the viewBox height when the shape has breathing room
+   * below the glyph (e.g. `rounded`, `circle`).
+   */
+  anchorY: number;
   outerPath: string;
-  innerPath: string;
-  /** Center of the content area in viewBox coordinates. */
-  contentCenter: [number, number];
-  /** Height of the body region (excluding pointer) — used to scale font size. */
-  contentAreaHeight: number;
+  inner: ShapeInner;
+  /** Circular content area used to place and scale text / icon / element content. */
+  content: ShapeContent;
+  /** When present, image content is clipped to this region (full-bleed) instead of the content circle. */
+  imageClip?: ShapeImageClip;
+  /** Pointer/tail sub-path re-painted in the inner color on top of clipped image content. */
+  pointerPath?: string;
 };
 
 //#endregion
@@ -34,65 +63,108 @@ export const SHADOW_FILTER: Record<NonNullable<MapTilerMarkerBaseOptions["shadow
 
 //#region Shapes
 
-// TODO: these will be updated when it comes to applying the presets.
 export const SHAPES: Record<NonNullable<MapTilerMarkerBaseOptions["shape"]>, ShapeDescriptor> = {
   rounded: {
-    viewBox: [110, 110],
-    outerPath: "M 20,0 H 90 A 20,20 0 0 1 110,20 V 90 A 20,20 0 0 1 90,110 H 20 A 20,20 0 0 1 0,90 V 20 A 20,20 0 0 1 20,0 Z",
-    innerPath: "M 20,10 H 90 A 10,10 0 0 1 100,20 V 90 A 10,10 0 0 1 90,100 H 20 A 10,10 0 0 1 10,90 V 20 A 10,10 0 0 1 20,10 Z",
-    contentCenter: [55, 55],
-    contentAreaHeight: 80,
+    viewBox: [100, 120],
+    anchor: "bottom",
+    anchorY: 107.4,
+    outerPath: "M50 4 C 24.6 4, 4 24.6, 4 50 C 4 70, 20 86, 40 104 C 45 108.5, 55 108.5, 60 104 C 80 86, 96 70, 96 50 C 96 24.6, 75.4 4, 50 4 Z",
+    inner: { type: "circle", cx: 50, cy: 50, r: 36 },
+    content: { cx: 50, cy: 50, r: 30 },
   },
   circle: {
-    viewBox: [110, 110],
-    outerPath: "M 55,0 A 55,55 0 0 1 110,55 A 55,55 0 0 1 55,110 A 55,55 0 0 1 0,55 A 55,55 0 0 1 55,0 Z",
-    innerPath: "M 55,10 A 45,45 0 0 1 100,55 A 45,45 0 0 1 55,100 A 45,45 0 0 1 10,55 A 45,45 0 0 1 55,10 Z",
-    contentCenter: [55, 55],
-    contentAreaHeight: 90,
+    viewBox: [100, 100],
+    anchor: "center",
+    anchorY: 96,
+    outerPath: "M50 4 A46 46 0 1 0 50 96 A46 46 0 1 0 50 4Z",
+    inner: { type: "circle", cx: 50, cy: 50, r: 38 },
+    content: { cx: 50, cy: 50, r: 31 },
   },
   "bubble-circle": {
-    viewBox: [110, 140],
-    outerPath: "M 55,0 A 55,55 0 0 1 110,55 A 55,55 0 0 1 85,101 L 55,140 L 25,101 A 55,55 0 0 1 0,55 A 55,55 0 0 1 55,0 Z",
-    innerPath: "M 55,10 A 45,45 0 0 1 100,55 A 45,45 0 0 1 76,95 L 55,128 L 34,95 A 45,45 0 0 1 10,55 A 45,45 0 0 1 55,10 Z",
-    contentCenter: [55, 55],
-    contentAreaHeight: 90,
+    viewBox: [17.828966, 19.942984],
+    anchor: "bottom",
+    anchorY: 19.942984,
+    outerPath:
+      "M 8.96061 0.00002 L 8.51408 0.00891 L 8.07590 0.03887 L 7.65676 0.08796 L 7.21043 0.16277 L 6.85625 0.23915 L 6.38942 0.36336 L 5.93003 0.51276 L 5.59118 0.64110 L 5.25784 0.78320 L 4.87784 0.96549 L 4.48139 1.18026 L 4.09635 1.41476 L 3.72363 1.66833 L 3.36411 1.94030 L 3.01869 2.23003 L 2.68825 2.53685 L 2.37393 2.85965 L 2.07627 3.19783 L 1.79597 3.55049 L 1.53369 3.91675 L 1.29013 4.29573 L 1.06597 4.68655 L 0.87234 5.06647 L 0.71622 5.41068 L 0.57497 5.76119 L 0.41009 6.23726 L 0.27249 6.72192 L 0.18747 7.09017 L 0.11530 7.48002 L 0.05637 7.90946 L 0.01830 8.34129 L 0.00110 8.77447 L 0.00477 9.20798 L 0.01883 9.49665 L 0.05733 9.92839 L 0.09461 10.21493 L 0.13863 10.48599 L 0.22039 10.88961 L 0.32080 11.28895 L 0.43961 11.68319 L 0.57656 12.07152 L 0.73140 12.45312 L 0.90387 12.82718 L 1.04814 13.10890 L 1.20236 13.38524 L 1.36626 13.65590 L 1.53963 13.92056 L 1.81690 14.30568 L 2.01289 14.55406 L 2.21750 14.79541 L 2.43051 15.02943 L 2.65168 15.25581 L 2.88697 15.47995 L 3.13667 15.70080 L 3.39439 15.91216 L 3.65977 16.11378 L 3.93245 16.30540 L 4.21204 16.48675 L 4.64359 16.73899 L 4.93888 16.89358 L 5.23979 17.03701 L 5.54596 17.16903 L 5.82390 17.27712 L 7.80853 19.41164 L 7.99798 19.60673 L 8.16715 19.75677 L 8.32194 19.86238 L 8.46830 19.92421 L 8.54017 19.93891 L 8.61215 19.94290 L 8.68499 19.93627 L 8.75942 19.91909 L 8.91603 19.85342 L 9.08791 19.74653 L 9.28099 19.59905 L 9.50120 19.41164 L 11.73651 17.37161 L 12.04726 17.26149 L 12.38379 17.12717 L 12.68810 16.99148 L 12.98703 16.84447 L 13.28019 16.68639 L 13.56724 16.51751 L 13.84780 16.33807 L 14.25570 16.04970 L 14.64698 15.73903 L 15.02042 15.40694 L 15.36332 15.06644 L 15.68185 14.71432 L 15.88362 14.47046 L 16.16984 14.09174 L 16.43564 13.69841 L 16.60112 13.42857 L 16.83119 13.01314 L 16.97214 12.72951 L 17.08611 12.47927 L 17.24234 12.09763 L 17.38066 11.70919 L 17.50082 11.31476 L 17.60258 10.91518 L 17.66007 10.64633 L 17.73059 10.23998 L 17.78352 9.81692 L 17.80791 9.52905 L 17.82712 9.09611 L 17.82547 8.66272 L 17.80295 8.22990 L 17.75957 7.79869 L 17.69531 7.37013 L 17.61714 6.97627 L 17.49109 6.47795 L 17.37772 6.10951 L 17.20189 5.62657 L 17.05184 5.27142 L 16.88645 4.92305 L 16.68489 4.54458 L 16.45382 4.15813 L 16.20359 3.78384 L 15.93490 3.42260 L 15.64844 3.07525 L 15.34490 2.74268 L 15.02497 2.42574 L 14.69503 2.12991 L 14.35087 1.85083 L 13.99336 1.58912 L 13.62336 1.34539 L 13.24174 1.12028 L 12.84936 0.91439 L 12.47170 0.73902 L 12.13627 0.60091 L 11.68083 0.43842 L 11.21722 0.30102 L 10.74675 0.18906 L 10.27074 0.10289 L 9.85116 0.04861 L 9.40662 0.01323 Z",
+    inner: { type: "circle", cx: 8.91, cy: 8.82, r: 7.23 },
+    content: { cx: 8.91, cy: 8.82, r: 5.75 },
   },
   "bubble-square": {
-    viewBox: [122.96108, 126.06905],
+    viewBox: [113.9009, 107.06401],
+    anchor: "bottom",
+    anchorY: 107.06401,
     outerPath:
-      "M 19.453125,0 C 8.677726,0 0,10.046094 0,22.527344 v 63.957031 c 0,12.473956 8.677426,22.527345 19.453125,22.527345 h 23.261719 l 12.401718,13.67578 c 4.170654,4.62119 5.628911,4.39488 10.506563,0 l 14.615157,-13.67578 h 23.257808 c 10.7754,0 19.45899,-10.046096 19.45899,-22.527345 l 0.006,-63.957031 C 122.96098,10.053387 114.28369,0 103.50199,0 Z",
-    innerPath:
-      "M 20.18,10.09 H 102.78 A 10.09,10.09 0 0 1 112.87,20.18 V 88.84 A 10.09,10.09 0 0 1 102.78,98.93 H 80.57 L 64.48,111.91 C 64.02,112.33 63.58,112.54 63.10,112.54 C 62.59,112.54 62.11,112.30 61.60,111.91 L 42.39,98.93 H 20.18 A 10.09,10.09 0 0 1 10.09,88.84 V 20.18 A 10.09,10.09 0 0 1 20.18,10.09 Z",
-    contentCenter: [61.66, 54.55],
-    contentAreaHeight: 98.93,
+      "M 18.224143,0 C 8.1279682,0 0,8.1279682 0,18.224143 v 54.672429 c 0,10.096174 8.1279682,18.224143 18.224143,18.224143 h 21.650068 l 4.022125,4.013227 c 0.05884,0.0721 0.128529,0.137435 0.195768,0.204665 l 6.362432,6.362433 c 0.06724,0.0672 0.132617,0.13693 0.204666,0.19577 l 4.35137,4.36027 c 1.075919,1.07592 2.803833,1.07591 3.879749,0 l 4.35137,-4.36027 c 0.07205,-0.0588 0.137421,-0.12852 0.204666,-0.19577 l 6.362433,-6.362433 c 0.06724,-0.0673 0.136925,-0.132615 0.195767,-0.204665 l 4.022125,-4.013227 H 95.67675 c 10.09618,0 18.22414,-8.127969 18.22414,-18.224143 V 18.224143 C 113.90089,8.1279682 105.77293,0 95.67675,0 Z",
+    inner: {
+      type: "path",
+      d: "m 18.224143,11.158728 c -4.105343,0 -7.065415,2.960073 -7.065415,7.065415 v 54.672429 c 0,4.105343 2.960071,7.065415 7.065415,7.065415 h 26.268393 l 7.688311,7.670513 0.04449,0.05339 4.725108,4.725107 4.725107,-4.725107 0.04449,-0.05339 7.68831,-7.670513 H 95.67675 c 4.105352,0 7.06542,-2.960066 7.06542,-7.065415 V 18.224143 c 0,-4.105348 -2.960068,-7.065415 -7.06542,-7.065415 z",
+    },
+    imageClip: {
+      type: "path",
+      d: "M 18.224143,11.158728 H 95.67675 A 7.065415,7.065415 0 0 1 102.74217,18.224143 V 72.896572 A 7.065415,7.065415 0 0 1 95.67675,79.961987 H 18.224143 A 7.065415,7.065415 0 0 1 11.158728,72.896572 V 18.224143 A 7.065415,7.065415 0 0 1 18.224143,11.158728 Z",
+      x: 11.158728,
+      y: 11.158728,
+      w: 91.583442,
+      h: 68.803259,
+    },
+    pointerPath: "m 44.492536,79.961987 7.688311,7.670513 0.04449,0.05339 4.725108,4.725107 4.725107,-4.725107 0.04449,-0.05339 7.68831,-7.670513 z",
+    content: { cx: 56.95, cy: 45.56, r: 26 },
   },
   square: {
-    viewBox: [110, 110],
-    outerPath: "M 0,0 H 110 V 110 H 0 Z",
-    innerPath: "M 10,10 H 100 V 100 H 10 Z",
-    contentCenter: [55, 55],
-    contentAreaHeight: 80,
+    viewBox: [100, 100],
+    anchor: "center",
+    anchorY: 96,
+    outerPath: "M 16,4 H 84 A 12,12 0 0 1 96,16 V 84 A 12,12 0 0 1 84,96 H 16 A 12,12 0 0 1 4,84 V 16 A 12,12 0 0 1 16,4 Z",
+    inner: { type: "path", d: "M 21,13 H 79 A 8,8 0 0 1 87,21 V 79 A 8,8 0 0 1 79,87 H 21 A 8,8 0 0 1 13,79 V 21 A 8,8 0 0 1 21,13 Z" },
+    imageClip: {
+      type: "path",
+      d: "M 21,13 H 79 A 8,8 0 0 1 87,21 V 79 A 8,8 0 0 1 79,87 H 21 A 8,8 0 0 1 13,79 V 21 A 8,8 0 0 1 21,13 Z",
+      x: 13,
+      y: 13,
+      w: 74,
+      h: 74,
+    },
+    content: { cx: 50, cy: 50, r: 30 },
   },
   bulb: {
-    viewBox: [110, 160],
-    outerPath: "M 55,5 C 85,5 105,25 105,55 C 105,85 85,100 70,110 C 60,120 55,160 55,160 C 55,160 50,120 40,110 C 25,100 5,85 5,55 C 5,25 25,5 55,5 Z",
-    innerPath: "M 55,15 C 80,15 95,30 95,55 C 95,80 78,93 65,103 C 58,115 55,150 55,150 C 55,150 52,115 45,103 C 32,93 15,80 15,55 C 15,30 30,15 55,15 Z",
-    contentCenter: [55, 55],
-    contentAreaHeight: 80,
+    viewBox: [100, 132],
+    anchor: "bottom",
+    anchorY: 128,
+    outerPath: "M 50,4 C 24.59,4 4,24.59 4,50 C 4,87.5 50,128 50,128 C 50,128 96,87.5 96,50 C 96,24.59 75.41,4 50,4 Z",
+    inner: { type: "circle", cx: 50, cy: 50, r: 34 },
+    content: { cx: 50, cy: 50, r: 28 },
   },
   squircle: {
-    viewBox: [110, 110],
-    outerPath: "M 55,0 C 97.35,0 110,12.65 110,55 C 110,97.35 97.35,110 55,110 C 12.65,110 0,97.35 0,55 C 0,12.65 12.65,0 55,0 Z",
-    innerPath: "M 55,10 C 89.65,10 100,20.35 100,55 C 100,89.65 89.65,100 55,100 C 20.35,100 10,89.65 10,55 C 10,20.35 20.35,10 55,10 Z",
-    contentCenter: [55, 55],
-    contentAreaHeight: 80,
+    viewBox: [100, 137],
+    anchor: "bottom",
+    anchorY: 133,
+    outerPath: "M 18,4 H 82 C 89.73,4 96,10.27 96,18 V 66 C 96,101.5 66,122 50,133 C 34,122 4,101.5 4,66 V 18 C 4,10.27 10.27,4 18,4 Z",
+    inner: { type: "path", d: "M 23,14 H 77 C 82,14 86,18 86,23 V 65 C 86,95 66,110 50,119 C 34,110 14,95 14,65 V 23 C 14,18 18,14 23,14 Z" },
+    imageClip: {
+      type: "path",
+      d: "M 23,14 H 77 C 82,14 86,18 86,23 V 65 C 86,95 66,110 50,119 C 34,110 14,95 14,65 V 23 C 14,18 18,14 23,14 Z",
+      x: 14,
+      y: 14,
+      w: 72,
+      h: 105,
+    },
+    content: { cx: 50, cy: 55, r: 34 },
   },
   shield: {
-    viewBox: [110, 130],
-    outerPath: "M 5,0 H 105 A 5,5 0 0 1 110,5 V 65 Q 110,110 55,130 Q 0,110 0,65 V 5 A 5,5 0 0 1 5,0 Z",
-    innerPath: "M 10,10 H 100 V 65 Q 100,100 55,118 Q 10,100 10,65 V 10 Z",
-    contentCenter: [55, 50],
-    contentAreaHeight: 80,
+    viewBox: [100, 137],
+    anchor: "bottom",
+    anchorY: 133,
+    outerPath: "M 14,4 H 86 C 91.52,4 96,8.48 96,14 V 58 C 96,99 72,123 50,133 C 28,123 4,99 4,58 V 14 C 4,8.48 8.48,4 14,4 Z",
+    inner: { type: "path", d: "M 23,14 H 77 C 82,14 86,18 86,23 V 56 C 86,87 67,109 50,118 C 33,109 14,87 14,56 V 23 C 14,18 18,14 23,14 Z" },
+    imageClip: {
+      type: "path",
+      d: "M 23,14 H 77 C 82,14 86,18 86,23 V 56 C 86,87 67,109 50,118 C 33,109 14,87 14,56 V 23 C 14,18 18,14 23,14 Z",
+      x: 14,
+      y: 14,
+      w: 72,
+      h: 104,
+    },
+    content: { cx: 50, cy: 54, r: 34 },
   },
 };
 
@@ -107,14 +179,30 @@ export const DEFAULT_OUTER_COLOR = "#FFFFFF";
 export const DEFAULT_INNER_COLOR = "hsl(223, 100%, 65%)";
 export const DEFAULT_CONTENT_COLOR = "#FFFFFF";
 
-// TODO: Default Y offsets, this is to ensure that the markers are positioned correctly depending on their size / viewbox
-// as right now they are just centered.
-export const DEFAULT_OFFSET_Y: Record<NonNullable<MapTilerMarkerBaseOptions["size"]>, number> = {
-  xs: 0,
-  s: 0,
-  m: 0,
-  l: 0,
-  xl: 0,
-};
+//#endregion
+
+//#region Anchor Offset
+
+/**
+ * Pixel offset (MapLibre `offset` convention, +y down) that places the
+ * shape's anchor point (`anchorY`) on the marker's lngLat instead of the
+ * element center (MapLibre's default `center` anchor).
+ * @param shapeKey - Shape variant.
+ * @param sizeKey - Size key; `xs` renders a centered dot, so no offset.
+ */
+export function getShapeAnchorOffset(shapeKey: NonNullable<MapTilerMarkerBaseOptions["shape"]>, sizeKey: NonNullable<MapTilerMarkerBaseOptions["size"]>): [number, number] {
+  if (sizeKey === "xs") return [0, 0];
+
+  const shape = SHAPES[shapeKey];
+
+  // center-anchored shapes sit on the lngLat as-is (MapLibre's default anchor)
+  if (shape.anchor === "center") return [0, 0];
+
+  const heightPx = SIZE_PX[sizeKey];
+  const scale = heightPx / shape.viewBox[1];
+
+  // shift the element up so the anchor line lands on the lngLat
+  return [0, -(shape.anchorY * scale - heightPx / 2)];
+}
 
 //#endregion

--- a/src/Marker/marker-symbols.ts
+++ b/src/Marker/marker-symbols.ts
@@ -1,4 +1,5 @@
 export const FlushDOMUpdatesSymbol = Symbol("MapTiler:Marker:flushDOMUpdates");
-export const CuedUpdatesSymbol = Symbol("MapTiler:Marker:cuedUpdates");
+export const PendingUpdatesSymbol = Symbol("MapTiler:Marker:pendingUpdates");
 export const MarkerElementSymbol = Symbol("MapTiler:Marker:markerElement");
 export const DetachFromDOMSymbol = Symbol("MapTiler:Marker:detachFromDOM");
+export const RefreshAdaptiveColorSymbol = Symbol("MapTiler:Marker:refreshAdaptiveColor");

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -89,10 +89,13 @@ export type MarkerPriorityExpression = unknown[];
 
 //#region Content Variants
 
-/** Marker content driven by a built-in content-type identifier. */
-export type MarkerContentByType = {
-  /** Identifier for a built-in content type. */
-  contentType: string;
+/**
+ * Marker content driven by a built-in icon identifier.
+ * TODO: icons are not implemented yet — this is a placeholder and renders nothing.
+ */
+export type MarkerContentTypeIcon = {
+  /** Identifier for a built-in icon. */
+  icon: string;
   url?: never;
   template?: never;
   templateParams?: never;
@@ -100,22 +103,22 @@ export type MarkerContentByType = {
 };
 
 /** Marker content driven by an image or SVG URL. */
-export type MarkerContentByUrl = {
+export type MarkerContentTypeImageUrl = {
   /** URL of an image or SVG to render as marker content. */
   url: string;
-  contentType?: never;
+  icon?: never;
   template?: never;
   templateParams?: never;
   element?: never;
 };
 
 /** Marker content driven by a named template and its parameters. */
-export type MarkerContentByTemplate = {
+export type MarkerContentTypeTemplate = {
   /** Identifier for a registered template factory function. */
   template: string;
   /** Parameters forwarded to the template config function. */
   templateParams?: Record<string, number | string>;
-  contentType?: never;
+  icon?: never;
   url?: never;
   element?: never;
 };
@@ -124,25 +127,25 @@ export type MarkerContentByTemplate = {
  * Marker content driven by an existing DOM or SVG element.
  * Useful when content is managed by a rendering engine such as React.
  */
-export type MarkerContentByElement = {
+export type MarkerContentTypeElement = {
   /** An HTML or SVG element to use as marker content. */
   element: HTMLElement | SVGElement;
-  contentType?: never;
+  icon?: never;
   url?: never;
   template?: never;
   templateParams?: never;
 };
 
 /** Marker with no explicit content — uses the default marker appearance. */
-export type MarkerContentNone = {
-  contentType?: never;
+export type MarkerContentTypeNone = {
+  icon?: never;
   url?: never;
   template?: never;
   templateParams?: never;
   element?: never;
 };
 
-export type MarkerContent = MarkerContentNone | MarkerContentByType | MarkerContentByUrl | MarkerContentByTemplate | MarkerContentByElement;
+export type MarkerContent = MarkerContentTypeNone | MarkerContentTypeIcon | MarkerContentTypeImageUrl | MarkerContentTypeTemplate | MarkerContentTypeElement;
 
 //#endregion
 
@@ -234,10 +237,10 @@ export type MapTilerMarkerBaseOptions = Omit<MarkerOptions, "scale" | "opacity" 
 export type MapTilerMarkerBehaviourOptions = Omit<MapTilerMarkerBaseOptions, "shape" | "size">;
 
 /** Options for a marker whose content is a pre-built DOM/SVG element. */
-export type MapTilerMarkerElementOptions = MapTilerMarkerBehaviourOptions & MarkerContentByElement;
+export type MapTilerMarkerElementOptions = MapTilerMarkerBehaviourOptions & MarkerContentTypeElement;
 
 /** Options for a marker whose content is generated from the built-in SVG system. */
-export type MapTilerMarkerSVGOptions = MapTilerMarkerBaseOptions & Exclude<MarkerContent, MarkerContentByElement>;
+export type MapTilerMarkerSVGOptions = MapTilerMarkerBaseOptions & Exclude<MarkerContent, MarkerContentTypeElement>;
 
 type MapTilerMarkerElementPropKeys =
   | "shape"

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -1,4 +1,5 @@
 import type { MarkerOptions } from "maplibre-gl";
+import type { AdaptiveColor, AdaptiveColorName } from "./marker-adaptive-colors";
 
 //#region Primitives
 
@@ -14,20 +15,26 @@ export type MapTilerMarkerShadow = "soft" | "medium" | "strong";
 /** Behaviour when this marker spatially overlaps another. */
 export const CollisionBehaviour = {
   /** No collision detection — marker is always shown. */
-  ALWAYS_SHOW: "ALWAYS_SHOW",
+  ALWAYS_SHOW: "always-show",
   /** Marker is hidden when it collides with a higher-priority marker. */
-  HIDE_BY_PRIORITY: "HIDE_BY_PRIORITY",
+  HIDE_BY_PRIORITY: "hide-by-priority",
   /** Marker is minimised to a simple point/circle when colliding with a higher-priority marker. */
-  MINIMIZE_BY_PRIORITY: "MINIMIZE_BY_PRIORITY",
+  MINIMIZE_BY_PRIORITY: "minimize-by-priority",
   /** Colliding markers are repositioned into a column at their average map position. */
-  REPOSITION_COLUMN: "REPOSITION_COLUMN",
+  REPOSITION_COLUMN: "reposition-column",
   /** Colliding markers are grouped at their average position and expand on hover/click. */
-  CLUSTER: "CLUSTER",
+  CLUSTER: "cluster",
 } as const;
 
 export type CollisionBehaviour = (typeof CollisionBehaviour)[keyof typeof CollisionBehaviour];
 
 export type Vector2 = [number, number];
+
+/**
+ * MapLibre-style expression that resolves to a numeric priority.
+ * Evaluated by the collision engine, not applied directly to the DOM.
+ */
+export type MarkerPriorityExpression = unknown[];
 
 //#endregion
 
@@ -141,12 +148,23 @@ export type MarkerContent = MarkerContentNone | MarkerContentByType | MarkerCont
 
 //#region Base Options
 
-export type MapTilerMarkerBaseOptions = Omit<MarkerOptions, "scale" | "opacity" | "opacityWhenCovered"> & {
+// `color` is omitted from the MapLibre options because it styles the default
+// pin (which we replace entirely) — we repurpose the key for adaptive colours
+export type MapTilerMarkerBaseOptions = Omit<MarkerOptions, "scale" | "opacity" | "opacityWhenCovered" | "color"> & {
   /** Visual shape of the marker body. */
   shape?: MapTilerMarkerShape;
   /** Size of the marker. */
   size?: MapTilerMarkerSize;
-  /** Fill colour of the inner area of the marker. */
+  /**
+   * Adaptive colour of the marker. Resolves the marker's inner (background)
+   * colour against the current map style via the colour's `bgColors`, and
+   * re-resolves whenever the map style changes.
+   * Accepts a built-in palette name (`"blue"` | `"red"` | `"green"`) or a
+   * custom {@link AdaptiveColor} definition.
+   * An explicit `innerColor` takes precedence and disables adaptation.
+   */
+  color?: AdaptiveColorName | AdaptiveColor;
+  /** Explicit fill colour of the inner area of the marker. Static — takes precedence over `color`. */
   innerColor?: string;
   /** Fill colour of the outer area (body/border) of the marker. */
   outerColor?: string;
@@ -161,20 +179,23 @@ export type MapTilerMarkerBaseOptions = Omit<MarkerOptions, "scale" | "opacity" 
   opacity?: number;
   opacityWhenCovered?: number;
   /**
-   * Unique marker name. Must be safe for use as a CSS class name.
-   * A UUID is generated automatically when omitted.
+   * Optional marker name, added as a CSS class on the marker element.
+   * Must be safe for use as a CSS class name.
    */
   name?: string;
 
+  /** Applied to the `title` attribute of the marker's root element (native tooltip). */
   title?: string;
+  /** Text content rendered inside the marker body. */
+  content?: string;
   /** HTML attributes applied directly to the marker's root element. */
   htmlAttributes?: Record<string, number | string>;
   /** 2-D scale of the marker as `[x, y]`. Defaults to `[1, 1]`. */
   scale?: Vector2;
-  /** Initial visibility of the marker. Defaults to `true`. */
+  /** Initial visibility of the marker. Defaults to `true`. TODO: not implemented yet. */
   visible?: boolean;
   /** Rendering priority used for collision detection and clustering. Accepts a numeric value or a MapLibre-style expression. */
-  priority?: number | unknown[];
+  priority?: number | MarkerPriorityExpression;
   // /** Lifecycle animations. (Non MVP) Certain fields (e.g. `iterations`) are ignored for `enter` and `exit` animations. */
   // animations?: {
   //   /** Played when the marker is added to the map. Defaults to a subtle drop-in effect. */
@@ -190,6 +211,8 @@ export type MapTilerMarkerBaseOptions = Omit<MarkerOptions, "scale" | "opacity" 
   userData?: Record<string, unknown>;
   /** Behaviour when this marker spatially overlaps another. */
   collisionBehaviour?: CollisionBehaviour;
+  /** When `true`, renders a debug overlay showing the marker's bounding box and center point. */
+  debug?: boolean;
   /**
    * Collision detection radius in pixels.
    * `0` means the marker's bounding box is used.
@@ -206,7 +229,7 @@ export type MapTilerMarkerBaseOptions = Omit<MarkerOptions, "scale" | "opacity" 
  * DOM/SVG element is supplied as marker content.  SVG-only layout fields
  * (`shape`, `size`) are omitted because they only affect SVG generation.
  * Color/shadow options are retained — they are applied as CSS custom properties
- * on the wrapper and can be consumed by the custom element.
+ * on the supplied element and can be consumed by its styles.
  */
 export type MapTilerMarkerBehaviourOptions = Omit<MapTilerMarkerBaseOptions, "shape" | "size">;
 
@@ -217,6 +240,8 @@ export type MapTilerMarkerElementOptions = MapTilerMarkerBehaviourOptions & Mark
 export type MapTilerMarkerSVGOptions = MapTilerMarkerBaseOptions & Exclude<MarkerContent, MarkerContentByElement>;
 
 type MapTilerMarkerElementPropKeys =
+  | "shape"
+  | "color"
   | "outerColor"
   | "innerColor"
   | "contentColor"
@@ -225,15 +250,23 @@ type MapTilerMarkerElementPropKeys =
   | "shadow"
   | "opacity"
   | "title"
+  | "content"
   | "htmlAttributes"
   | "rotation"
   | "scale"
-  | "size";
+  | "size"
+  | "debug"
+  | "priority";
 
 export type MapTilerMarkerElementProps = Pick<MapTilerMarkerBaseOptions, MapTilerMarkerElementPropKeys>;
 
 export type MapTilerMarkerOptions = MapTilerMarkerBaseOptions & MarkerContent;
 
-export type HTMLElementUpdateCue = Map<keyof MapTilerMarkerElementProps, MapTilerMarkerElementProps[keyof MapTilerMarkerElementProps]>;
+/**
+ * Batch of property updates waiting to be flushed to the DOM.
+ * A key being present (even with an `undefined` value) means "apply this
+ * property" — e.g. `{ shadow: undefined }` removes the shadow.
+ */
+export type PendingMarkerUpdates = Partial<MapTilerMarkerElementProps>;
 
 //#endregion

--- a/src/mapstyle.ts
+++ b/src/mapstyle.ts
@@ -139,3 +139,34 @@ export function convertStringToStyleSpecification(str: string): StyleValidationR
     };
   }
 }
+
+/**
+ * Derives the MapTiler style id (e.g. `"streets-v4-dark"`) from a style input,
+ * without expanding or fetching it.
+ * Returns `undefined` for custom `StyleSpecification`s and URLs that don't
+ * follow the MapTiler Cloud `/maps/<id>/style.json` shape.
+ */
+export function styleToStyleId(style: string | ReferenceMapStyle | MapStyleVariant | maplibregl.StyleSpecification | null | undefined): string | undefined {
+  if (!style) {
+    // same default as styleToStyle()
+    return MapStyle[mapStylePresetList[0].referenceStyleID as keyof typeof MapStyle].getDefaultVariant().getId();
+  }
+
+  if (style instanceof MapStyleVariant) return style.getId();
+
+  if (style instanceof ReferenceMapStyle) return (style.getDefaultVariant() as MapStyleVariant).getId();
+
+  if (typeof style === "string") {
+    const urlMatch = /\/maps\/([^/]+)\/style\.json/.exec(style);
+    if (urlMatch) return urlMatch[1];
+
+    // other URLs and inline JSON styles carry no derivable id
+    if (style.startsWith("http") || style.toLowerCase().includes(".json") || style.trim().startsWith("{")) return undefined;
+
+    // shorthand ("streets-v4", possibly "maptiler://streets-v4") or a MapTiler Cloud style UUID
+    return style.replace("maptiler://", "");
+  }
+
+  const id = (style as { id?: unknown }).id;
+  return typeof id === "string" ? id : undefined;
+}


### PR DESCRIPTION
## Objective
Implements the SVGs and design first pass for the new markers.

## Description
- Add adaptive marker colors: palette (blue/red/green) resolves inner color per map style, re-resolves on style change via `MarkerManager` styledata listener
- Add `Map.getStyleId()` + `styleToStyleId()` in mapstyle.ts — track requested style id at setStyle time (not recoverable from parsed stylesheet)
- Add marker content registry (contentType/template factories) + content variants (url/element/text) in marker-dom-utils
- refactor Marker to single props store + generic setProp, replace per-prop fields and update-cue Map with typed `PendingMarkerUpdates`
- Fixes:
  - shadow option not stored inernally and so was lost on changes
  - `forwardPointerEvents` wasn't properly forwarding
  - fixed remove()
  - maplibre `color` option collapsing adaptive color type
- renames `setMarkerShape`=>`setShape`, cue => pending naming, `MarkerManagerFactory` => `MarkerManagerImpl`; drop empty symbols.ts
- demo 16: map-style switcher, adaptive color buttons, resolved-color status line (AI created)

## Acceptance
- Manually tested, will be reviewed thoroughly before release.

## Checklist
- [ ] ~I have added relevant info to the CHANGELOG.md~ N/A

## AI disclosure
- demo vibe coded in it's entirety.
- Changes reviewed by AI, naming suggestions and some structural changes implemented. 
- tsdoc comments for type and class descriptions expanded on by AI