### PR TITLE
CL-5874 Support EU endpoints configuration across SDK

### DIFF
--- a/src/ImageViewer/ImageViewer.ts
+++ b/src/ImageViewer/ImageViewer.ts
@@ -911,5 +911,5 @@ function getAPIBasePath() {
     return overrideUrl;
   }
 
-  return "https://api.maptiler.com/images";
+  return `${config.apiURL}images`;
 }

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1693,7 +1693,7 @@ export class Map extends maplibregl.Map {
       const sourceURL = new URL(source.url);
 
       // Only layers managed by MapTiler are considered for language switch
-      if (sourceURL.host !== defaults.maptilerApiHost) {
+      if (sourceURL.host !== config.apiHost) {
         continue;
       }
 
@@ -1890,7 +1890,7 @@ export class Map extends maplibregl.Map {
 
       this.addSource(defaults.terrainSourceId, {
         type: "raster-dem",
-        url: defaults.terrainSourceURL,
+        url: `${config.apiURL}tiles/terrain-rgb-v2/tiles.json`,
       });
 
       // Setting up the terrain with a 0 exaggeration factor

--- a/src/Telemetry.ts
+++ b/src/Telemetry.ts
@@ -1,7 +1,6 @@
 import { getVersion } from ".";
 import type { Map as MapSDK } from "./Map";
 import { config, MAPTILER_SESSION_ID } from "./config";
-import { defaults } from "./constants/defaults";
 
 /**
  * A Telemetry instance sends some usage and merics to a dedicated endpoint at MapTiler Cloud.
@@ -59,7 +58,7 @@ export class Telemetry {
   }
 
   private preparePayload(): string {
-    const telemetryUrl = new URL(defaults.telemetryURL);
+    const telemetryUrl = new URL(`${config.apiURL}metrics`);
 
     // Adding the version of the SDK
     telemetryUrl.searchParams.append("sdk", getVersion());

--- a/src/caching.ts
+++ b/src/caching.ts
@@ -4,7 +4,6 @@ import { config } from "./config";
 
 import maplibregl from "maplibre-gl";
 
-import { defaults } from "./constants/defaults";
 import { TileJSON } from "@maptiler/client";
 
 const LOCAL_CACHE_PROTOCOL_SOURCE = "localcache_source";
@@ -20,7 +19,7 @@ const { addProtocol } = maplibregl;
 //#region localCacheTransformRequest
 
 export function localCacheTransformRequest(reqUrl: URL, resourceType?: ResourceType): string {
-  if (CACHE_API_AVAILABLE && config.caching && config.session && reqUrl.host === defaults.maptilerApiHost) {
+  if (CACHE_API_AVAILABLE && config.caching && config.session && reqUrl.host === config.apiHost) {
     if (resourceType === "Source" && reqUrl.href.includes("tiles.json")) {
       return reqUrl.href.replace("https://", `${LOCAL_CACHE_PROTOCOL_SOURCE}://`);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,18 +114,18 @@ class SdkConfig extends EventEmitter {
 
   /**
    * Switch between the default `api.maptiler.com` host and the EU-based `api.maptiler.eu` host.
-   * Call with `false` to switch back to the default.
+   * Set to `false` to switch back to the default.
    */
-  useEuEndpoints(value = true): void {
-    clientConfig.useEuEndpoints(value);
+  set useEuEndpoints(value: boolean) {
+    clientConfig.useEuEndpoints = value;
     this.emit("useEuEndpoints", value);
   }
 
   /**
    * Whether the EU-based `api.maptiler.eu` host is currently in use instead of the default `api.maptiler.com`
    */
-  get isUsingEuEndpoints(): boolean {
-    return clientConfig.isUsingEuEndpoints;
+  get useEuEndpoints(): boolean {
+    return clientConfig.useEuEndpoints;
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -113,6 +113,37 @@ class SdkConfig extends EventEmitter {
   }
 
   /**
+   * Switch between the default `api.maptiler.com` host and the EU-based `api.maptiler.eu` host.
+   * Call with `false` to switch back to the default.
+   */
+  useEuEndpoints(value = true): void {
+    clientConfig.useEuEndpoints(value);
+    this.emit("useEuEndpoints", value);
+  }
+
+  /**
+   * Whether the EU-based `api.maptiler.eu` host is currently in use instead of the default `api.maptiler.com`
+   */
+  get isUsingEuEndpoints(): boolean {
+    return clientConfig.isUsingEuEndpoints;
+  }
+
+  /**
+   * The host currently used for the MapTiler API requests (`api.maptiler.com` or `api.maptiler.eu`)
+   */
+  get apiHost(): string {
+    return clientConfig.apiHost;
+  }
+
+  /**
+   * The base URL currently used for the MapTiler API requests
+   * (`https://api.maptiler.com/` or `https://api.maptiler.eu/`)
+   */
+  get apiURL(): string {
+    return clientConfig.apiURL;
+  }
+
+  /**
    * The default number of steps to sample for the experimental flyTo path preloading.
    */
   private _experimentalDefaultPathSampleSteps = 4;

--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -4,14 +4,10 @@ import { Language } from "../language";
  * Some default settings for the SDK
  */
 const defaults = {
-  maptilerLogoURL: "https://api.maptiler.com/resources/logo.svg",
   maptilerURL: "https://www.maptiler.com/",
-  maptilerApiHost: "api.maptiler.com",
-  telemetryURL: "https://api.maptiler.com/metrics",
   rtlPluginURL: "https://cdn.maptiler.com/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.min.js",
   primaryLanguage: Language.STYLE,
   secondaryLanguage: Language.LOCAL,
-  terrainSourceURL: "https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json",
   terrainSourceId: "maptiler-terrain",
 };
 

--- a/src/controls/MaptilerLogoControl.ts
+++ b/src/controls/MaptilerLogoControl.ts
@@ -1,5 +1,6 @@
 import type { LogoControlOptions as LogoControlOptionsML } from "maplibre-gl";
 import { defaults } from "../constants/defaults";
+import { config } from "../config";
 import { LogoControl } from "../MLAdapters/LogoControl";
 import type { Map as SDKMap } from "../Map";
 
@@ -20,7 +21,7 @@ export class MaptilerLogoControl extends LogoControl {
   constructor(options: LogoControlOptions = {}) {
     super(options);
 
-    this.logoURL = options.logoURL ?? defaults.maptilerLogoURL;
+    this.logoURL = options.logoURL ?? `${config.apiURL}resources/logo.svg`;
     this.linkURL = options.linkURL ?? defaults.maptilerURL;
   }
 

--- a/src/custom-layers/CubemapLayer/CubemapLayer.ts
+++ b/src/custom-layers/CubemapLayer/CubemapLayer.ts
@@ -1,6 +1,7 @@
 import type { CustomLayerInterface, CustomRenderMethodInput } from "maplibre-gl";
 import { mat4 } from "gl-matrix";
 
+import { config } from "../../config";
 import type { Map as MapSDK } from "../../Map";
 import { createObject3D, type WebGLContext, type Object3D, parseColorStringToVec4, Vec4 } from "../../utils/webgl-utils";
 
@@ -12,7 +13,9 @@ import { cubemapPresets, type CubemapDefinition, type CubemapFaces, type Cubemap
 import { lerp, lerpVec4 } from "../../utils/math-utils";
 import { orderObjectKeys } from "../../utils/object";
 
-const SPACE_IMAGES_BASE_URL = "https://api.maptiler.com/resources/space";
+function getSpaceImagesBaseUrl(): string {
+  return `${config.apiURL}resources/space`;
+}
 
 const ATTRIBUTES_KEYS = ["vertexPosition"] as const;
 const UNIFORMS_KEYS = ["projectionMatrix", "modelViewMatrix", "cubeSampler", "bgColor", "fadeOpacity"] as const;
@@ -711,12 +714,12 @@ function getCubemapFaces(options: CubemapDefinition): CubemapFaces | null {
 
   if (options.preset) {
     return {
-      pX: `${SPACE_IMAGES_BASE_URL}/${options.preset}/px.webp`,
-      nX: `${SPACE_IMAGES_BASE_URL}/${options.preset}/nx.webp`,
-      pY: `${SPACE_IMAGES_BASE_URL}/${options.preset}/py.webp`,
-      nY: `${SPACE_IMAGES_BASE_URL}/${options.preset}/ny.webp`,
-      pZ: `${SPACE_IMAGES_BASE_URL}/${options.preset}/pz.webp`,
-      nZ: `${SPACE_IMAGES_BASE_URL}/${options.preset}/nz.webp`,
+      pX: `${getSpaceImagesBaseUrl()}/${options.preset}/px.webp`,
+      nX: `${getSpaceImagesBaseUrl()}/${options.preset}/nx.webp`,
+      pY: `${getSpaceImagesBaseUrl()}/${options.preset}/py.webp`,
+      nY: `${getSpaceImagesBaseUrl()}/${options.preset}/ny.webp`,
+      pZ: `${getSpaceImagesBaseUrl()}/${options.preset}/pz.webp`,
+      nZ: `${getSpaceImagesBaseUrl()}/${options.preset}/nz.webp`,
     };
   }
 

--- a/src/helpers/vectorlayerhelpers.ts
+++ b/src/helpers/vectorlayerhelpers.ts
@@ -541,7 +541,7 @@ export async function addPolyline(
   if (typeof data === "string") {
     // if options.data exists and is a uuid string, we consider that it points to a MapTiler Dataset
     if (isUUID(data)) {
-      data = `https://api.maptiler.com/data/${data}/features.json?key=${config.apiKey}`;
+      data = `${config.apiURL}data/${data}/features.json?key=${config.apiKey}`;
     } else {
       // options.data could be absolute or relative url
       if (/^(?:\w+:|\.|\/)/.test(data)) {
@@ -729,7 +729,7 @@ export function addPolygon(
 
     // If is a UUID, we extend it to be the URL to a MapTiler Cloud hosted dataset
     if (typeof data === "string" && isUUID(data)) {
-      data = `https://api.maptiler.com/data/${data}/features.json?key=${config.apiKey}`;
+      data = `${config.apiURL}data/${data}/features.json?key=${config.apiKey}`;
     }
 
     // Adding the source
@@ -944,7 +944,7 @@ export function addPoint(
 
     // If is a UUID, we extend it to be the URL to a MapTiler Cloud hosted dataset
     if (typeof data === "string" && isUUID(data)) {
-      data = `https://api.maptiler.com/data/${data}/features.json?key=${config.apiKey}`;
+      data = `${config.apiURL}data/${data}/features.json?key=${config.apiKey}`;
     }
 
     // Adding the source
@@ -1275,7 +1275,7 @@ export function addHeatmap(
 
     // If is a UUID, we extend it to be the URL to a MapTiler Cloud hosted dataset
     if (typeof data === "string" && isUUID(data)) {
-      data = `https://api.maptiler.com/data/${data}/features.json?key=${config.apiKey}`;
+      data = `${config.apiURL}data/${data}/features.json?key=${config.apiKey}`;
     }
 
     // Adding the source

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -52,7 +52,7 @@ export function maptilerCloudTransformRequest(url: string, resourceType?: Resour
     };
   }
 
-  if (reqUrl.host === defaults.maptilerApiHost) {
+  if (reqUrl.host === config.apiHost) {
     if (!reqUrl.searchParams.has("key")) {
       reqUrl.searchParams.append("key", config.apiKey);
     }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { config } from "../src/config";
+import { maptilerCloudTransformRequest } from "../src/tools";
+
+describe("config.useEuEndpoints()", () => {
+  afterEach(() => {
+    config.useEuEndpoints(false);
+  });
+
+  it("defaults to the .com host", () => {
+    expect(config.isUsingEuEndpoints).toBe(false);
+    expect(config.apiHost).toBe("api.maptiler.com");
+    expect(config.apiURL).toBe("https://api.maptiler.com/");
+  });
+
+  it("switches to the .eu host and back", () => {
+    config.useEuEndpoints();
+    expect(config.isUsingEuEndpoints).toBe(true);
+    expect(config.apiHost).toBe("api.maptiler.eu");
+    expect(config.apiURL).toBe("https://api.maptiler.eu/");
+
+    config.useEuEndpoints(false);
+    expect(config.isUsingEuEndpoints).toBe(false);
+    expect(config.apiHost).toBe("api.maptiler.com");
+  });
+
+  it("is honored by maptilerCloudTransformRequest when injecting the API key", () => {
+    config.apiKey = "TEST_KEY";
+    config.useEuEndpoints();
+
+    const req = maptilerCloudTransformRequest("https://api.maptiler.eu/tiles/v3/tiles.json");
+    const url = new URL(req.url);
+    expect(url.searchParams.get("key")).toBe("TEST_KEY");
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -3,31 +3,31 @@ import { describe, it, expect, afterEach } from "vitest";
 import { config } from "../src/config";
 import { maptilerCloudTransformRequest } from "../src/tools";
 
-describe("config.useEuEndpoints()", () => {
+describe("config.useEuEndpoints", () => {
   afterEach(() => {
-    config.useEuEndpoints(false);
+    config.useEuEndpoints = false;
   });
 
   it("defaults to the .com host", () => {
-    expect(config.isUsingEuEndpoints).toBe(false);
+    expect(config.useEuEndpoints).toBe(false);
     expect(config.apiHost).toBe("api.maptiler.com");
     expect(config.apiURL).toBe("https://api.maptiler.com/");
   });
 
   it("switches to the .eu host and back", () => {
-    config.useEuEndpoints();
-    expect(config.isUsingEuEndpoints).toBe(true);
+    config.useEuEndpoints = true;
+    expect(config.useEuEndpoints).toBe(true);
     expect(config.apiHost).toBe("api.maptiler.eu");
     expect(config.apiURL).toBe("https://api.maptiler.eu/");
 
-    config.useEuEndpoints(false);
-    expect(config.isUsingEuEndpoints).toBe(false);
+    config.useEuEndpoints = false;
+    expect(config.useEuEndpoints).toBe(false);
     expect(config.apiHost).toBe("api.maptiler.com");
   });
 
   it("is honored by maptilerCloudTransformRequest when injecting the API key", () => {
     config.apiKey = "TEST_KEY";
-    config.useEuEndpoints();
+    config.useEuEndpoints = true;
 
     const req = maptilerCloudTransformRequest("https://api.maptiler.eu/tiles/v3/tiles.json");
     const url = new URL(req.url);


### PR DESCRIPTION
## Objective
Enable the SDK to dynamically switch between MapTiler's default `.com` and EU-based `.eu` API endpoints throughout all components that make API requests.

## Description
This change introduces comprehensive support for EU endpoint configuration by:

1. **Extended config API** (`src/config.ts`):
   - Added `useEuEndpoints(value?: boolean)` method to switch between `api.maptiler.com` and `api.maptiler.eu`
   - Added `isUsingEuEndpoints` getter to check current endpoint status
   - Added `apiHost` getter to retrieve the current host
   - Added `apiURL` getter to retrieve the current base URL

2. **Replaced hardcoded URLs** with dynamic config references:
   - `src/Map.ts`: Updated terrain source URL and host checks to use `config.apiURL` and `config.apiHost`
   - `src/helpers/vectorlayerhelpers.ts`: Updated dataset feature URLs in polyline, polygon, point, and heatmap functions
   - `src/Telemetry.ts`: Updated telemetry endpoint to use `config.apiURL`
   - `src/caching.ts`: Updated host check to use `config.apiHost`
   - `src/controls/MaptilerLogoControl.ts`: Updated logo URL to use `config.apiURL`
   - `src/ImageViewer/ImageViewer.ts`: Updated image API base path to use `config.apiURL`
   - `src/custom-layers/CubemapLayer/CubemapLayer.ts`: Introduced `getSpaceImagesBaseUrl()` function to dynamically construct space image URLs
   - `src/tools.ts`: Updated host check to use `config.apiHost`

3. **Cleaned up defaults** (`src/constants/defaults.ts`):
   - Removed hardcoded API URLs and host that are now dynamically determined by config

4. **Added comprehensive tests** (`test/config.test.ts`):
   - Tests for default `.com` endpoint behavior
   - Tests for switching to/from `.eu` endpoints
   - Tests verifying that endpoint changes are honored by request transformation

## Acceptance
- Added unit tests covering endpoint switching and integration with request transformation
- All hardcoded API references have been replaced with dynamic config-based URLs
- Existing functionality is preserved while enabling EU endpoint support

## Checklist
- [ ] I have added relevant info to the CHANGELOG.md

https://claude.ai/code/session_01HF5td6ttnvHZWWFeG9L3Yy