### PR TITLE
RD-1404 transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NEXT
 ### ✨ Features and improvements
+- Adds a marker `transitions` API: `position`, `scale`, `rotation`, and colour properties (`outerColor`, `innerColor`, `contentColor`, `outlineColor`) can now ease to a new value instead of snapping.
+  - Configure via the `transitions` constructor option or `setTransitionForProperty(property, [duration, easing?, delay?] | null)`; inspect with `getTransitions()`.
+  - Fires `transitionstart` / `transitionend` events — same shape as MapLibre's marker events (`type`, `target`), plus `props`: the transitioning property keyed to its value at that point (the eased-from value on `transitionstart`, the reached value on `transitionend`).
+  - Collision hide/show/minimize fade transitions are now parameterised per map via `setMarkerCollisionOptions({ transitionDuration, transitionEasing })`.
 
 ### 🐛 Bug Fixes
  - Fixes a bug in halo where a mismatch between the layer added to the map and the layer added to the `.halo` field were different instances, causing a runtime error.

--- a/demos/public/01-simple.html
+++ b/demos/public/01-simple.html
@@ -3,27 +3,14 @@
 
 <head>
   <title>MapTiler JS SDK example</title>
+  <link rel="stylesheet" href="/demo-styles.css">
   <style>
-    html,
-    body {
-      margin: 0;
-    }
-
-    #map {
-      position: absolute;
-      width: 100vw;
-      height: 100vh;
-      background: #ccc;
-    }
-
     #style-picker-container {
       position: absolute;
       z-index: 2;
       margin: 10px;
     }
   </style>
-
-  <link rel="stylesheet" href="../build/maptiler-sdk.css">
 </head>
 
 <body>

--- a/demos/public/02-sky-day.html
+++ b/demos/public/02-sky-day.html
@@ -2,12 +2,8 @@
 
 <head>
   <title>MapTiler JS SDK example</title>
+  <link rel="stylesheet" href="/demo-styles.css">
   <style>
-    html,
-    body {
-      margin: 0;
-    }
-
     #map-container {
       position: absolute;
       width: 100vw;

--- a/demos/public/03-sky-night.html
+++ b/demos/public/03-sky-night.html
@@ -23,7 +23,7 @@
     }
   </style>
 
-  <link rel="stylesheet" href="../build/maptiler-sdk.css">
+  <link rel="stylesheet" href="/demo-styles.css">
 </head>
 
 <body>

--- a/demos/public/04-ready-event.html
+++ b/demos/public/04-ready-event.html
@@ -22,7 +22,7 @@
     }
   </style>
 
-  <link rel="stylesheet" href="../build/maptiler-sdk.css">
+  <link rel="stylesheet" href="/demo-styles.css">
 </head>
 
 <body>

--- a/demos/public/18-maptiler-markers-ui-states.html
+++ b/demos/public/18-maptiler-markers-ui-states.html
@@ -100,6 +100,19 @@
       font-weight: 700;
       color: hsl(223, 100%, 45%);
     }
+
+    #transition-log {
+      font-family: monospace;
+      font-size: 10px;
+      max-height: 90px;
+      overflow-y: auto;
+    }
+
+    #transition-log div {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   </style>
 
   <link rel="stylesheet" href="../build/maptiler-sdk.css">
@@ -169,7 +182,7 @@
         <button id="transition-position" class="ctrl-btn">Nudge position</button>
         <button id="transition-toggle" class="ctrl-btn">Disable transitions</button>
       </div>
-      <div class="ctrl-hint">Last events (<code>transitionstart</code> / <code>transitionend</code>):</div>
+      <div class="ctrl-hint">Last 5 events (<code>transitionstart</code> / <code>transitionend</code>):</div>
       <div class="legend" id="transition-log"></div>
       <div class="ctrl-hint" style="word-break: break-all;" id="transition-config"></div>
     </div>

--- a/demos/public/18-maptiler-markers-ui-states.html
+++ b/demos/public/18-maptiler-markers-ui-states.html
@@ -152,6 +152,27 @@
         <span id="dom-transform">—</span>
       </div>
     </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Transitions (T marker)</div>
+      <div class="ctrl-hint">
+        <code>scale</code>, <code>outerColor</code> and <code>position</code>
+        each ease to their new value over a configured duration/easing/delay
+        instead of snapping — set via the <code>transitions</code> option or
+        <code>setTransitionForProperty()</code>.
+      </div>
+      <div class="btn-row">
+        <button id="transition-scale" class="ctrl-btn">Toggle scale</button>
+        <button id="transition-color" class="ctrl-btn">Toggle color</button>
+      </div>
+      <div class="btn-row">
+        <button id="transition-position" class="ctrl-btn">Nudge position</button>
+        <button id="transition-toggle" class="ctrl-btn">Disable transitions</button>
+      </div>
+      <div class="ctrl-hint">Last events (<code>transitionstart</code> / <code>transitionend</code>):</div>
+      <div class="legend" id="transition-log"></div>
+      <div class="ctrl-hint" style="word-break: break-all;" id="transition-config"></div>
+    </div>
   </div>
 
   <script type="module" src="/src/18-maptiler-markers-ui-states.ts"></script>

--- a/demos/public/18-maptiler-markers-ui-states.html
+++ b/demos/public/18-maptiler-markers-ui-states.html
@@ -114,8 +114,6 @@
       text-overflow: ellipsis;
     }
   </style>
-
-  <link rel="stylesheet" href="../build/maptiler-sdk.css">
 </head>
 
 <body>

--- a/demos/public/demo-styles.css
+++ b/demos/public/demo-styles.css
@@ -9,6 +9,8 @@ body {
 }
 
 #map {
-  height: 100%;
-  width: 100%;
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  background: #ccc;
 }

--- a/demos/src/18-maptiler-markers-ui-states.ts
+++ b/demos/src/18-maptiler-markers-ui-states.ts
@@ -157,10 +157,11 @@ async function main() {
 
   const eventLogEl = el("transition-log");
   const logTransitionEvent = (type: string, props: Record<string, unknown>) => {
+    const time = new Date().toLocaleTimeString(undefined, { hour12: false, minute: "2-digit", second: "2-digit", fractionalSecondDigits: 3 } as Intl.DateTimeFormatOptions);
     const line = document.createElement("div");
-    line.textContent = `${type} · ${JSON.stringify(props)}`;
+    line.textContent = `${time} · ${type} · ${JSON.stringify(props)}`;
     eventLogEl.prepend(line);
-    while (eventLogEl.childNodes.length > 4) eventLogEl.lastChild?.remove();
+    while (eventLogEl.childNodes.length > 5) eventLogEl.lastChild?.remove();
   };
   transitionMarker.on("transitionstart", (e: MarkerTransitionEventData) => {
     logTransitionEvent("start", e.props);

--- a/demos/src/18-maptiler-markers-ui-states.ts
+++ b/demos/src/18-maptiler-markers-ui-states.ts
@@ -137,12 +137,11 @@ async function main() {
   }, 100);
 
   // Transitions: scale/colour/position ease over their configured
-  // duration+easing+delay instead of snapping. Easing names are
-  // case-insensitive ("bouncein" resolves the same as "BounceIn").
+  // duration+easing+delay instead of snapping.
   const TRANSITIONS: MapTilerMarkerTransitions = {
-    scale: [500, "bouncein"],
-    outerColor: [600, "linear", 100],
-    position: [700, "sinusoidalinout"],
+    scale: [500, "BounceIn"],
+    outerColor: [600, "Linear", 100],
+    position: [700, "SinusoidalInOut"],
   };
 
   const transitionMarker = new Marker({

--- a/demos/src/18-maptiler-markers-ui-states.ts
+++ b/demos/src/18-maptiler-markers-ui-states.ts
@@ -1,6 +1,6 @@
 import { Map, MapStyle, Marker, config } from "../../src/index";
 import { setupMapTilerApiKey } from "./demo-utils";
-import type { MapTilerMarkerOptions } from "../../src/Marker";
+import type { MapTilerMarkerOptions, MapTilerMarkerTransitions, MarkerTransitionProperty, MarkerTransitionSpec, MarkerTransitionEventData } from "../../src/Marker";
 
 setupMapTilerApiKey({ config });
 
@@ -135,6 +135,69 @@ async function main() {
     propScaleEl.textContent = JSON.stringify(liveMarker.getScale());
     domTransformEl.textContent = renderedTransform(liveMarker);
   }, 100);
+
+  // Transitions: scale/colour/position ease over their configured
+  // duration+easing+delay instead of snapping. Easing names are
+  // case-insensitive ("bouncein" resolves the same as "BounceIn").
+  const TRANSITIONS: MapTilerMarkerTransitions = {
+    scale: [500, "bouncein"],
+    outerColor: [600, "linear", 100],
+    position: [700, "sinusoidalinout"],
+  };
+
+  const transitionMarker = new Marker({
+    ...base,
+    content: "T",
+    title: "Transitions",
+    transitions: { ...TRANSITIONS },
+  });
+  transitionMarker.setLngLat(at(4));
+  map.addMarker(transitionMarker);
+  addCaption(map, at(4), "TRANSITIONS (see panel)");
+
+  const eventLogEl = el("transition-log");
+  const logTransitionEvent = (type: string, props: Record<string, unknown>) => {
+    const line = document.createElement("div");
+    line.textContent = `${type} · ${JSON.stringify(props)}`;
+    eventLogEl.prepend(line);
+    while (eventLogEl.childNodes.length > 4) eventLogEl.lastChild?.remove();
+  };
+  transitionMarker.on("transitionstart", (e: MarkerTransitionEventData) => {
+    logTransitionEvent("start", e.props);
+  });
+  transitionMarker.on("transitionend", (e: MarkerTransitionEventData) => {
+    logTransitionEvent("end", e.props);
+  });
+
+  let scaledUp = false;
+  el<HTMLButtonElement>("transition-scale").addEventListener("click", () => {
+    scaledUp = !scaledUp;
+    transitionMarker.setScale(scaledUp ? [1.6, 1.6] : [1, 1]);
+  });
+
+  let colorSwapped = false;
+  el<HTMLButtonElement>("transition-color").addEventListener("click", () => {
+    colorSwapped = !colorSwapped;
+    transitionMarker.setOuterColor(colorSwapped ? "#ef4444" : undefined);
+  });
+
+  let nudged = false;
+  el<HTMLButtonElement>("transition-position").addEventListener("click", () => {
+    nudged = !nudged;
+    transitionMarker.setLngLat(nudged ? at(4.6) : at(4));
+  });
+
+  const transitionsToggleEl = el<HTMLButtonElement>("transition-toggle");
+  let transitionsEnabled = true;
+  transitionsToggleEl.addEventListener("click", () => {
+    transitionsEnabled = !transitionsEnabled;
+    for (const [property, spec] of Object.entries(TRANSITIONS) as [MarkerTransitionProperty, MarkerTransitionSpec][]) {
+      transitionMarker.setTransitionForProperty(property, transitionsEnabled ? spec : null);
+    }
+    transitionsToggleEl.textContent = transitionsEnabled ? "Disable transitions" : "Enable transitions";
+  });
+
+  el("transition-config").textContent = JSON.stringify(transitionMarker.getTransitions());
 }
 
 void main();

--- a/demos/src/18-maptiler-markers-ui-states.ts
+++ b/demos/src/18-maptiler-markers-ui-states.ts
@@ -139,9 +139,9 @@ async function main() {
   // Transitions: scale/colour/position ease over their configured
   // duration+easing+delay instead of snapping.
   const TRANSITIONS: MapTilerMarkerTransitions = {
-    scale: [500, "BounceIn"],
+    scale: [500, "SinusoidalInOut"],
     outerColor: [600, "Linear", 100],
-    position: [700, "SinusoidalInOut"],
+    position: [700, "ElasticOut"],
   };
 
   const transitionMarker = new Marker({

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1521,6 +1521,8 @@ export class Map extends maplibregl.Map {
    *   marker on this map (`always-show` | `hide-by-priority` |
    *   `minimize-by-priority`). A marker's own `collisionBehaviour` option
    *   overrides it. Defaults to `always-show`.
+   * @param options.transitionDuration - Duration in ms of the hide/show/minimize fade. Defaults to `150`.
+   * @param options.transitionEasing - CSS easing function for the fade. Defaults to `"ease"`.
    */
   setMarkerCollisionOptions(options: MarkerCollisionOptions): this {
     MarkerManager.setCollisionOptions(this, options);

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -13,6 +13,10 @@ import type {
   MapTilerMarkerUIStateName,
   MapTilerMarkerUIStates,
   UIStateSpec,
+  MarkerTransitionProperty,
+  MapTilerMarkerTransitions,
+  MarkerTransitionSpec,
+  MarkerTransitionEventData,
 } from "./types";
 import { omit } from "../utils/object";
 import { v4 as uuid } from "uuid";
@@ -32,6 +36,15 @@ import { getAdaptiveBgColor, resolveAdaptiveColor } from "./marker-adaptive-colo
 import { MarkerManager } from "./MarkerManager";
 import type { MarkerFootprint } from "./collision-helpers";
 import { flattenUIStates } from "./marker-state-helpers";
+import {
+  runPropertyTransition,
+  scaleTransitionCodec,
+  rotationTransitionCodec,
+  colorTransitionCodec,
+  positionTransitionCodec,
+  type TransitionValueCodec,
+} from "./marker-transitions";
+import type { MaptilerAnimation } from "../MaptilerAnimation";
 import {
   PendingUpdatesSymbol,
   DetachFromDOMSymbol,
@@ -79,6 +92,7 @@ const maptilerBaseOptionsKeys = [
   "rotation",
   "debug",
   "states",
+  "transitions",
 ] as const;
 
 /**
@@ -172,6 +186,12 @@ export class Marker extends maplibregl.Marker {
    */
   private appliedUIStateKeys: (keyof PendingMarkerUpdates)[] = [];
 
+  /** Registered per-property transition config, keyed by property name. */
+  private transitions: MapTilerMarkerTransitions;
+
+  /** In-flight transitions, keyed by property name — at most one per property. */
+  private readonly activeTransitions = new Map<MarkerTransitionProperty, MaptilerAnimation>();
+
   //#endregion
 
   //#region Constructor
@@ -240,6 +260,7 @@ export class Marker extends maplibregl.Marker {
 
     this.options = options;
     this.uiStates = { ...options.states };
+    this.transitions = { ...options.transitions };
     this.attachUIStateListeners();
   }
 
@@ -444,7 +465,7 @@ export class Marker extends maplibregl.Marker {
       this.cullTimer = setTimeout(() => {
         this.cullTimer = null;
         applyCollisionCulled(this.getElement(), true);
-      }, COLLISION_FADE_DURATION_MS);
+      }, this.collisionTransitionMs());
       return;
     }
 
@@ -474,13 +495,13 @@ export class Marker extends maplibregl.Marker {
       this.minimizeSwapTimer = null;
       this.setMinimizedApplied(wantMinimized);
       this.setCollisionHidden(false);
-    }, COLLISION_FADE_DURATION_MS);
+    }, this.collisionTransitionMs());
   }
 
   /**
    * Toggles the collision-hidden fade, and (re)schedules releasing the fade
-   * class once {@link COLLISION_FADE_DURATION_MS} passes with no further
-   * fade/dip transition — see {@link fadeClassReleaseTimer}.
+   * class once the map's collision transition duration passes with no
+   * further fade/dip transition — see {@link fadeClassReleaseTimer}.
    */
   private setCollisionHidden(hidden: boolean): void {
     applyCollisionHidden(this.getElement(), hidden);
@@ -488,7 +509,13 @@ export class Marker extends maplibregl.Marker {
     this.fadeClassReleaseTimer = setTimeout(() => {
       this.fadeClassReleaseTimer = null;
       releaseCollisionFadeClass(this.getElement());
-    }, COLLISION_FADE_DURATION_MS);
+    }, this.collisionTransitionMs());
+  }
+
+  /** The fade duration (ms) configured for this marker's map, or the SDK default when off a map. */
+  private collisionTransitionMs(): number {
+    const map = MarkerManager.getMap(this);
+    return map ? MarkerManager.getCollisionTransitionDuration(map) : COLLISION_FADE_DURATION_MS;
   }
 
   /** Applies or restores the minimized appearance if it differs from what the DOM shows. */
@@ -572,9 +599,12 @@ export class Marker extends maplibregl.Marker {
    * @param lnglat - The new position.
    */
   override setLngLat(lnglat: LngLatLike): this {
-    super.setLngLat(lnglat);
-    const map = MarkerManager.getMap(this);
-    if (map) MarkerManager.invalidateCollisions(map);
+    const target = maplibregl.LngLat.convert(lnglat);
+    this.applyTransitionable("position", this.getLngLat(), target, positionTransitionCodec, (v) => {
+      super.setLngLat(v);
+      const map = MarkerManager.getMap(this);
+      if (map) MarkerManager.invalidateCollisions(map);
+    });
     return this;
   }
 
@@ -603,7 +633,9 @@ export class Marker extends maplibregl.Marker {
    * @param scaleVector - Scale factors for the x and y axes.
    */
   setScale(scaleVector: Vector2) {
-    this.setProp("scale", scaleVector);
+    this.applyTransitionable<Vector2>("scale", this.props.scale ?? [1, 1], scaleVector, scaleTransitionCodec, (v) => {
+      this.setProp("scale", v);
+    });
   }
 
   /** Returns the current 2-D scale. Defaults to `[1, 1]`. */
@@ -679,7 +711,9 @@ export class Marker extends maplibregl.Marker {
    * @param color - Any valid CSS colour string.
    */
   setOuterColor(color: MapTilerMarkerOptions["outerColor"]) {
-    this.setProp("outerColor", color);
+    this.applyTransitionable("outerColor", this.props.outerColor, color, colorTransitionCodec, (v) => {
+      this.setProp("outerColor", v);
+    });
   }
 
   /** Returns the current outer body colour. */
@@ -726,7 +760,9 @@ export class Marker extends maplibregl.Marker {
       this.setProp("color", this.props.color); // resume adaptation
       return;
     }
-    this.setProp("innerColor", color);
+    this.applyTransitionable("innerColor", this.props.innerColor, color, colorTransitionCodec, (v) => {
+      this.setProp("innerColor", v);
+    });
   }
 
   /**
@@ -752,7 +788,9 @@ export class Marker extends maplibregl.Marker {
    * @param color - Any valid CSS colour string.
    */
   setContentColor(color: MapTilerMarkerOptions["contentColor"]) {
-    this.setProp("contentColor", color);
+    this.applyTransitionable("contentColor", this.props.contentColor, color, colorTransitionCodec, (v) => {
+      this.setProp("contentColor", v);
+    });
   }
 
   /** Returns the current content colour. */
@@ -770,7 +808,9 @@ export class Marker extends maplibregl.Marker {
    * @param color - Any valid CSS colour string.
    */
   setOutlineColor(color: MapTilerMarkerOptions["outlineColor"]) {
-    this.setProp("outlineColor", color);
+    this.applyTransitionable("outlineColor", this.props.outlineColor, color, colorTransitionCodec, (v) => {
+      this.setProp("outlineColor", v);
+    });
   }
 
   /** Returns the current outline stroke colour. */
@@ -882,7 +922,9 @@ export class Marker extends maplibregl.Marker {
    * @param rotation - Clockwise rotation in degrees.
    */
   override setRotation(rotation: number): this {
-    this.setProp("rotation", rotation);
+    this.applyTransitionable("rotation", this.props.rotation ?? 0, rotation, rotationTransitionCodec, (v) => {
+      this.setProp("rotation", v);
+    });
     return this;
   }
 
@@ -989,6 +1031,78 @@ export class Marker extends maplibregl.Marker {
 
   //#endregion
 
+  //#region Transitions
+
+  /**
+   * Configures (or clears) the easing used the next time `property` changes.
+   * Applies immediately, before the config takes effect on a future call —
+   * it does not retroactively animate the property's current value.
+   * @param property - Transitionable property (`position` | `scale` | `rotation` | `outerColor` | `innerColor` | `contentColor` | `outlineColor`).
+   * @param transition - `[duration, easing?, delay?]` in milliseconds, or `null` to make future changes snap immediately again.
+   */
+  setTransitionForProperty(property: MarkerTransitionProperty, transition: MarkerTransitionSpec | null): void {
+    if (transition) {
+      this.transitions[property] = transition;
+      return;
+    }
+    this.transitions = omit(this.transitions, [property]);
+  }
+
+  /** Returns a copy of the currently configured per-property transitions. */
+  getTransitions(): MapTilerMarkerTransitions {
+    return { ...this.transitions };
+  }
+
+  /**
+   * Applies `to` to `property`, either immediately or, when a transition is
+   * configured for it and the marker is on a map, by easing from `from` over
+   * the configured duration/easing/delay. Fires `transitionstart` once
+   * playback begins (i.e. after `delay`) and `transitionend` once `to` is
+   * reached. Supersedes any transition already in flight for `property`.
+   * @param property - Transitionable property being changed.
+   * @param from - Current value.
+   * @param to - Value being set.
+   * @param codec - Bridges `T` to/from the flat numeric props the underlying animation interpolates.
+   * @param apply - Writes an interpolated (or the immediate) value to the marker.
+   */
+  private applyTransitionable<T>(property: MarkerTransitionProperty, from: T, to: T, codec: TransitionValueCodec<T>, apply: (value: T) => void): void {
+    this.cancelTransition(property);
+
+    const spec = this.transitions[property];
+    if (!spec || !MarkerManager.getMap(this)) {
+      apply(to);
+      return;
+    }
+
+    const animation = runPropertyTransition(from, to, spec, {
+      codec,
+      onUpdate: apply,
+      onStart: () => this.fire("transitionstart", { props: { [property]: from } } as Pick<MarkerTransitionEventData, "props">),
+      onEnd: (finalValue) => {
+        this.activeTransitions.delete(property);
+        apply(finalValue);
+        this.fire("transitionend", { props: { [property]: finalValue } } as Pick<MarkerTransitionEventData, "props">);
+      },
+    });
+
+    this.activeTransitions.set(property, animation);
+  }
+
+  /** Cancels any transition in flight for `property`, leaving its current (mid-transition) value as-is. */
+  private cancelTransition(property: MarkerTransitionProperty): void {
+    const animation = this.activeTransitions.get(property);
+    if (!animation) return;
+    animation.destroy();
+    this.activeTransitions.delete(property);
+  }
+
+  /** Cancels every transition in flight. Called on removal so a destroyed marker's props can't keep animating. */
+  private cancelAllTransitions(): void {
+    for (const property of [...this.activeTransitions.keys()]) this.cancelTransition(property);
+  }
+
+  //#endregion
+
   //#region Lifecycle
 
   /**
@@ -998,6 +1112,7 @@ export class Marker extends maplibregl.Marker {
    * up its own state — calling `remove()` here would cause infinite recursion.
    */
   [DetachFromDOMSymbol](): void {
+    this.cancelAllTransitions();
     super.remove();
   }
 

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -16,7 +16,7 @@ import {
   type ResolutionEntry,
   type ResolutionMode,
 } from "./collision-helpers";
-import { applyCollisionCulled } from "./marker-dom-utils";
+import { applyCollisionCulled, COLLISION_FADE_DURATION_MS } from "./marker-dom-utils";
 import {
   DetachFromDOMSymbol,
   FlushDOMUpdatesSymbol,
@@ -53,6 +53,10 @@ type MapCollisionState = {
   accuracy: MarkerCollisionAccuracy;
   /** Map-wide default collision behaviour; a marker's own `collisionBehaviour` overrides it. */
   behaviour: CollisionBehaviour;
+  /** Duration in ms of the hide/show/minimize fade transition. */
+  transitionDuration: number;
+  /** CSS easing function for the fade transition. */
+  transitionEasing: string;
 };
 
 /** One marker's resolved geometry within a detection pass. */
@@ -377,13 +381,31 @@ class MarkerManagerImpl {
    * @param options.behaviour - Default collision behaviour for every marker
    *   on the map; a marker's own `collisionBehaviour` option overrides it.
    *   Defaults to `always-show`.
+   * @param options.transitionDuration - Duration in ms of the hide/show/minimize fade. Defaults to `150`.
+   * @param options.transitionEasing - CSS easing function for the fade. Defaults to `"ease"`.
    */
   setCollisionOptions(map: SDKMap, options: MarkerCollisionOptions): void {
     const state = this.getOrCreateCollisionState(map);
     if (options.proximityPadding !== undefined) state.proximityPadding = options.proximityPadding;
     if (options.accuracy !== undefined) state.accuracy = options.accuracy;
     if (options.behaviour !== undefined) state.behaviour = options.behaviour;
+    if (options.transitionDuration !== undefined) state.transitionDuration = options.transitionDuration;
+    if (options.transitionEasing !== undefined) state.transitionEasing = options.transitionEasing;
+    this.applyCollisionTransitionVars(map, state);
     this.invalidateCollisions(map);
+  }
+
+  /** Returns the fade-transition duration (ms) configured for `map`, or the SDK default if never configured. */
+  getCollisionTransitionDuration(map: SDKMap): number {
+    return this.collisionState.get(map)?.transitionDuration ?? COLLISION_FADE_DURATION_MS;
+  }
+
+  // exposes the per-map fade duration/easing to CSS, so the collision fade
+  // classes (defined once in the stylesheet) pick up per-map overrides
+  private applyCollisionTransitionVars(map: SDKMap, state: MapCollisionState): void {
+    const container = map.getContainer();
+    container.style.setProperty("--maptiler-collision-transition-duration", `${state.transitionDuration}ms`);
+    container.style.setProperty("--maptiler-collision-transition-easing", state.transitionEasing);
   }
 
   // lazily creates the per-map collision state and attaches the camera
@@ -398,8 +420,11 @@ class MarkerManagerImpl {
       proximityPadding: DEFAULT_PROXIMITY_PADDING,
       accuracy: "high",
       behaviour: CollisionBehaviour.ALWAYS_SHOW,
+      transitionDuration: COLLISION_FADE_DURATION_MS,
+      transitionEasing: "ease",
     };
     this.collisionState.set(map, state);
+    this.applyCollisionTransitionVars(map, state);
 
     // the pass runs when movement settles — during camera movement markers
     // track their positions via MapLibre's own per-frame update, and in

--- a/src/Marker/marker-transitions.ts
+++ b/src/Marker/marker-transitions.ts
@@ -1,0 +1,97 @@
+import { MaptilerAnimation } from "../MaptilerAnimation";
+import type { EasingFunctionName } from "../MaptilerAnimation/types";
+import EasingFunctions from "../MaptilerAnimation/easing";
+import { parseColorStringToVec4 } from "../utils/webgl-utils";
+import type { MarkerTransitionSpec, Vector2 } from "./types";
+
+const EASING_NAMES_LOWER: Record<string, EasingFunctionName> = Object.keys(EasingFunctions).reduce<Record<string, EasingFunctionName>>((acc, name) => {
+  acc[name.toLowerCase()] = name as EasingFunctionName;
+  return acc;
+}, {});
+
+/** Resolves a transition's easing name case-insensitively (e.g. `"bouncein"` -> `"BounceIn"`), falling back to `"Linear"` for unknown names. */
+export function resolveTransitionEasing(name: string | undefined): EasingFunctionName {
+  if (!name) return "Linear";
+  const resolved = EASING_NAMES_LOWER[name.toLowerCase()];
+  if (!resolved) {
+    console.warn(`[Marker] Unknown transition easing "${name}", falling back to "Linear".`);
+    return "Linear";
+  }
+  return resolved;
+}
+
+/** Bridges a transitionable property's real value to/from the flat numeric props {@link MaptilerAnimation} interpolates between. */
+export type TransitionValueCodec<T> = {
+  toNumeric(value: T): Record<string, number>;
+  fromNumeric(props: Record<string, number>): T;
+};
+
+export const scaleTransitionCodec: TransitionValueCodec<Vector2> = {
+  toNumeric: ([x, y]) => ({ x, y }),
+  fromNumeric: (props) => [props.x, props.y] as Vector2,
+};
+
+export const rotationTransitionCodec: TransitionValueCodec<number> = {
+  toNumeric: (value) => ({ value }),
+  fromNumeric: (props) => props.value,
+};
+
+export type LngLatPosition = { lng: number; lat: number };
+
+export const positionTransitionCodec: TransitionValueCodec<LngLatPosition> = {
+  toNumeric: ({ lng, lat }) => ({ lng, lat }),
+  fromNumeric: ({ lng, lat }) => ({ lng, lat }),
+};
+
+// colours with no value (unset) have nothing to interpolate from/to — fall
+// back to transparent black, since the exact endpoint is always re-applied
+// as-is once the transition ends (see runPropertyTransition)
+export const colorTransitionCodec: TransitionValueCodec<string | undefined> = {
+  toNumeric: (color) => {
+    if (color === undefined) return { r: 0, g: 0, b: 0, a: 0 };
+    const [r, g, b, a] = parseColorStringToVec4(color);
+    return { r, g, b, a };
+  },
+  fromNumeric: ({ r, g, b, a }) => `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`,
+};
+
+export type PropertyTransitionHandlers<T> = {
+  codec: TransitionValueCodec<T>;
+  onUpdate: (value: T) => void;
+  onStart: () => void;
+  onEnd: (value: T) => void;
+};
+
+/**
+ * Eases `from` to `to` over `spec`'s duration/easing/delay via a one-shot
+ * {@link MaptilerAnimation}, calling `onUpdate` every frame and `onEnd` once
+ * with the exact target value. The returned animation is already playing;
+ * callers own its lifetime — `.destroy()` it to cancel.
+ */
+export function runPropertyTransition<T>(from: T, to: T, spec: MarkerTransitionSpec, handlers: PropertyTransitionHandlers<T>): MaptilerAnimation {
+  const [duration, easing, delay] = spec;
+
+  const animation = new MaptilerAnimation({
+    keyframes: [
+      { delta: 0, props: handlers.codec.toNumeric(from), easing: resolveTransitionEasing(easing) },
+      { delta: 1, props: handlers.codec.toNumeric(to) },
+    ],
+    duration,
+    iterations: 1,
+    delay: delay ?? 0,
+  });
+
+  animation.addEventListener("play", () => {
+    handlers.onStart();
+  });
+  animation.addEventListener("timeupdate", (event) => {
+    handlers.onUpdate(handlers.codec.fromNumeric(event.props));
+  });
+  animation.addEventListener("animationend", () => {
+    handlers.onEnd(to);
+    animation.destroy();
+  });
+
+  animation.play();
+  return animation;
+}

--- a/src/Marker/marker-transitions.ts
+++ b/src/Marker/marker-transitions.ts
@@ -1,24 +1,6 @@
 import { MaptilerAnimation } from "../MaptilerAnimation";
-import type { EasingFunctionName } from "../MaptilerAnimation/types";
-import EasingFunctions from "../MaptilerAnimation/easing";
 import { parseColorStringToVec4 } from "../utils/webgl-utils";
 import type { MarkerTransitionSpec, Vector2 } from "./types";
-
-const EASING_NAMES_LOWER: Record<string, EasingFunctionName> = Object.keys(EasingFunctions).reduce<Record<string, EasingFunctionName>>((acc, name) => {
-  acc[name.toLowerCase()] = name as EasingFunctionName;
-  return acc;
-}, {});
-
-/** Resolves a transition's easing name case-insensitively (e.g. `"bouncein"` -> `"BounceIn"`), falling back to `"Linear"` for unknown names. */
-export function resolveTransitionEasing(name: string | undefined): EasingFunctionName {
-  if (!name) return "Linear";
-  const resolved = EASING_NAMES_LOWER[name.toLowerCase()];
-  if (!resolved) {
-    console.warn(`[Marker] Unknown transition easing "${name}", falling back to "Linear".`);
-    return "Linear";
-  }
-  return resolved;
-}
 
 /** Bridges a transitionable property's real value to/from the flat numeric props {@link MaptilerAnimation} interpolates between. */
 export type TransitionValueCodec<T> = {
@@ -73,7 +55,7 @@ export function runPropertyTransition<T>(from: T, to: T, spec: MarkerTransitionS
 
   const animation = new MaptilerAnimation({
     keyframes: [
-      { delta: 0, props: handlers.codec.toNumeric(from), easing: resolveTransitionEasing(easing) },
+      { delta: 0, props: handlers.codec.toNumeric(from), easing: easing ?? "Linear" },
       { delta: 1, props: handlers.codec.toNumeric(to) },
     ],
     duration,

--- a/src/Marker/marker-transitions.ts
+++ b/src/Marker/marker-transitions.ts
@@ -3,6 +3,9 @@ import { MaptilerAnimation } from "../MaptilerAnimation";
 import { parseColorStringToVec4 } from "../utils/webgl-utils";
 import type { MarkerTransitionSpec, Vector2 } from "./types";
 
+// Without this codec layer, either MaptilerAnimation would need bespoke interpolation
+// logic per property type (defeating the point of a shared engine), or Marker.ts would
+// need to hand-roll lerping for every transitionable property itself.
 /** Bridges a transitionable property's real value to/from the flat numeric props {@link MaptilerAnimation} interpolates between. */
 export type TransitionValueCodec<T> = {
   toNumeric(value: T): Record<string, number>;
@@ -20,6 +23,8 @@ export const rotationTransitionCodec: TransitionValueCodec<number> = {
 };
 
 export const positionTransitionCodec: TransitionValueCodec<LngLat> = {
+  // this looks pointless, but its designed to strip the LngLat object of its type
+  // so that it can be passed to the MaptilerAnimation engine
   toNumeric: ({ lng, lat }) => ({ lng, lat }),
   fromNumeric: ({ lng, lat }) => new LngLat(lng, lat),
 };

--- a/src/Marker/marker-transitions.ts
+++ b/src/Marker/marker-transitions.ts
@@ -1,3 +1,4 @@
+import { LngLat } from "../index";
 import { MaptilerAnimation } from "../MaptilerAnimation";
 import { parseColorStringToVec4 } from "../utils/webgl-utils";
 import type { MarkerTransitionSpec, Vector2 } from "./types";
@@ -18,11 +19,9 @@ export const rotationTransitionCodec: TransitionValueCodec<number> = {
   fromNumeric: (props) => props.value,
 };
 
-export type LngLatPosition = { lng: number; lat: number };
-
-export const positionTransitionCodec: TransitionValueCodec<LngLatPosition> = {
+export const positionTransitionCodec: TransitionValueCodec<LngLat> = {
   toNumeric: ({ lng, lat }) => ({ lng, lat }),
-  fromNumeric: ({ lng, lat }) => ({ lng, lat }),
+  fromNumeric: ({ lng, lat }) => new LngLat(lng, lat),
 };
 
 // colours with no value (unset) have nothing to interpolate from/to — fall

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -1,4 +1,5 @@
 import type { MarkerOptions } from "maplibre-gl";
+import type { EasingFunctionName } from "../MaptilerAnimation/types";
 import type { AdaptiveColor, AdaptiveColorName } from "./marker-adaptive-colors";
 import type { Marker } from "./Marker";
 
@@ -170,11 +171,10 @@ export type MarkerTransitionProperty = "position" | "scale" | "rotation" | "oute
 /**
  * Configures how a transitionable property eases to a newly-set value.
  * `[duration, easing?, delay?]`, all in milliseconds except `easing`.
- * `easing` names any {@link EasingFunctionName} (case-insensitive — e.g.
- * `"bouncein"` resolves to `"BounceIn"`); unrecognised names fall back to
- * `"Linear"`. Defaults to no delay when omitted.
+ * `easing` is any {@link EasingFunctionName}, defaulting to `"Linear"` when omitted.
+ * Defaults to no delay when omitted.
  */
-export type MarkerTransitionSpec = [duration: number, easing?: string, delay?: number];
+export type MarkerTransitionSpec = [duration: number, easing?: EasingFunctionName, delay?: number];
 
 /** Per-property transition configuration, keyed by {@link MarkerTransitionProperty}. */
 export type MapTilerMarkerTransitions = Partial<Record<MarkerTransitionProperty, MarkerTransitionSpec>>;

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -84,6 +84,17 @@ export type MarkerCollisionOptions = {
    * (nothing is ever hidden until a behaviour is opted into).
    */
   behaviour?: CollisionBehaviour;
+  /**
+   * Duration in milliseconds of the hide/show/minimize fade transition
+   * markers go through under collision behaviours. Defaults to `150`.
+   */
+  transitionDuration?: number;
+  /**
+   * CSS easing function for the fade transition (e.g. `"ease"`,
+   * `"ease-in-out"`, `"linear"`, or a `cubic-bezier(...)` expression).
+   * Defaults to `"ease"`.
+   */
+  transitionEasing?: string;
 };
 
 /**
@@ -149,23 +160,39 @@ export type MarkerPriorityExpression = unknown[];
 //     }
 //   | MaptilerAnimation;
 
-// Transitions
+//#endregion
 
-// /** CSS transition config for interactive marker states. */
-// export type MapTilerMarkerTransitions = {
-//   /**
-//    * CSS `transition` property value applied to the marker element
-//    * (e.g. `'transform 0.3s ease, opacity 0.3s ease'`).
-//    * A sensible default is used when omitted.
-//    */
-//   property?: string;
-//   /** CSS properties applied while the cursor is over the marker. */
-//   hover?: Record<string, string | number>;
-//   /** CSS properties applied while the marker has keyboard focus. */
-//   focus?: Record<string, string | number>;
-//   /** CSS properties applied while the marker is being activated (e.g. mousedown). */
-//   active?: Record<string, string | number>;
-// };
+//#region Transitions
+
+/** Marker properties that can be eased from their old value to a new one instead of snapping. */
+export type MarkerTransitionProperty = "position" | "scale" | "rotation" | "outerColor" | "innerColor" | "contentColor" | "outlineColor";
+
+/**
+ * Configures how a transitionable property eases to a newly-set value.
+ * `[duration, easing?, delay?]`, all in milliseconds except `easing`.
+ * `easing` names any {@link EasingFunctionName} (case-insensitive — e.g.
+ * `"bouncein"` resolves to `"BounceIn"`); unrecognised names fall back to
+ * `"Linear"`. Defaults to no delay when omitted.
+ */
+export type MarkerTransitionSpec = [duration: number, easing?: string, delay?: number];
+
+/** Per-property transition configuration, keyed by {@link MarkerTransitionProperty}. */
+export type MapTilerMarkerTransitions = Partial<Record<MarkerTransitionProperty, MarkerTransitionSpec>>;
+
+/**
+ * Event fired by a marker's `transitionstart` / `transitionend` — the same
+ * shape as MapLibre's own marker events (`type`, `target`), plus `props`.
+ */
+export type MarkerTransitionEventData = {
+  type: "transitionstart" | "transitionend";
+  target: Marker;
+  /**
+   * The property being transitioned, keyed to its value at the time of the
+   * event — the value it's easing from on `transitionstart`, the value it
+   * reached on `transitionend`.
+   */
+  props: Partial<Record<MarkerTransitionProperty, unknown>>;
+};
 
 //#endregion
 
@@ -303,8 +330,12 @@ export type MapTilerMarkerBaseOptions = Omit<MarkerOptions, "scale" | "opacity" 
   //   /** Loops continuously while the marker is idle on the map. */
   //   idle?: AnimationOptions[];
   // };
-  // /** CSS transitions for interactive marker states. */
-  // transitions?: MapTilerMarkerTransitions;
+  /**
+   * Per-property easing applied when a transitionable property (`position`,
+   * `scale`, `rotation`, or a colour) is next set, instead of the change
+   * snapping immediately. See {@link setTransitionForProperty}.
+   */
+  transitions?: MapTilerMarkerTransitions;
   /** Arbitrary user-defined data attached to the marker instance. */
   userData?: Record<string, unknown>;
   /** Behaviour when this marker spatially overlaps another. Overrides the map-level default (see `MarkerCollisionOptions`). */

--- a/src/style/style_template.css
+++ b/src/style/style_template.css
@@ -182,7 +182,8 @@
    fades, visibility flips only once the fade completes, pointer events stop
    immediately so a fading-out marker can't be clicked. */
 .maptiler-marker-collision-fade {
-  transition: opacity 150ms ease, visibility 150ms ease;
+  transition: opacity var(--maptiler-collision-transition-duration, 150ms) var(--maptiler-collision-transition-easing, ease),
+    visibility var(--maptiler-collision-transition-duration, 150ms) var(--maptiler-collision-transition-easing, ease);
 }
 
 .maptiler-marker-collision-hidden {
@@ -207,7 +208,7 @@
    inline `scale() rotate()` transform; the mismatched transform lists
    interpolate via matrix decomposition. */
 .maptiler-marker-collision-fade .marker-transform-wrapper {
-  transition: transform 150ms ease;
+  transition: transform var(--maptiler-collision-transition-duration, 150ms) var(--maptiler-collision-transition-easing, ease);
 }
 
 .maptiler-marker-collision-hidden .marker-transform-wrapper {


### PR DESCRIPTION
## Objective

Implements [RD-2255](https://maptiler.atlassian.net/browse/RD-2255).
- Adds transition support to markers so property changes (scale, colour, position) ease into place instead of snapping
- Adds `transitionstart` / `transitionend` events so consumers can hook into the animation lifecycle.

## Description

- Added a `marker-transitions.ts` module implementing configurable transitions (duration, easing, delay) per marker property
- Extended `Marker` and `MarkerManager` to drive these transitions for `scale`, `outerColor`, and `position`, including `setTransitionForProperty()` for runtime overrides and
  `getTransitions()` to read current config.
- Added `transitionstart` and `transitionend` events, firing with the affected props so callers can track transition state per property.
- Updated `types.ts` with the new `MapTilerMarkerTransitions`, `MarkerTransitionProperty`, `MarkerTransitionSpec`, and `MarkerTransitionEventData` types.
- Updated the UI states demo

## Acceptance

- Manually tested
- e2e and unit test coverage will follow in a future PR.

## Checklist

  - [ ] ~~I have added relevant info to the CHANGELOG.md~~ — N/A, changelog entry will be added on feature release

[RD-2255]: https://maptiler.atlassian.net/browse/RD-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ