### PR TITLE
RD-1406 implement base collision logic

### DIFF
--- a/demos/src/16-maptiler-markers.ts
+++ b/demos/src/16-maptiler-markers.ts
@@ -1,6 +1,6 @@
 import { Map, MapStyle, Marker, config, registerMarkerTemplate } from "../../src/index";
 import { setupMapTilerApiKey } from "./demo-utils";
-import type { MapTilerMarkerBaseOptions, MapTilerMarkerOptions, MapTilerMarkerSVGOptions } from "../../src/Marker";
+import type { MapTilerMarkerBaseOptions, MapTilerMarkerOptions, MapTilerMarkerSVGOptions, MarkerCollisionEventData } from "../../src/Marker";
 
 // demo template: dark round badge with a label
 registerMarkerTemplate("badge", (params) => {
@@ -126,7 +126,7 @@ async function main() {
     draggable: true,
     scale: [1, 1],
     shape: "bubble-square",
-    size: "m",
+    size: "xl",
     color: "blue", // adaptive — resolves against the current map style
     outerColor: "#ffffff",
     contentColor: "#ffffff",
@@ -174,8 +174,31 @@ async function main() {
     }
   }
 
+  // collision logging — markers emit only enter/exit transitions, so the
+  // console stays quiet while a collision persists between passes
+  function markerLabel(m: Marker): string {
+    return m.getTitle() ?? m.getContent() ?? m.id.slice(0, 8);
+  }
+
+  function logCollisions(m: Marker) {
+    for (const eventName of ["markeroverlap"] as const) {
+      m.on(eventName, (event: MarkerCollisionEventData) => {
+        const current = event.current;
+        const exited = event.exited;
+        current.forEach(m => {
+          m.setColor("green");
+        });
+        exited.forEach(m => {
+          m.setColor("blue");
+        });
+      });
+
+    }
+  }
+
   function mountMarker(m: Marker, lngLat: [number, number]) {
     m.on("click", console.log);
+    logCollisions(m);
     m.setLngLat(lngLat);
     map.addMarker(m);
   }
@@ -208,6 +231,7 @@ async function main() {
   for (let i = 0; i < 4; i++) {
     const otherMarker = new Marker({ ...markerOptions, content: String(i + 2), title: `Marker ${String(i + 2)}`, priority: 1 + i });
     otherMarker.on("click", console.log);
+    logCollisions(otherMarker);
     const offsetLat = Math.sin((i / 4) * Math.PI * 2) / 20;
     const offsetLon = Math.cos((i / 4) * Math.PI * 2) / 20;
     otherMarker.setLngLat([10 + offsetLon, 50 + offsetLat]);

--- a/demos/src/16-maptiler-markers.ts
+++ b/demos/src/16-maptiler-markers.ts
@@ -1,4 +1,5 @@
-import { Map, MapStyle, Marker, config, registerMarkerTemplate } from "../../src/index";
+import { Map, MapStyle, Marker, config } from "../../src/index";
+import { registerMarkerTemplate } from "../../src/Marker/marker-content-registry";
 import { setupMapTilerApiKey } from "./demo-utils";
 import type { MapTilerMarkerBaseOptions, MapTilerMarkerOptions, MapTilerMarkerSVGOptions, MarkerCollisionEventData } from "../../src/Marker";
 
@@ -172,12 +173,6 @@ async function main() {
         return new Marker({ ...behaviour, element: pin });
       }
     }
-  }
-
-  // collision logging — markers emit only enter/exit transitions, so the
-  // console stays quiet while a collision persists between passes
-  function markerLabel(m: Marker): string {
-    return m.getTitle() ?? m.getContent() ?? m.id.slice(0, 8);
   }
 
   function logCollisions(m: Marker) {

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -52,7 +52,7 @@ import { CubemapDefinition, CubemapLayer, CubemapLayerConstructorOptions } from 
 import { GradientDefinition, RadialGradientLayer, RadialGradientLayerConstructorOptions } from "./custom-layers/RadialGradientLayer";
 import { StyleSpecificationWithMetaData } from "./custom-layers/extractCustomLayerStyle";
 import { logSDKVersion } from "./utils/logSDKVersion";
-import { MapTilerMarkerOptions, MapTilerMarkerSVGOptions, Marker, setWorkerCount } from ".";
+import { MapTilerMarkerOptions, MapTilerMarkerSVGOptions, Marker, MarkerCollisionOptions, setWorkerCount } from ".";
 import { MarkerManager } from "./Marker/MarkerManager";
 import { EXPERIMENTAL_TILE_PRELOADING_VERSION } from "./tile-preloading/version";
 
@@ -1498,6 +1498,20 @@ export class Map extends maplibregl.Map {
 
   getMarker(id: string): Marker | undefined {
     return MarkerManager.getMarker(this, id);
+  }
+
+  /**
+   * Configures marker collision detection for this map.
+   * @param options.proximityPadding - Distance in CSS px within which two
+   *   markers count as "in proximity". Overlap always uses 0.
+   * @param options.accuracy - `high` (default) tests rotated markers with
+   *   their actual rotated box; `low` uses the upright box enclosing it,
+   *   which is cheaper per pair but over-reports collisions for rotated
+   *   markers (it never misses a real one).
+   */
+  setMarkerCollisionOptions(options: MarkerCollisionOptions): this {
+    MarkerManager.setCollisionOptions(this, options);
+    return this;
   }
 
   /**

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -1,14 +1,33 @@
 import maplibregl from "maplibre-gl";
-import type { MarkerOptions } from "maplibre-gl";
+import type { LngLatLike, MarkerOptions, PointLike } from "maplibre-gl";
 import type { Map as SDKMap } from "../Map";
-import type { MapTilerMarkerElementProps, MapTilerMarkerElementOptions, MapTilerMarkerSVGOptions, PendingMarkerUpdates, Vector2, MapTilerMarkerOptions } from "./types";
+import type {
+  MapTilerMarkerElementProps,
+  MapTilerMarkerElementOptions,
+  MapTilerMarkerSVGOptions,
+  PendingMarkerUpdates,
+  Vector2,
+  MapTilerMarkerOptions,
+  MarkerCollisionEventData,
+} from "./types";
 import { omit } from "../utils/object";
 import { v4 as uuid } from "uuid";
 import { applyMarkerStyleVariables, createMarkerElement, updateMarkerElement } from "./marker-dom-utils";
-import { DEFAULT_SHAPE, DEFAULT_SIZE, getShapeAnchorOffset } from "./marker-svg-config";
+import { DEFAULT_SHAPE, DEFAULT_SIZE, SHAPES, SIZE_PX, getShapeAnchorOffset } from "./marker-svg-config";
 import { getAdaptiveBgColor, resolveAdaptiveColor } from "./marker-adaptive-colors";
 import { MarkerManager } from "./MarkerManager";
-import { PendingUpdatesSymbol, DetachFromDOMSymbol, FlushDOMUpdatesSymbol, MarkerElementSymbol, RefreshAdaptiveColorSymbol } from "./marker-symbols";
+import type { MarkerFootprint } from "./collision-helpers";
+import {
+  PendingUpdatesSymbol,
+  DetachFromDOMSymbol,
+  FlushDOMUpdatesSymbol,
+  MarkerElementSymbol,
+  RefreshAdaptiveColorSymbol,
+  CollisionFootprintSymbol,
+  EmitCollisionDiffSymbol,
+  ShouldHideSymbol,
+  MeasuredElementSizeSymbol,
+} from "./marker-symbols";
 
 const maplibreMarkerConstructorOverrides: MarkerOptions = {
   scale: 1, // scale in our class will be a 2D vector.
@@ -73,6 +92,14 @@ export class Marker extends maplibregl.Marker {
 
   /** Property updates waiting to be flushed to the DOM on the next animation frame. */
   [PendingUpdatesSymbol]: PendingMarkerUpdates = {};
+
+  /**
+   * Unscaled CSS pixel size of a custom `element`, measured once by
+   * {@link MarkerManager} when the marker is registered (the only time DOM
+   * measurement is allowed — never during a collision pass).
+   * `null` until measured; built-in SVG markers never need it.
+   */
+  [MeasuredElementSizeSymbol]: Vector2 | null = null;
 
   /** UUID that uniquely identifies this marker instance. */
   public readonly id = uuid();
@@ -208,6 +235,100 @@ export class Marker extends maplibregl.Marker {
   [RefreshAdaptiveColorSymbol](): void {
     if (this.props.color === undefined || this.props.innerColor !== undefined) return;
     this.setProp("color", this.props.color);
+  }
+
+  //#endregion
+
+  //#region Collision
+
+  /**
+   * Resolves the marker's screen footprint for collision detection.
+   *
+   * Built entirely from stored props / lookup tables — no DOM reads — so it
+   * is safe to call once per marker per detection pass. Called by
+   * {@link MarkerManager} which pairs it with the marker's projected screen
+   * position to build the collision box.
+   */
+  [CollisionFootprintSymbol](): MarkerFootprint {
+    const [sx, sy] = this.props.scale ?? [1, 1];
+    const offset = this.getOffset();
+    const shared = {
+      offset: [offset.x, offset.y] as Vector2,
+      rotation: this.props.rotation ?? 0,
+      mapAligned: this.getRotationAlignment() === "map",
+    };
+
+    // explicit collision radius replaces the visual box with a centred square
+    const radius = this.options.collisionRadius;
+    if (radius && radius > 0) {
+      return { width: radius * 2, height: radius * 2, anchor: "center", ...shared };
+    }
+
+    const anchor = this.options.anchor ?? "center";
+
+    // custom element: size measured once at registration
+    if (this.options.element) {
+      const [w, h] = this[MeasuredElementSizeSymbol] ?? [0, 0];
+      return { width: w * sx, height: h * sy, anchor, ...shared };
+    }
+
+    // built-in SVG: height comes from the size key, width from the shape's
+    // aspect ratio (see setMarkerSVGDimensions); `xs` renders a square dot
+    const size = this.props.size ?? DEFAULT_SIZE;
+    const heightPx = SIZE_PX[size];
+    const shape = SHAPES[this.props.shape ?? DEFAULT_SHAPE];
+    const widthPx = size === "xs" ? heightPx : heightPx * (shape.viewBox[0] / shape.viewBox[1]);
+    return { width: widthPx * sx, height: heightPx * sy, anchor, ...shared };
+  }
+
+  /**
+   * Fires the state-change collision event (`markeroverlap` or
+   * `markerproximity`) for this marker. Called by {@link MarkerManager}
+   * after diffing the pass results against the previous pass — only
+   * transitions reach this point, unchanged collisions are never re-emitted.
+   */
+  [EmitCollisionDiffSymbol](data: MarkerCollisionEventData): void {
+    this.fire(data.kind === "overlap" ? "markeroverlap" : "markerproximity", data);
+  }
+
+  /**
+   * Whether the marker should currently be hidden by the collision engine.
+   *
+   * Placeholder seam for the behaviour layer: the next PR resolves this from
+   * the marker's `collisionBehaviour` (see {@link CollisionBehaviour}),
+   * `priority` and the detected collision groups. In this PR detection only
+   * reports collisions — nothing is ever hidden.
+   */
+  [ShouldHideSymbol](): boolean {
+    return false;
+  }
+
+  /**
+   * Sets the marker's geographical position.
+   *
+   * Overridden to re-run collision detection — a marker moving changes
+   * collisions with no map event to hang the pass on.
+   * @param lnglat - The new position.
+   */
+  override setLngLat(lnglat: LngLatLike): this {
+    super.setLngLat(lnglat);
+    const map = MarkerManager.getMap(this);
+    if (map) MarkerManager.invalidateCollisions(map);
+    return this;
+  }
+
+  /**
+   * Sets the marker's screen-space pixel offset.
+   *
+   * Overridden to re-run collision detection — the offset shifts the
+   * marker's collision box.
+   * @param offset - Offset in pixels (+y down).
+   */
+  override setOffset(offset: PointLike): this {
+    super.setOffset(offset);
+    const map = MarkerManager.getMap(this);
+    if (map) MarkerManager.invalidateCollisions(map);
+    return this;
   }
 
   //#endregion

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -258,18 +258,20 @@ export class Marker extends maplibregl.Marker {
       mapAligned: this.getRotationAlignment() === "map",
     };
 
-    // explicit collision radius replaces the visual box with a centred square
+    // explicit collision radius replaces the visual box with a centred
+    // square pinned on the anchor point — rotation must not move it
     const radius = this.options.collisionRadius;
     if (radius && radius > 0) {
-      return { width: radius * 2, height: radius * 2, anchor: "center", ...shared };
+      return { width: radius * 2, height: radius * 2, anchor: "center", ...shared, pivot: [0, 0] };
     }
 
     const anchor = this.options.anchor ?? "center";
 
-    // custom element: size measured once at registration
+    // custom element: size measured once at registration; rotation uses the
+    // CSS default transform-origin (element center)
     if (this.options.element) {
       const [w, h] = this[MeasuredElementSizeSymbol] ?? [0, 0];
-      return { width: w * sx, height: h * sy, anchor, ...shared };
+      return { width: w * sx, height: h * sy, anchor, ...shared, pivot: [0, 0] };
     }
 
     // built-in SVG: height comes from the size key, width from the shape's
@@ -278,7 +280,11 @@ export class Marker extends maplibregl.Marker {
     const heightPx = SIZE_PX[size];
     const shape = SHAPES[this.props.shape ?? DEFAULT_SHAPE];
     const widthPx = size === "xs" ? heightPx : heightPx * (shape.viewBox[0] / shape.viewBox[1]);
-    return { width: widthPx * sx, height: heightPx * sy, anchor, ...shared };
+    const height = heightPx * sy;
+    // bottom-anchored shapes rotate around their tip (transform-origin
+    // "center bottom" — see createMarkerElement / applyShape)
+    const pivot: Vector2 = shape.anchor === "center" ? [0, 0] : [0, height / 2];
+    return { width: widthPx * sx, height, anchor, ...shared, pivot };
   }
 
   /**

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -1,7 +1,18 @@
 import type { Marker } from "./Marker";
 import type { Map as SDKMap } from "../Map";
-import type { MarkerCollisionGroups, MarkerCollisionKind } from "./types";
-import { computeMarkerAABB, createCandidateSource, deriveCollisionGroups, inflateBounds, boundsIntersect, DEFAULT_PROXIMITY_PADDING, type Bounds } from "./collision-helpers";
+import type { MarkerCollisionAccuracy, MarkerCollisionGroups, MarkerCollisionKind, MarkerCollisionOptions } from "./types";
+import {
+  computeMarkerOBB,
+  obbToAABB,
+  obbIntersect,
+  createCandidateSource,
+  deriveCollisionGroups,
+  inflateBounds,
+  boundsIntersect,
+  DEFAULT_PROXIMITY_PADDING,
+  type Bounds,
+  type OBB,
+} from "./collision-helpers";
 import {
   DetachFromDOMSymbol,
   FlushDOMUpdatesSymbol,
@@ -23,15 +34,19 @@ type MapCollisionState = {
   groups: MarkerCollisionGroups;
   /** Proximity threshold in CSS px (overlap always uses 0). */
   proximityPadding: number;
+  /** Collision box accuracy: `high` tests rotated boxes exactly, `low` tests their enclosing upright boxes. */
+  accuracy: MarkerCollisionAccuracy;
 };
 
 /** One marker's resolved geometry within a detection pass. */
 type CollisionEntry = {
   index: number;
   marker: Marker;
-  /** Exact box — the overlap test. */
+  /** Exact rotated box — the narrow-phase test at `high` accuracy. */
+  obb: OBB;
+  /** Upright box enclosing `obb` — the overlap test at `low` accuracy. */
   bounds: Bounds;
-  /** Box inflated by half the proximity padding — two of these intersecting means the gap is within the padding. */
+  /** `bounds` inflated by half the proximity padding — the broad-phase / `low`-accuracy proximity box. */
   proximityBounds: Bounds;
 };
 
@@ -315,10 +330,14 @@ class MarkerManagerImpl {
    * Configures collision detection for a map.
    * @param options.proximityPadding - Distance in CSS px within which two
    *   markers count as "in proximity". Overlap always uses 0.
+   * @param options.accuracy - `high` (default) tests rotated markers with
+   *   their actual rotated box; `low` uses the enclosing upright box, which
+   *   is cheaper but over-reports collisions for rotated markers.
    */
-  setCollisionOptions(map: SDKMap, options: { proximityPadding?: number }): void {
+  setCollisionOptions(map: SDKMap, options: MarkerCollisionOptions): void {
     const state = this.getOrCreateCollisionState(map);
     if (options.proximityPadding !== undefined) state.proximityPadding = options.proximityPadding;
+    if (options.accuracy !== undefined) state.accuracy = options.accuracy;
     this.invalidateCollisions(map);
   }
 
@@ -332,6 +351,7 @@ class MarkerManagerImpl {
         previous: { overlap: new Map(), proximity: new Map() },
         groups: { overlap: [], proximity: [] },
         proximityPadding: DEFAULT_PROXIMITY_PADDING,
+        accuracy: "high",
       };
       this.collisionState.set(map, state);
 
@@ -364,6 +384,7 @@ class MarkerManagerImpl {
     // half on each box: two inflated boxes touch exactly when the gap
     // between the exact boxes is the full padding
     const halfPadding = state.proximityPadding / 2;
+    const exact = state.accuracy === "high";
 
     const entries: CollisionEntry[] = [];
     for (const marker of index.values()) {
@@ -371,13 +392,15 @@ class MarkerManagerImpl {
       const angle = (footprint.mapAligned ? bearing : 0) + footprint.rotation;
       // the box is rebuilt from a fresh projection every pass — the camera
       // has usually moved since the last one, so caching it would lie
-      const bounds = computeMarkerAABB(map.project(marker.getLngLat()), footprint, angle);
-      entries.push({ index: entries.length, marker, bounds, proximityBounds: inflateBounds(bounds, halfPadding) });
+      const obb = computeMarkerOBB(map.project(marker.getLngLat()), footprint, angle);
+      const bounds = obbToAABB(obb);
+      entries.push({ index: entries.length, marker, obb, bounds, proximityBounds: inflateBounds(bounds, halfPadding) });
     }
 
-    // overlap and proximity are the same test at different paddings: the
-    // candidate query IS the proximity test (both boxes pre-inflated), and
-    // the exact boxes re-tested inside it give overlap
+    // overlap and proximity are the same test at different paddings. At low
+    // accuracy the upright boxes decide both directly; at high accuracy the
+    // upright-box query is only a broad-phase prefilter (it can over-include
+    // but never miss) and the rotated boxes decide
     const source = createCandidateSource(entries, (entry) => entry.proximityBounds);
     const overlapPairs: [number, number][] = [];
     const proximityPairs: [number, number][] = [];
@@ -386,9 +409,11 @@ class MarkerManagerImpl {
     for (const entry of entries) {
       for (const other of source.query(entry.proximityBounds)) {
         if (other.index <= entry.index) continue; // each pair once, and never self
+        if (exact && !obbIntersect(entry.obb, other.obb, halfPadding)) continue;
         proximityPairs.push([entry.index, other.index]);
         this.linkCollision(next.proximity, entry.marker, other.marker);
-        if (boundsIntersect(entry.bounds, other.bounds)) {
+        const overlaps = exact ? obbIntersect(entry.obb, other.obb) : boundsIntersect(entry.bounds, other.bounds);
+        if (overlaps) {
           overlapPairs.push([entry.index, other.index]);
           this.linkCollision(next.overlap, entry.marker, other.marker);
         }

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -1,6 +1,41 @@
 import type { Marker } from "./Marker";
 import type { Map as SDKMap } from "../Map";
-import { DetachFromDOMSymbol, FlushDOMUpdatesSymbol, RefreshAdaptiveColorSymbol } from "./marker-symbols";
+import type { MarkerCollisionGroups, MarkerCollisionKind } from "./types";
+import { computeMarkerAABB, createCandidateSource, deriveCollisionGroups, inflateBounds, boundsIntersect, DEFAULT_PROXIMITY_PADDING, type Bounds } from "./collision-helpers";
+import {
+  DetachFromDOMSymbol,
+  FlushDOMUpdatesSymbol,
+  RefreshAdaptiveColorSymbol,
+  PendingUpdatesSymbol,
+  CollisionFootprintSymbol,
+  EmitCollisionDiffSymbol,
+  MeasuredElementSizeSymbol,
+} from "./marker-symbols";
+
+/** Pending props that change a marker's footprint and therefore its collisions. */
+const FOOTPRINT_PROPS = ["shape", "size", "scale", "rotation"] as const;
+
+/** Per-map state of the collision detection engine. */
+type MapCollisionState = {
+  /** Collision sets from the previous pass, per kind, keyed by marker id — the diffing baseline for enter/exit events. */
+  previous: Record<MarkerCollisionKind, Map<string, Set<Marker>>>;
+  /** Groups from the latest pass. */
+  groups: MarkerCollisionGroups;
+  /** Proximity threshold in CSS px (overlap always uses 0). */
+  proximityPadding: number;
+};
+
+/** One marker's resolved geometry within a detection pass. */
+type CollisionEntry = {
+  index: number;
+  marker: Marker;
+  /** Exact box — the overlap test. */
+  bounds: Bounds;
+  /** Box inflated by half the proximity padding — two of these intersecting means the gap is within the padding. */
+  proximityBounds: Bounds;
+};
+
+const EMPTY_MARKER_SET: ReadonlySet<Marker> = new Set();
 
 /**
  * @class MarkerManagerImpl
@@ -29,6 +64,16 @@ class MarkerManagerImpl {
   // Last style id seen per map — used to skip redundant adaptive-colour
   // refreshes, since `styledata` fires many times per style load.
   private readonly lastStyleId = new WeakMap<SDKMap, string | undefined>();
+
+  // Per-map collision detection state (previous pass, groups, config).
+  private readonly collisionState = new WeakMap<SDKMap, MapCollisionState>();
+
+  // Maps with a collision pass pending on the next animation frame. All
+  // invalidations coalesce here so a bulk add runs the pass once, not N times.
+  private readonly collisionPending = new Set<SDKMap>();
+
+  // Per-marker `dragend` handlers, kept so deregister can detach them.
+  private readonly dragEndHandlers = new WeakMap<Marker, () => void>();
 
   //#endregion
 
@@ -81,11 +126,39 @@ class MarkerManagerImpl {
 
   // registers a marker to be managed, called internally in Map.addMarker
   register(marker: Marker, map: SDKMap): void {
+    // maplibre's addTo() starts with this.remove() (detach from any previous
+    // map), which routes through our remove() override and would deregister
+    // the marker we are registering — add first, track after
+    marker.addTo(map);
+
     this.markerMap.set(marker, map);
 
     this.getOrCreateIndex(map).set(marker.id, marker);
 
-    marker.addTo(map);
+    // custom elements have unknowable geometry — measure once, now that the
+    // element is in the DOM, so collision passes never have to touch layout.
+    // An SVG root can be supplied as the marker element and SVG has no
+    // offsetWidth — use the bounding rect there
+    const customElement = marker.options.element;
+    if (customElement && !marker[MeasuredElementSizeSymbol]) {
+      if (customElement instanceof HTMLElement) {
+        marker[MeasuredElementSizeSymbol] = [customElement.offsetWidth, customElement.offsetHeight];
+      } else {
+        // unreachable per the typings, but plain-JS callers can pass an SVG
+        // root, which has no offsetWidth
+        const rect = (customElement as Element).getBoundingClientRect();
+        marker[MeasuredElementSizeSymbol] = [rect.width, rect.height];
+      }
+    }
+
+    // dragging moves the marker with no map event to re-run detection on
+    const onDragEnd = () => {
+      this.invalidateCollisions(map);
+    };
+    marker.on("dragend", onDragEnd);
+    this.dragEndHandlers.set(marker, onDragEnd);
+
+    this.invalidateCollisions(map);
 
     // adaptive colours could only resolve to `base` before the marker had a
     // map — re-resolve against this map's style
@@ -101,6 +174,21 @@ class MarkerManagerImpl {
     this.markerMap.delete(marker);
     this.mapIndex.get(map)?.delete(marker.id);
     this.cancelCuedUpdatesForMarker(marker);
+
+    const onDragEnd = this.dragEndHandlers.get(marker);
+    if (onDragEnd) {
+      marker.off("dragend", onDragEnd);
+      this.dragEndHandlers.delete(marker);
+    }
+
+    // drop the marker's own collision baseline; counterparts still holding it
+    // in theirs get their exit events from the pass scheduled below
+    const state = this.collisionState.get(map);
+    if (state) {
+      state.previous.overlap.delete(marker.id);
+      state.previous.proximity.delete(marker.id);
+    }
+    this.invalidateCollisions(map);
 
     marker[DetachFromDOMSymbol]();
   }
@@ -162,14 +250,25 @@ class MarkerManagerImpl {
 
   // iterates through the markers that require updates and applies then to the DOM.
   flushUpdates() {
-    // TODO collision logic will go here...
-
     for (const marker of this.dirty) {
+      // a footprint-changing prop means this marker's collisions may change
+      if (FOOTPRINT_PROPS.some((prop) => prop in marker[PendingUpdatesSymbol])) {
+        const map = this.markerMap.get(marker);
+        if (map) this.collisionPending.add(map);
+      }
       marker[FlushDOMUpdatesSymbol]();
     }
 
     // clear updates.
     this.dirty.clear();
+
+    // detection runs in the same frame, after the DOM writes; it reads only
+    // props and map.project(), never the DOM, so ordering is for cadence only
+    const pending = [...this.collisionPending];
+    this.collisionPending.clear();
+    for (const map of pending) {
+      this.runCollisionPass(map);
+    }
   }
 
   // called when a marker state is updated
@@ -181,6 +280,152 @@ class MarkerManagerImpl {
   // abort any updates
   cancelCuedUpdatesForMarker(marker: Marker): void {
     this.dirty.delete(marker);
+  }
+
+  //#endregion
+
+  //#region Collision Detection
+
+  /**
+   * Requests a full collision detection pass for a map's markers.
+   *
+   * The single entry point for everything that can change collisions —
+   * marker add / remove / move, footprint changes, and camera `moveend`.
+   * Requests coalesce onto one animation frame, so a bulk add runs the pass
+   * once. During camera movement markers track their positions via MapLibre's
+   * own per-frame update (the cheap tier); the full pass (the expensive tier)
+   * only runs when movement ends.
+   */
+  invalidateCollisions(map: SDKMap): void {
+    this.getOrCreateCollisionState(map);
+    this.collisionPending.add(map);
+    this.scheduleFlush();
+  }
+
+  /**
+   * Collision groups from the latest detection pass: the full sets of
+   * mutually-colliding markers, with no priority or winner/loser resolution.
+   * The behaviour layer consumes these to decide what to do about collisions.
+   */
+  getCollisionGroups(map: SDKMap): MarkerCollisionGroups {
+    return this.collisionState.get(map)?.groups ?? { overlap: [], proximity: [] };
+  }
+
+  /**
+   * Configures collision detection for a map.
+   * @param options.proximityPadding - Distance in CSS px within which two
+   *   markers count as "in proximity". Overlap always uses 0.
+   */
+  setCollisionOptions(map: SDKMap, options: { proximityPadding?: number }): void {
+    const state = this.getOrCreateCollisionState(map);
+    if (options.proximityPadding !== undefined) state.proximityPadding = options.proximityPadding;
+    this.invalidateCollisions(map);
+  }
+
+  // lazily creates the per-map collision state and attaches the camera
+  // trigger; `remove` tears both down along with any pending pass
+  private getOrCreateCollisionState(map: SDKMap): MapCollisionState {
+    let state = this.collisionState.get(map);
+
+    if (!state) {
+      state = {
+        previous: { overlap: new Map(), proximity: new Map() },
+        groups: { overlap: [], proximity: [] },
+        proximityPadding: DEFAULT_PROXIMITY_PADDING,
+      };
+      this.collisionState.set(map, state);
+
+      const onMoveEnd = () => {
+        this.invalidateCollisions(map);
+      };
+      map.on("moveend", onMoveEnd);
+      void map.once("remove", () => {
+        map.off("moveend", onMoveEnd);
+        this.collisionPending.delete(map);
+        this.collisionState.delete(map);
+      });
+    }
+
+    return state;
+  }
+
+  /**
+   * The full detection pass. Builds each marker's screen box from its stored
+   * footprint and projected position (no DOM reads), finds intersecting
+   * pairs, derives collision groups, then diffs against the previous pass so
+   * markers only emit enter/exit transitions.
+   */
+  private runCollisionPass(map: SDKMap): void {
+    const state = this.collisionState.get(map);
+    const index = this.mapIndex.get(map);
+    if (!state || !index) return;
+
+    const bearing = map.getBearing();
+    // half on each box: two inflated boxes touch exactly when the gap
+    // between the exact boxes is the full padding
+    const halfPadding = state.proximityPadding / 2;
+
+    const entries: CollisionEntry[] = [];
+    for (const marker of index.values()) {
+      const footprint = marker[CollisionFootprintSymbol]();
+      const angle = (footprint.mapAligned ? bearing : 0) + footprint.rotation;
+      // the box is rebuilt from a fresh projection every pass — the camera
+      // has usually moved since the last one, so caching it would lie
+      const bounds = computeMarkerAABB(map.project(marker.getLngLat()), footprint, angle);
+      entries.push({ index: entries.length, marker, bounds, proximityBounds: inflateBounds(bounds, halfPadding) });
+    }
+
+    // overlap and proximity are the same test at different paddings: the
+    // candidate query IS the proximity test (both boxes pre-inflated), and
+    // the exact boxes re-tested inside it give overlap
+    const source = createCandidateSource(entries, (entry) => entry.proximityBounds);
+    const overlapPairs: [number, number][] = [];
+    const proximityPairs: [number, number][] = [];
+    const next: Record<MarkerCollisionKind, Map<string, Set<Marker>>> = { overlap: new Map(), proximity: new Map() };
+
+    for (const entry of entries) {
+      for (const other of source.query(entry.proximityBounds)) {
+        if (other.index <= entry.index) continue; // each pair once, and never self
+        proximityPairs.push([entry.index, other.index]);
+        this.linkCollision(next.proximity, entry.marker, other.marker);
+        if (boundsIntersect(entry.bounds, other.bounds)) {
+          overlapPairs.push([entry.index, other.index]);
+          this.linkCollision(next.overlap, entry.marker, other.marker);
+        }
+      }
+    }
+
+    state.groups = {
+      overlap: deriveCollisionGroups(entries, overlapPairs).map((group) => group.map((entry) => entry.marker)),
+      proximity: deriveCollisionGroups(entries, proximityPairs).map((group) => group.map((entry) => entry.marker)),
+    };
+
+    this.emitCollisionDiffs(index, state.previous.proximity, next.proximity, "proximity");
+    this.emitCollisionDiffs(index, state.previous.overlap, next.overlap, "overlap");
+    state.previous = next;
+  }
+
+  // records a colliding pair in both markers' collision sets
+  private linkCollision(sets: Map<string, Set<Marker>>, a: Marker, b: Marker): void {
+    let setA = sets.get(a.id);
+    if (!setA) sets.set(a.id, (setA = new Set()));
+    setA.add(b);
+    let setB = sets.get(b.id);
+    if (!setB) sets.set(b.id, (setB = new Set()));
+    setB.add(a);
+  }
+
+  // diffs each marker's collision set against the previous pass and has the
+  // marker emit only the transitions — unchanged collisions stay silent
+  private emitCollisionDiffs(index: Map<string, Marker>, previous: Map<string, Set<Marker>>, next: Map<string, Set<Marker>>, kind: MarkerCollisionKind): void {
+    for (const marker of index.values()) {
+      const previousSet = previous.get(marker.id) ?? EMPTY_MARKER_SET;
+      const nextSet = next.get(marker.id) ?? EMPTY_MARKER_SET;
+      const entered = [...nextSet].filter((counterpart) => !previousSet.has(counterpart));
+      const exited = [...previousSet].filter((counterpart) => !nextSet.has(counterpart));
+      if (entered.length === 0 && exited.length === 0) continue;
+      marker[EmitCollisionDiffSymbol]({ kind, entered, exited, current: [...nextSet] });
+    }
   }
 
   //#endregion

--- a/src/Marker/collision-helpers.ts
+++ b/src/Marker/collision-helpers.ts
@@ -14,9 +14,25 @@ export type Bounds = {
   top: number;
   bottom: number;
 };
-
 /** A point in screen space from top left in px. */
 export type ScreenPoint = { x: number; y: number };
+
+/**
+ * Screen-space oriented bounding box: the marker's actual rotated rectangle.
+ * `cos`/`sin` are precomputed from the rotation angle so both the SAT test
+ * and the enclosing-AABB derivation reuse them.
+ */
+export type OBB = {
+  /** Box center, screen px. */
+  cx: number;
+  cy: number;
+  /** Half extents along the box's own axes, px. */
+  hw: number;
+  hh: number;
+  /** Rotation of the box's axes (cos/sin of the angle). */
+  cos: number;
+  sin: number;
+};
 
 /**
  * A marker's screen footprint, resolved from its props once per pass —
@@ -31,6 +47,13 @@ export type MarkerFootprint = {
   anchor: NonNullable<MarkerOptions["anchor"]>;
   /** Screen-space pixel offset applied after projection (+y down). */
   offset: [number, number];
+  /**
+   * Displacement from the element center to the rotation origin, in CSS px
+   * (+y down). Mirrors the inner wrapper's CSS `transform-origin`: `[0, 0]`
+   * for center-origin elements, `[0, height / 2]` for bottom-anchored shapes
+   * that rotate around their tip.
+   */
+  pivot: [number, number];
   /** The marker's own rotation in degrees (its inner-shell CSS rotation). */
   rotation: number;
   /** `true` when the marker rotates with the map bearing (`rotationAlignment: "map"`). */
@@ -55,6 +78,7 @@ export const DEFAULT_PROXIMITY_PADDING = 4;
  * Displacement from the anchor point to the element center, unrotated.
  * E.g. a `bottom` anchor puts the element's bottom edge on the point, so the
  * center sits half a height *above* it (-y).
+ * TODO: refactor this to avoid a complicated if / else chain.
  */
 function anchorToCenter(anchor: MarkerFootprint["anchor"], width: number, height: number): [number, number] {
   let dx = 0;
@@ -67,14 +91,13 @@ function anchorToCenter(anchor: MarkerFootprint["anchor"], width: number, height
 }
 
 /**
- * Computes the screen-space AABB of a rotated marker box.
+ * Computes the screen-space oriented box of a marker.
  *
  * The box is rotated by `angleDeg` (map bearing for map-aligned markers plus
- * the marker's own rotation) and the enclosing axis-aligned box is returned.
- * For unrotated (viewport-aligned) markers the rotation terms collapse to
- * the plain box. Pitch is deliberately ignored — under pitch the true
- * footprint foreshortens, so the full-height box over-reserves space, which
- * fails safe.
+ * the marker's own rotation). For unrotated (viewport-aligned) markers the
+ * rotation terms collapse to the plain box. Pitch is deliberately ignored —
+ * under pitch the true footprint foreshortens, so the full-height box
+ * over-reserves space, which fails safe.
  *
  * @param position - The marker's *screen* position (normally
  *   `map.project(lngLat)`). Taken as an explicit argument so behaviours that
@@ -82,23 +105,69 @@ function anchorToCenter(anchor: MarkerFootprint["anchor"], width: number, height
  *   the rendered point instead.
  * @param footprint - The marker's resolved footprint.
  * @param angleDeg - Total clockwise rotation of the box in degrees.
- * @param padding - Inflates the box on every side; `0` gives the exact box.
  */
-export function computeMarkerAABB(position: ScreenPoint, footprint: MarkerFootprint, angleDeg: number, padding = 0): Bounds {
+export function computeMarkerOBB(position: ScreenPoint, footprint: MarkerFootprint, angleDeg: number): OBB {
   const rad = (angleDeg * Math.PI) / 180;
   const cos = Math.cos(rad);
   const sin = Math.sin(rad);
 
-  // the anchor displacement rotates with the element; the offset is applied
-  // by MapLibre in screen space before the rotation transform, so it doesn't
+  // MapLibre applies the anchor translate and offset on the outer container,
+  // before the inner wrapper's rotation transform — neither rotates. The
+  // rotation happens around the wrapper's transform-origin, so the element
+  // center swings around that pivot: with origin O = C0 + p, the rotated
+  // center is C = O - R·p.
   const [adx, ady] = anchorToCenter(footprint.anchor, footprint.width, footprint.height);
-  const cx = position.x + footprint.offset[0] + (adx * cos - ady * sin);
-  const cy = position.y + footprint.offset[1] + (adx * sin + ady * cos);
+  const [px, py] = footprint.pivot;
+  const cx = position.x + footprint.offset[0] + adx + px - (px * cos - py * sin);
+  const cy = position.y + footprint.offset[1] + ady + py - (px * sin + py * cos);
 
-  const ex = (footprint.width / 2) * Math.abs(cos) + (footprint.height / 2) * Math.abs(sin) + padding;
-  const ey = (footprint.width / 2) * Math.abs(sin) + (footprint.height / 2) * Math.abs(cos) + padding;
+  return { cx, cy, hw: footprint.width / 2, hh: footprint.height / 2, cos, sin };
+}
 
-  return { left: cx - ex, right: cx + ex, top: cy - ey, bottom: cy + ey };
+/**
+ * Returns the axis-aligned box enclosing an oriented box, inflated by
+ * `padding` on every side. Used as the broad-phase box: it can only
+ * over-include, never miss a real intersection.
+ */
+export function obbToAABB(obb: OBB, padding = 0): Bounds {
+  const ex = obb.hw * Math.abs(obb.cos) + obb.hh * Math.abs(obb.sin) + padding;
+  const ey = obb.hw * Math.abs(obb.sin) + obb.hh * Math.abs(obb.cos) + padding;
+  return { left: obb.cx - ex, right: obb.cx + ex, top: obb.cy - ey, bottom: obb.cy + ey };
+}
+
+/**
+ * Exact intersection test for two oriented boxes via the separating axis
+ * theorem: two convex boxes are disjoint iff some axis of either box
+ * separates their projections, so only the four box axes need testing.
+ *
+ * @param padding - Inflates both boxes' half extents; the two-box test then
+ *   answers "are the exact boxes within `2 * padding` of each other" the same
+ *   way the pre-inflated AABBs do for the axis-aligned path.
+ */
+export function obbIntersect(a: OBB, b: OBB, padding = 0): boolean {
+  const ahw = a.hw + padding;
+  const ahh = a.hh + padding;
+  const bhw = b.hw + padding;
+  const bhh = b.hh + padding;
+  const dx = b.cx - a.cx;
+  const dy = b.cy - a.cy;
+
+  // both boxes' local axes: (cos, sin) is the x-axis, (-sin, cos) the y-axis
+  const axes: [number, number][] = [
+    [a.cos, a.sin],
+    [-a.sin, a.cos],
+    [b.cos, b.sin],
+    [-b.sin, b.cos],
+  ];
+
+  for (const [nx, ny] of axes) {
+    // projection radius of each box onto the axis: sum of its half-extent
+    // vectors' absolute projections
+    const ra = ahw * Math.abs(a.cos * nx + a.sin * ny) + ahh * Math.abs(-a.sin * nx + a.cos * ny);
+    const rb = bhw * Math.abs(b.cos * nx + b.sin * ny) + bhh * Math.abs(-b.sin * nx + b.cos * ny);
+    if (Math.abs(dx * nx + dy * ny) > ra + rb) return false;
+  }
+  return true;
 }
 
 /** Returns `bounds` grown by `padding` px on every side. */

--- a/src/Marker/collision-helpers.ts
+++ b/src/Marker/collision-helpers.ts
@@ -1,0 +1,183 @@
+import type { MarkerOptions } from "maplibre-gl";
+
+/**
+ * Pure geometry and grouping helpers for marker collision detection.
+ *
+ */
+
+//#region Types
+
+/** Screen-space axis-aligned bounding box, in CSS pixels (+y down). */
+export type Bounds = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+/** A point in screen space from top left in px. */
+export type ScreenPoint = { x: number; y: number };
+
+/**
+ * A marker's screen footprint, resolved from its props once per pass —
+ * never measured from the DOM inside the pass. (.getBoundingClientRect triggers layout)
+ */
+export type MarkerFootprint = {
+  /** Rendered width in CSS px, with 2-D scale applied. */
+  width: number;
+  /** Rendered height in CSS px, with 2-D scale applied. */
+  height: number;
+  /** Which point of the element sits on the marker's screen position. */
+  anchor: NonNullable<MarkerOptions["anchor"]>;
+  /** Screen-space pixel offset applied after projection (+y down). */
+  offset: [number, number];
+  /** The marker's own rotation in degrees (its inner-shell CSS rotation). */
+  rotation: number;
+  /** `true` when the marker rotates with the map bearing (`rotationAlignment: "map"`). */
+  mapAligned: boolean;
+};
+
+//#endregion
+
+//#region Config
+
+/**
+ * Default proximity threshold in CSS px: two markers whose boxes come within
+ * this distance of each other are "in proximity". Overlap always uses 0.
+ */
+export const DEFAULT_PROXIMITY_PADDING = 4;
+
+//#endregion
+
+//#region Geometry
+
+/**
+ * Displacement from the anchor point to the element center, unrotated.
+ * E.g. a `bottom` anchor puts the element's bottom edge on the point, so the
+ * center sits half a height *above* it (-y).
+ */
+function anchorToCenter(anchor: MarkerFootprint["anchor"], width: number, height: number): [number, number] {
+  let dx = 0;
+  let dy = 0;
+  if (anchor.includes("left")) dx = width / 2;
+  else if (anchor.includes("right")) dx = -width / 2;
+  if (anchor.includes("top")) dy = height / 2;
+  else if (anchor.includes("bottom")) dy = -height / 2;
+  return [dx, dy];
+}
+
+/**
+ * Computes the screen-space AABB of a rotated marker box.
+ *
+ * The box is rotated by `angleDeg` (map bearing for map-aligned markers plus
+ * the marker's own rotation) and the enclosing axis-aligned box is returned.
+ * For unrotated (viewport-aligned) markers the rotation terms collapse to
+ * the plain box. Pitch is deliberately ignored — under pitch the true
+ * footprint foreshortens, so the full-height box over-reserves space, which
+ * fails safe.
+ *
+ * @param position - The marker's *screen* position (normally
+ *   `map.project(lngLat)`). Taken as an explicit argument so behaviours that
+ *   render a marker somewhere other than its geographic position can pass
+ *   the rendered point instead.
+ * @param footprint - The marker's resolved footprint.
+ * @param angleDeg - Total clockwise rotation of the box in degrees.
+ * @param padding - Inflates the box on every side; `0` gives the exact box.
+ */
+export function computeMarkerAABB(position: ScreenPoint, footprint: MarkerFootprint, angleDeg: number, padding = 0): Bounds {
+  const rad = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+
+  // the anchor displacement rotates with the element; the offset is applied
+  // by MapLibre in screen space before the rotation transform, so it doesn't
+  const [adx, ady] = anchorToCenter(footprint.anchor, footprint.width, footprint.height);
+  const cx = position.x + footprint.offset[0] + (adx * cos - ady * sin);
+  const cy = position.y + footprint.offset[1] + (adx * sin + ady * cos);
+
+  const ex = (footprint.width / 2) * Math.abs(cos) + (footprint.height / 2) * Math.abs(sin) + padding;
+  const ey = (footprint.width / 2) * Math.abs(sin) + (footprint.height / 2) * Math.abs(cos) + padding;
+
+  return { left: cx - ex, right: cx + ex, top: cy - ey, bottom: cy + ey };
+}
+
+/** Returns `bounds` grown by `padding` px on every side. */
+export function inflateBounds(bounds: Bounds, padding: number): Bounds {
+  return {
+    left: bounds.left - padding,
+    right: bounds.right + padding,
+    top: bounds.top - padding,
+    bottom: bounds.bottom + padding,
+  };
+}
+
+/** The single intersection test — overlap and proximity both go through here. */
+export function boundsIntersect(a: Bounds, b: Bounds): boolean {
+  return a.left <= b.right && b.left <= a.right && a.top <= b.bottom && b.top <= a.bottom;
+}
+
+//#endregion
+
+//#region Candidate Search
+
+/** Answers "which entries are near this box" for the detection pass. */
+export type CollisionCandidateSource<T> = {
+  query(bounds: Bounds): readonly T[];
+};
+
+/**
+ * The seam between the pairwise scan and the grouping/event logic.
+ *
+ * Currently a linear scan (O(n) per query, O(n²) per pass). When marker
+ * counts demand it, replace the internals with a spatial index (rbush /
+ * uniform grid) — callers only depend on `query`.
+ */
+export function createCandidateSource<T>(items: readonly T[], boundsOf: (item: T) => Bounds): CollisionCandidateSource<T> {
+  return {
+    query(bounds: Bounds): readonly T[] {
+      return items.filter((item) => boundsIntersect(boundsOf(item), bounds));
+    },
+  };
+}
+
+//#endregion
+
+//#region Grouping
+
+/**
+ * Derives collision groups (connected components) from pairwise collisions.
+ *
+ * Groups keep the *full set* of mutually-colliding items — no winners or
+ * losers. Behaviours like reposition-column and cluster need every member to
+ * compute an average position, which winner/loser output cannot provide.
+ *
+ * @param items - All entries in the pass, indexable by the pair indices.
+ * @param pairs - Colliding index pairs `[i, j]`.
+ * @returns Components with two or more members; singletons are not groups.
+ */
+export function deriveCollisionGroups<T>(items: readonly T[], pairs: readonly [number, number][]): T[][] {
+  // union-find with path compression
+  const parent = items.map((_, i) => i);
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]];
+      i = parent[i];
+    }
+    return i;
+  };
+  for (const [a, b] of pairs) {
+    parent[find(a)] = find(b);
+  }
+
+  const components = new Map<number, T[]>();
+  for (let i = 0; i < items.length; i++) {
+    const root = find(i);
+    const members = components.get(root);
+    if (members) members.push(items[i]);
+    else components.set(root, [items[i]]);
+  }
+
+  return [...components.values()].filter((group) => group.length > 1);
+}
+
+//#endregion

--- a/src/Marker/index.ts
+++ b/src/Marker/index.ts
@@ -1,4 +1,3 @@
 export * from "./Marker";
 export * from "./types";
-export * from "./marker-content-registry";
-export * from "./marker-adaptive-colors";
+export type { ReferenceStyleKey, AdaptiveStyleKey, AdaptiveColor, AdaptiveColorName } from "./marker-adaptive-colors";

--- a/src/Marker/marker-dom-utils.ts
+++ b/src/Marker/marker-dom-utils.ts
@@ -367,8 +367,7 @@ function buildDebugOverlay(): SVGSVGElement {
   box.setAttribute("width", "100%");
   box.setAttribute("height", "100%");
   box.setAttribute("fill", "none");
-  box.setAttribute("stroke-dasharray", "0.1");
-  box.setAttribute("stroke-width", "0.1");
+  box.setAttribute("stroke-dasharray", "4 4");
   svg.appendChild(box);
 
   const hLine = svgEl("line");
@@ -377,7 +376,6 @@ function buildDebugOverlay(): SVGSVGElement {
   hLine.setAttribute("x2", "100%");
   hLine.setAttribute("y2", "50%");
   hLine.setAttribute("opacity", "0.5");
-  hLine.setAttribute("stroke-width", "0.1");
   svg.appendChild(hLine);
 
   const vLine = svgEl("line");
@@ -386,7 +384,6 @@ function buildDebugOverlay(): SVGSVGElement {
   vLine.setAttribute("x2", "50%");
   vLine.setAttribute("y2", "100%");
   vLine.setAttribute("opacity", "0.5");
-  vLine.setAttribute("stroke-width", "0.1");
   svg.appendChild(vLine);
 
   // zero-length round-capped line renders as a fixed-size dot — unlike a
@@ -397,7 +394,7 @@ function buildDebugOverlay(): SVGSVGElement {
   dot.setAttribute("x2", "50%");
   dot.setAttribute("y2", "50%");
   dot.setAttribute("stroke-linecap", "round");
-  dot.setAttribute("stroke-width", "1");
+  dot.setAttribute("stroke-width", "5");
   svg.appendChild(dot);
 
   for (const part of [box, hLine, vLine, dot]) {

--- a/src/Marker/marker-dom-utils.ts
+++ b/src/Marker/marker-dom-utils.ts
@@ -662,7 +662,7 @@ function appendTemplateContent(svg: SVGSVGElement, template: string, params: Rec
   const factory = getMarkerTemplate(template);
 
   if (!factory) {
-    console.warn(`Unknown marker template "${template}" — register it with registerMarkerTemplate().`);
+    console.warn(`Unknown marker template "${template}".`);
     return;
   }
 

--- a/src/Marker/marker-symbols.ts
+++ b/src/Marker/marker-symbols.ts
@@ -3,3 +3,7 @@ export const PendingUpdatesSymbol = Symbol("MapTiler:Marker:pendingUpdates");
 export const MarkerElementSymbol = Symbol("MapTiler:Marker:markerElement");
 export const DetachFromDOMSymbol = Symbol("MapTiler:Marker:detachFromDOM");
 export const RefreshAdaptiveColorSymbol = Symbol("MapTiler:Marker:refreshAdaptiveColor");
+export const CollisionFootprintSymbol = Symbol("MapTiler:Marker:collisionFootprint");
+export const EmitCollisionDiffSymbol = Symbol("MapTiler:Marker:emitCollisionDiff");
+export const ShouldHideSymbol = Symbol("MapTiler:Marker:shouldHide");
+export const MeasuredElementSizeSymbol = Symbol("MapTiler:Marker:measuredElementSize");

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -1,5 +1,6 @@
 import type { MarkerOptions } from "maplibre-gl";
 import type { AdaptiveColor, AdaptiveColorName } from "./marker-adaptive-colors";
+import type { Marker } from "./Marker";
 
 //#region Primitives
 
@@ -29,6 +30,41 @@ export const CollisionBehaviour = {
 export type CollisionBehaviour = (typeof CollisionBehaviour)[keyof typeof CollisionBehaviour];
 
 export type Vector2 = [number, number];
+
+/**
+ * Kind of spatial collision between two markers.
+ * - `overlap` — the markers' boxes intersect.
+ * - `proximity` — the boxes are within the configured proximity padding
+ *   (a superset of `overlap`).
+ */
+export type MarkerCollisionKind = "overlap" | "proximity";
+
+/**
+ * Payload of the `markeroverlap` / `markerproximity` events.
+ *
+ * Emitted on state change only: a marker fires when counterparts *enter* or
+ * *exit* collision with it, never for collisions that persist unchanged
+ * between passes.
+ */
+export type MarkerCollisionEventData = {
+  kind: MarkerCollisionKind;
+  /** Markers that started colliding with this marker in this pass. */
+  entered: Marker[];
+  /** Markers that stopped colliding with this marker in this pass (may already be removed from the map). */
+  exited: Marker[];
+  /** All markers currently colliding with this marker. */
+  current: Marker[];
+};
+
+/**
+ * Sets of mutually-colliding markers from the latest detection pass —
+ * connected components of the pairwise collision graph, with no
+ * winner/loser resolution applied.
+ */
+export type MarkerCollisionGroups = {
+  overlap: Marker[][];
+  proximity: Marker[][];
+};
 
 /**
  * MapLibre-style expression that resolves to a numeric priority.

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -67,6 +67,24 @@ export type MarkerCollisionGroups = {
 };
 
 /**
+ * How precisely marker collision boxes track rotation.
+ * - `high` (default) — rotated markers are tested with their actual rotated
+ *   box (separating-axis test), so collisions match the rendered footprint.
+ * - `low` — rotated markers are tested with the upright box enclosing the
+ *   rotated one. Cheaper per pair, but over-reports collisions for elongated
+ *   markers at strong rotations (never misses a real one).
+ */
+export type MarkerCollisionAccuracy = "low" | "high";
+
+/** Per-map configuration of the marker collision engine. */
+export type MarkerCollisionOptions = {
+  /** Distance in CSS px within which two markers count as "in proximity". Overlap always uses 0. */
+  proximityPadding?: number;
+  /** Collision box accuracy for rotated markers. Defaults to `high`. */
+  accuracy?: MarkerCollisionAccuracy;
+};
+
+/**
  * MapLibre-style expression that resolves to a numeric priority.
  * Evaluated by the collision engine, not applied directly to the DOM.
  */


### PR DESCRIPTION
## Objective
Implements collision detection in Markers using internal math rather than DOM (`.getBoundingClientRect()`) access with the idea of it being more efficient and able to be used on every frame.


## Description
- fixes debugging logic
- adds collision helpers
- implement collision logic in `MarkerManager` and `Marker` classes
- fix exports to only export needed public APIs
- remove `registerTemplate` api (superfluous)
- comment types and functions (AI)
- update demo (AI)
- add precision option for marker collisions
- add `obbIntersect` helper func (AI) to check rotated intersecting bounding boxes.
- add `setMarkerCollisionOptions` method the Map class for changing collision precision and proximity settings
- add associated method to `MarkerManager` class `setCollisionOptions`

## Acceptance
- Manually tested.

## Checklist
- [ ] ~I have added relevant info to the CHANGELOG.md`~