### PR TITLE
RD-1409 add enter exit, idle animation feature

### DIFF
--- a/demos/public/19-maptiler-markers-lifecycle-animations.html
+++ b/demos/public/19-maptiler-markers-lifecycle-animations.html
@@ -60,6 +60,16 @@
       color: rgba(0, 0, 0, 0.85);
     }
 
+    select.ctrl-select {
+      height: 28px;
+      border: 1.5px solid rgba(0, 0, 0, 0.12);
+      border-radius: 6px;
+      background: white;
+      font: 600 11px system-ui;
+      color: rgba(0, 0, 0, 0.75);
+      padding: 0 6px;
+    }
+
     .btn-row {
       display: flex;
       gap: 4px;
@@ -109,41 +119,34 @@
 
   <div id="panel">
     <div class="ctrl-group">
-      <div class="ctrl-label">Enter (E marker)</div>
-      <div class="ctrl-hint">No <code>exit</code> configured — <b>Add</b> fades in, <b>Remove</b> snaps away instantly.</div>
-      <div class="btn-row">
-        <button id="toggle-enter" class="ctrl-btn">Add</button>
-      </div>
+      <div class="ctrl-label">Enter</div>
+      <select id="enter-preset" class="ctrl-select"></select>
     </div>
 
-    <hr>
-
     <div class="ctrl-group">
-      <div class="ctrl-label">Exit (X marker)</div>
-      <div class="ctrl-hint">No <code>enter</code> configured — <b>Remove</b> fades out (the marker stays on the map until the fade finishes), <b>Add</b> snaps back instantly.</div>
-      <div class="btn-row">
-        <button id="toggle-exit" class="ctrl-btn">Remove</button>
-      </div>
+      <div class="ctrl-label">Idle</div>
+      <select id="idle-preset" class="ctrl-select"></select>
     </div>
 
-    <hr>
-
     <div class="ctrl-group">
-      <div class="ctrl-label">Idle (I marker)</div>
-      <div class="ctrl-hint"><code>idle</code> is accepted and typed, but is currently a no-op — no visual change, no events fired. Add/remove both snap.</div>
-      <div class="btn-row">
-        <button id="toggle-idle" class="ctrl-btn">Remove</button>
-      </div>
+      <div class="ctrl-label">Exit</div>
+      <select id="exit-preset" class="ctrl-select"></select>
     </div>
 
-    <hr>
-
     <div class="ctrl-group">
-      <div class="ctrl-label">Enter + Idle + Exit (A marker)</div>
-      <div class="ctrl-hint">All three configured together — <b>Add</b> fades in, <b>Remove</b> fades out; idle is still a no-op in between.</div>
-      <div class="btn-row">
-        <button id="toggle-all" class="ctrl-btn">Add</button>
-      </div>
+      <div class="ctrl-label">Magnitude (<span id="magnitude-value">1.0</span>)</div>
+      <input id="magnitude" type="range" min="0" max="2" step="0.1" value="1">
+    </div>
+
+    <div class="ctrl-hint">Picking a preset (or "custom") only affects markers added <b>after</b> the change — each marker is built from the selections at the moment it's added. Magnitude is ignored by "custom" and "none".</div>
+
+    <div class="btn-row">
+      <button id="add-marker" class="ctrl-btn">Add one</button>
+      <button id="add-5-markers" class="ctrl-btn">Add 10</button>
+    </div>
+
+    <div class="btn-row">
+      <button id="remove-all-markers" class="ctrl-btn">Remove all (<span id="marker-count">0</span>)</button>
     </div>
 
     <hr>

--- a/demos/public/19-maptiler-markers-lifecycle-animations.html
+++ b/demos/public/19-maptiler-markers-lifecycle-animations.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>MapTiler Markers – Lifecycle Animations</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      width: 100%;
+      height: 100%;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+
+    #map {
+      position: absolute;
+      inset: 0;
+    }
+
+    #panel {
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      z-index: 100;
+      width: 280px;
+      max-height: calc(100vh - 24px);
+      overflow-y: auto;
+      background: rgba(255, 255, 255, 0.92);
+      backdrop-filter: blur(12px);
+      border: 1px solid rgba(0, 0, 0, 0.1);
+      border-radius: 10px;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+      padding: 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .ctrl-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .ctrl-label {
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(0, 0, 0, 0.45);
+    }
+
+    .ctrl-hint {
+      font-size: 11px;
+      color: rgba(0, 0, 0, 0.6);
+      line-height: 1.5;
+    }
+
+    .ctrl-hint b {
+      color: rgba(0, 0, 0, 0.85);
+    }
+
+    .btn-row {
+      display: flex;
+      gap: 4px;
+    }
+
+    .ctrl-btn {
+      flex: 1;
+      height: 28px;
+      border: 1.5px solid rgba(0, 0, 0, 0.12);
+      border-radius: 6px;
+      background: transparent;
+      font: 600 11px system-ui;
+      color: rgba(0, 0, 0, 0.55);
+      cursor: pointer;
+      transition: all 0.1s;
+    }
+
+    .ctrl-btn:hover {
+      border-color: rgba(0, 0, 0, 0.25);
+      color: rgba(0, 0, 0, 0.8);
+    }
+
+    hr {
+      border: none;
+      border-top: 1px solid rgba(0, 0, 0, 0.08);
+    }
+
+    #lifecycle-log {
+      font-family: monospace;
+      font-size: 10px;
+      max-height: 140px;
+      overflow-y: auto;
+    }
+
+    #lifecycle-log div {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  </style>
+
+  <link rel="stylesheet" href="../build/maptiler-sdk.css">
+</head>
+
+<body>
+  <div id="map"></div>
+
+  <div id="panel">
+    <div class="ctrl-group">
+      <div class="ctrl-label">Enter (E marker)</div>
+      <div class="ctrl-hint">No <code>exit</code> configured — <b>Add</b> fades in, <b>Remove</b> snaps away instantly.</div>
+      <div class="btn-row">
+        <button id="toggle-enter" class="ctrl-btn">Add</button>
+      </div>
+    </div>
+
+    <hr>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Exit (X marker)</div>
+      <div class="ctrl-hint">No <code>enter</code> configured — <b>Remove</b> fades out (the marker stays on the map until the fade finishes), <b>Add</b> snaps back instantly.</div>
+      <div class="btn-row">
+        <button id="toggle-exit" class="ctrl-btn">Remove</button>
+      </div>
+    </div>
+
+    <hr>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Idle (I marker)</div>
+      <div class="ctrl-hint"><code>idle</code> is accepted and typed, but is currently a no-op — no visual change, no events fired. Add/remove both snap.</div>
+      <div class="btn-row">
+        <button id="toggle-idle" class="ctrl-btn">Remove</button>
+      </div>
+    </div>
+
+    <hr>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Enter + Idle + Exit (A marker)</div>
+      <div class="ctrl-hint">All three configured together — <b>Add</b> fades in, <b>Remove</b> fades out; idle is still a no-op in between.</div>
+      <div class="btn-row">
+        <button id="toggle-all" class="ctrl-btn">Add</button>
+      </div>
+    </div>
+
+    <hr>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Last 8 events</div>
+      <div id="lifecycle-log"></div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/19-maptiler-markers-lifecycle-animations.ts"></script>
+</body>
+
+</html>

--- a/demos/public/index.html
+++ b/demos/public/index.html
@@ -69,6 +69,7 @@
       <a href="16-maptiler-markers.html">MapTiler Markers →</a>
       <a href="17-maptiler-markers-collision.html">MapTiler Markers – Collisions →</a>
       <a href="18-maptiler-markers-ui-states.html">MapTiler Markers – UI States →</a>
+      <a href="19-maptiler-markers-lifecycle-animations.html">MapTiler Markers – Lifecycle Animations →</a>
     </div>
   </div>
 </body>

--- a/demos/src/01-simple.ts
+++ b/demos/src/01-simple.ts
@@ -67,8 +67,6 @@ async function main() {
     languageOption.innerHTML = l.name;
     languageDropdown.appendChild(languageOption);
   });
-
-  console.log(map.getLayersOrder());
 }
 
 void main();

--- a/demos/src/01-simple.ts
+++ b/demos/src/01-simple.ts
@@ -67,6 +67,8 @@ async function main() {
     languageOption.innerHTML = l.name;
     languageDropdown.appendChild(languageOption);
   });
+
+  console.log(map.getLayersOrder());
 }
 
 void main();

--- a/demos/src/19-maptiler-markers-lifecycle-animations.ts
+++ b/demos/src/19-maptiler-markers-lifecycle-animations.ts
@@ -1,0 +1,140 @@
+import { Map, MapStyle, Marker, config } from "../../src/index";
+import { setupMapTilerApiKey } from "./demo-utils";
+import type { MapTilerMarkerOptions, MarkerLifecycleAnimationEventData } from "../../src/Marker";
+
+setupMapTilerApiKey({ config });
+
+function el<T extends HTMLElement = HTMLElement>(id: string): T {
+  const found = document.getElementById(id);
+  if (!found) throw new Error(`#${id} not found`);
+  return found as T;
+}
+
+const CENTER: [number, number] = [14.42, 50.08];
+const SPACING = 0.0026;
+
+/** Static caption pinned under a marker's position — always visible, unlike a hover-only `title` tooltip. */
+function addCaption(map: Map, lngLat: [number, number], text: string) {
+  const captionEl = document.createElement("div");
+  captionEl.textContent = text;
+  captionEl.style.font = "700 10px system-ui";
+  captionEl.style.letterSpacing = "0.03em";
+  captionEl.style.color = "rgba(0, 0, 0, 0.75)";
+  captionEl.style.background = "rgba(255, 255, 255, 0.85)";
+  captionEl.style.padding = "2px 6px";
+  captionEl.style.borderRadius = "4px";
+  captionEl.style.whiteSpace = "nowrap";
+  captionEl.style.pointerEvents = "none";
+
+  const caption = new Marker({ element: captionEl, anchor: "top", offset: [0, 34], htmlAttributes: { tabindex: "-1" } });
+  caption.setLngLat(lngLat);
+  map.addMarker(caption);
+}
+
+const LIFECYCLE_EVENTS = ["enteranimationstart", "enteranimationend", "exitanimationstart", "exitanimationend", "idleanimationstart", "idleanimationiteration", "idleanimationend"] as const;
+
+async function main() {
+  const map = new Map({
+    container: el("map"),
+    style: MapStyle.STREETS.DEFAULT,
+    zoom: 15,
+    center: CENTER,
+  });
+
+  await map.onLoadAsync();
+
+  const base: MapTilerMarkerOptions = { shape: "circle", size: "l", color: "blue" };
+  const at = (i: number): [number, number] => [CENTER[0] + i * SPACING, CENTER[1]];
+
+  // Shared event feed — every marker below logs into this.
+  const eventLogEl = el("lifecycle-log");
+  const logEvent = (label: string, type: string) => {
+    const time = new Date().toLocaleTimeString(undefined, { hour12: false, minute: "2-digit", second: "2-digit", fractionalSecondDigits: 3 } as Intl.DateTimeFormatOptions);
+    const line = document.createElement("div");
+    line.textContent = `${time} · ${label} · ${type}`;
+    eventLogEl.prepend(line);
+    while (eventLogEl.childNodes.length > 8) eventLogEl.lastChild?.remove();
+  };
+
+  function wireLogging(marker: Marker, label: string) {
+    for (const type of LIFECYCLE_EVENTS) {
+      marker.on(type, (e: MarkerLifecycleAnimationEventData) => logEvent(label, e.type));
+    }
+  }
+
+  /** Wires a button to add/remove `marker`, toggling its label. `exit` only plays through `marker.remove()` — never `map.removeMarker()`. */
+  function setupToggle(buttonId: string, marker: Marker, initiallyOnMap: boolean) {
+    const button = el<HTMLButtonElement>(buttonId);
+    let onMap = initiallyOnMap;
+    button.textContent = onMap ? "Remove" : "Add";
+
+    button.addEventListener("click", () => {
+      if (onMap) {
+        marker.remove();
+      } else {
+        map.addMarker(marker);
+      }
+      onMap = !onMap;
+      button.textContent = onMap ? "Remove" : "Add";
+    });
+  }
+
+  // ENTER only — starts off the map so "Add" shows the fade-in. Removing
+  // has no exit configured, so it snaps away instantly.
+  const enterMarker = new Marker({
+    ...base,
+    content: "E",
+    title: "Enter",
+    animations: { enter: { preset: "fade", duration: 900, easing: "SinusoidalOut" } },
+  });
+  enterMarker.setLngLat(at(-3));
+  wireLogging(enterMarker, "ENTER");
+  addCaption(map, at(-3), "ENTER (click Add)");
+  setupToggle("toggle-enter", enterMarker, false);
+
+  // EXIT only — starts on the map so "Remove" shows the fade-out; the
+  // marker stays visible/interactive until the fade finishes.
+  const exitMarker = new Marker({
+    ...base,
+    content: "X",
+    title: "Exit",
+    animations: { exit: { preset: "fade", duration: 900, easing: "SinusoidalIn" } },
+  });
+  exitMarker.setLngLat(at(-1));
+  map.addMarker(exitMarker);
+  wireLogging(exitMarker, "EXIT");
+  addCaption(map, at(-1), "EXIT (click Remove)");
+  setupToggle("toggle-exit", exitMarker, true);
+
+  // IDLE only — MVP stub: accepted and typed, but currently a no-op, so
+  // add/remove both snap and the event log never fires for this marker.
+  const idleMarker = new Marker({
+    ...base,
+    content: "I",
+    title: "Idle",
+    animations: { idle: { preset: "fade", duration: 1200, iterations: Infinity } },
+  });
+  idleMarker.setLngLat(at(1));
+  map.addMarker(idleMarker);
+  wireLogging(idleMarker, "IDLE");
+  addCaption(map, at(1), "IDLE (no-op for now)");
+  setupToggle("toggle-idle", idleMarker, true);
+
+  // ALL THREE — enter fades in, idle is configured (no-op), exit fades out.
+  const allMarker = new Marker({
+    ...base,
+    content: "A",
+    title: "Enter + Idle + Exit",
+    animations: {
+      enter: { preset: "fade", duration: 700, easing: "SinusoidalOut" },
+      idle: { preset: "fade", duration: 1200, iterations: Infinity },
+      exit: { preset: "fade", duration: 700, easing: "SinusoidalIn" },
+    },
+  });
+  allMarker.setLngLat(at(3));
+  wireLogging(allMarker, "ALL");
+  addCaption(map, at(3), "ENTER + IDLE + EXIT");
+  setupToggle("toggle-all", allMarker, false);
+}
+
+void main();

--- a/demos/src/19-maptiler-markers-lifecycle-animations.ts
+++ b/demos/src/19-maptiler-markers-lifecycle-animations.ts
@@ -1,37 +1,67 @@
 import { Map, MapStyle, Marker, config } from "../../src/index";
-import { setupMapTilerApiKey } from "./demo-utils";
-import type { MapTilerMarkerOptions, MarkerLifecycleAnimationEventData } from "../../src/Marker";
+import { el, setupMapTilerApiKey } from "./demo-utils";
+import type {
+  EnterAnimationPreset,
+  ExitAnimationPreset,
+  IdleAnimationPreset,
+  MapTilerMarkerAnimations,
+  MapTilerMarkerSVGOptions,
+  MarkerLifecycleAnimationEventData,
+} from "../../src/Marker";
 
 setupMapTilerApiKey({ config });
 
-function el<T extends HTMLElement = HTMLElement>(id: string): T {
-  const found = document.getElementById(id);
-  if (!found) throw new Error(`#${id} not found`);
-  return found as T;
-}
-
 const CENTER: [number, number] = [14.42, 50.08];
 const SPACING = 0.0026;
+const GRID_COLUMNS = 10;
 
-/** Static caption pinned under a marker's position — always visible, unlike a hover-only `title` tooltip. */
-function addCaption(map: Map, lngLat: [number, number], text: string) {
-  const captionEl = document.createElement("div");
-  captionEl.textContent = text;
-  captionEl.style.font = "700 10px system-ui";
-  captionEl.style.letterSpacing = "0.03em";
-  captionEl.style.color = "rgba(0, 0, 0, 0.75)";
-  captionEl.style.background = "rgba(255, 255, 255, 0.85)";
-  captionEl.style.padding = "2px 6px";
-  captionEl.style.borderRadius = "4px";
-  captionEl.style.whiteSpace = "nowrap";
-  captionEl.style.pointerEvents = "none";
+const LIFECYCLE_EVENTS = [
+  "enteranimationstart",
+  "enteranimationend",
+  "exitanimationstart",
+  "exitanimationend",
+  "idleanimationstart",
+  "idleanimationiteration",
+  "idleanimationend",
+] as const;
 
-  const caption = new Marker({ element: captionEl, anchor: "top", offset: [0, 34], htmlAttributes: { tabindex: "-1" } });
-  caption.setLngLat(lngLat);
-  map.addMarker(caption);
+const TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = { hour12: false, minute: "2-digit", second: "2-digit", fractionalSecondDigits: 3 };
+
+const NONE = "none";
+const CUSTOM = "custom";
+const ENTER_PRESETS: EnterAnimationPreset[] = ["grow", "drop", "pop", "bounce", "fade"];
+const IDLE_PRESETS: IdleAnimationPreset[] = ["pulsescale", "ring", "pulseopacity", "bounce"];
+const EXIT_PRESETS: ExitAnimationPreset[] = ["shrink", "fade", "pop", "explode"];
+
+// `custom` examples — combine public setters (setScale/setRotation) with direct
+// element opacity, since the SDK has no public setOpacity() (only the built-in
+// lifecycle presets can reach it, via an internal prop). Alpha is already eased.
+function customEnter(alpha: number, marker: Marker) {
+  marker.setScale([alpha, alpha]);
+  marker.setRotation(360 * (1 - alpha));
+  marker.getElement().style.opacity = String(alpha);
 }
 
-const LIFECYCLE_EVENTS = ["enteranimationstart", "enteranimationend", "exitanimationstart", "exitanimationend", "idleanimationstart", "idleanimationiteration", "idleanimationend"] as const;
+function customExit(alpha: number, marker: Marker) {
+  marker.setScale([1 - alpha, 1 - alpha]);
+  marker.setRotation(360 * alpha);
+  marker.getElement().style.opacity = String(1 - alpha);
+}
+
+function customIdle(alpha: number, marker: Marker) {
+  marker.setRotation(Math.sin(alpha * Math.PI * 2) * 15);
+}
+
+function populateSelect(selectId: string, options: string[]) {
+  const select = el<HTMLSelectElement>(selectId);
+  for (const value of [NONE, ...options, CUSTOM]) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = value;
+    select.appendChild(option);
+  }
+  return select;
+}
 
 async function main() {
   const map = new Map({
@@ -43,98 +73,86 @@ async function main() {
 
   await map.onLoadAsync();
 
-  const base: MapTilerMarkerOptions = { shape: "circle", size: "l", color: "blue" };
-  const at = (i: number): [number, number] => [CENTER[0] + i * SPACING, CENTER[1]];
+  const base: MapTilerMarkerSVGOptions = { shape: "circle", size: "l", color: "blue", content: "M" };
 
-  // Shared event feed — every marker below logs into this.
+  const enterSelect = populateSelect("enter-preset", ENTER_PRESETS);
+  const idleSelect = populateSelect("idle-preset", IDLE_PRESETS);
+  const exitSelect = populateSelect("exit-preset", EXIT_PRESETS);
+
+  const magnitudeInput = el<HTMLInputElement>("magnitude");
+  const magnitudeValueEl = el("magnitude-value");
+  magnitudeInput.addEventListener("input", () => {
+    magnitudeValueEl.textContent = Number(magnitudeInput.value).toFixed(1);
+  });
+
   const eventLogEl = el("lifecycle-log");
-  const logEvent = (label: string, type: string) => {
-    const time = new Date().toLocaleTimeString(undefined, { hour12: false, minute: "2-digit", second: "2-digit", fractionalSecondDigits: 3 } as Intl.DateTimeFormatOptions);
+  function logEvent(type: string) {
+    const time = new Date().toLocaleTimeString(undefined, TIME_FORMAT_OPTIONS);
     const line = document.createElement("div");
-    line.textContent = `${time} · ${label} · ${type}`;
+    line.textContent = `${time} · ${type}`;
     eventLogEl.prepend(line);
     while (eventLogEl.childNodes.length > 8) eventLogEl.lastChild?.remove();
+  }
+
+  const markers: Marker[] = [];
+  let nextSlot = 0;
+  const countEl = el("marker-count");
+  const updateCount = () => {
+    countEl.textContent = String(markers.length);
   };
 
-  function wireLogging(marker: Marker, label: string) {
-    for (const type of LIFECYCLE_EVENTS) {
-      marker.on(type, (e: MarkerLifecycleAnimationEventData) => logEvent(label, e.type));
+  function addOneMarker() {
+    const magnitude = Number(magnitudeInput.value);
+    const animations: MapTilerMarkerAnimations = {};
+
+    if (enterSelect.value === CUSTOM) {
+      animations.enter = { custom: customEnter, duration: 900 };
+    } else if (enterSelect.value !== NONE) {
+      animations.enter = { preset: enterSelect.value as EnterAnimationPreset, duration: 900, magnitude };
     }
+
+    if (idleSelect.value === CUSTOM) {
+      animations.idle = { custom: customIdle, duration: 1500, iterations: Infinity };
+    } else if (idleSelect.value !== NONE) {
+      animations.idle = { preset: idleSelect.value as IdleAnimationPreset, iterations: Infinity, magnitude };
+    }
+
+    if (exitSelect.value === CUSTOM) {
+      animations.exit = { custom: customExit, duration: 900 };
+    } else if (exitSelect.value !== NONE) {
+      animations.exit = { preset: exitSelect.value as ExitAnimationPreset, duration: 900, magnitude };
+    }
+
+    const marker = new Marker({ ...base, animations });
+    const col = nextSlot % GRID_COLUMNS;
+    const row = Math.floor(nextSlot / GRID_COLUMNS);
+    nextSlot++;
+    marker.setLngLat([CENTER[0] + (col - (GRID_COLUMNS - 1) / 2) * SPACING, CENTER[1] + row * SPACING]);
+
+    for (const type of LIFECYCLE_EVENTS) {
+      marker.on(type, (e: MarkerLifecycleAnimationEventData) => {
+        logEvent(`${e.type} (${e.preset})`);
+      });
+    }
+
+    map.addMarker(marker);
+    markers.push(marker);
+    updateCount();
   }
 
-  /** Wires a button to add/remove `marker`, toggling its label. `exit` only plays through `marker.remove()` — never `map.removeMarker()`. */
-  function setupToggle(buttonId: string, marker: Marker, initiallyOnMap: boolean) {
-    const button = el<HTMLButtonElement>(buttonId);
-    let onMap = initiallyOnMap;
-    button.textContent = onMap ? "Remove" : "Add";
-
-    button.addEventListener("click", () => {
-      if (onMap) {
-        marker.remove();
-      } else {
-        map.addMarker(marker);
-      }
-      onMap = !onMap;
-      button.textContent = onMap ? "Remove" : "Add";
-    });
-  }
-
-  // ENTER only — starts off the map so "Add" shows the fade-in. Removing
-  // has no exit configured, so it snaps away instantly.
-  const enterMarker = new Marker({
-    ...base,
-    content: "E",
-    title: "Enter",
-    animations: { enter: { preset: "fade", duration: 900, easing: "SinusoidalOut" } },
+  el<HTMLButtonElement>("add-marker").addEventListener("click", () => {
+    addOneMarker();
   });
-  enterMarker.setLngLat(at(-3));
-  wireLogging(enterMarker, "ENTER");
-  addCaption(map, at(-3), "ENTER (click Add)");
-  setupToggle("toggle-enter", enterMarker, false);
 
-  // EXIT only — starts on the map so "Remove" shows the fade-out; the
-  // marker stays visible/interactive until the fade finishes.
-  const exitMarker = new Marker({
-    ...base,
-    content: "X",
-    title: "Exit",
-    animations: { exit: { preset: "fade", duration: 900, easing: "SinusoidalIn" } },
+  el<HTMLButtonElement>("add-5-markers").addEventListener("click", () => {
+    for (let i = 0; i < 10; i++) addOneMarker();
   });
-  exitMarker.setLngLat(at(-1));
-  map.addMarker(exitMarker);
-  wireLogging(exitMarker, "EXIT");
-  addCaption(map, at(-1), "EXIT (click Remove)");
-  setupToggle("toggle-exit", exitMarker, true);
 
-  // IDLE only — MVP stub: accepted and typed, but currently a no-op, so
-  // add/remove both snap and the event log never fires for this marker.
-  const idleMarker = new Marker({
-    ...base,
-    content: "I",
-    title: "Idle",
-    animations: { idle: { preset: "fade", duration: 1200, iterations: Infinity } },
+  el<HTMLButtonElement>("remove-all-markers").addEventListener("click", () => {
+    for (const marker of markers.splice(0)) marker.remove();
+    nextSlot = 0;
+    updateCount();
   });
-  idleMarker.setLngLat(at(1));
-  map.addMarker(idleMarker);
-  wireLogging(idleMarker, "IDLE");
-  addCaption(map, at(1), "IDLE (no-op for now)");
-  setupToggle("toggle-idle", idleMarker, true);
-
-  // ALL THREE — enter fades in, idle is configured (no-op), exit fades out.
-  const allMarker = new Marker({
-    ...base,
-    content: "A",
-    title: "Enter + Idle + Exit",
-    animations: {
-      enter: { preset: "fade", duration: 700, easing: "SinusoidalOut" },
-      idle: { preset: "fade", duration: 1200, iterations: Infinity },
-      exit: { preset: "fade", duration: 700, easing: "SinusoidalIn" },
-    },
-  });
-  allMarker.setLngLat(at(3));
-  wireLogging(allMarker, "ALL");
-  addCaption(map, at(3), "ENTER + IDLE + EXIT");
-  setupToggle("toggle-all", allMarker, false);
 }
 
 void main();

--- a/demos/src/demo-utils.ts
+++ b/demos/src/demo-utils.ts
@@ -1,6 +1,33 @@
 import "../../dist/maptiler-sdk.css";
 import { SdkConfig } from "../../src/config";
+import { Marker } from "../../src/index";
+import type { Map } from "../../src/index";
 import Stats from "stats.js";
+
+/** Looks up an element by id, throwing if it isn't found. */
+export function el<T extends HTMLElement = HTMLElement>(id: string): T {
+  const found = document.getElementById(id);
+  if (!found) throw new Error(`#${id} not found`);
+  return found as T;
+}
+
+/** Static caption pinned under a marker's position — always visible, unlike a hover-only `title` tooltip. */
+export function addCaption(map: Map, lngLat: [number, number], text: string) {
+  const captionEl = document.createElement("div");
+  captionEl.textContent = text;
+  captionEl.style.font = "700 10px system-ui";
+  captionEl.style.letterSpacing = "0.03em";
+  captionEl.style.color = "rgba(0, 0, 0, 0.75)";
+  captionEl.style.background = "rgba(255, 255, 255, 0.85)";
+  captionEl.style.padding = "2px 6px";
+  captionEl.style.borderRadius = "4px";
+  captionEl.style.whiteSpace = "nowrap";
+  captionEl.style.pointerEvents = "none";
+
+  const caption = new Marker({ element: captionEl, anchor: "top", offset: [0, 34], htmlAttributes: { tabindex: "-1" } });
+  caption.setLngLat(lngLat);
+  map.addMarker(caption);
+}
 /**
  * Adds performance statistics to the page.
  */

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -22,7 +22,6 @@ import type {
   MarkerAnimationOptions,
   MarkerCustomAnimationOptions,
   MarkerIdleAnimationOptions,
-  MarkerLifecycleAnimationEventData,
   EnterAnimationPreset,
   ExitAnimationPreset,
   IdleAnimationPreset,
@@ -1212,7 +1211,7 @@ export class Marker extends maplibregl.Marker {
         this.setProp("scale", v.scale);
         applyLifecycleLift(this[MarkerElementSymbol], v.lift);
       },
-      onStart: () => this.fire(`${phase}animationstart`, { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">),
+      onStart: () => this.fire(`${phase}animationstart`, { preset }),
       onEnd: (finalValue) => {
         this.clearEnterMask();
         this.activeTransitions.delete("opacity");
@@ -1220,7 +1219,7 @@ export class Marker extends maplibregl.Marker {
         this.setProp("opacity", finalValue.opacity);
         this.setProp("scale", finalValue.scale);
         applyLifecycleLift(this[MarkerElementSymbol], finalValue.lift);
-        this.fire(`${phase}animationend`, { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">);
+        this.fire(`${phase}animationend`, { preset });
         onComplete?.();
       },
     });
@@ -1244,12 +1243,12 @@ export class Marker extends maplibregl.Marker {
         this.clearEnterMask();
         spec.custom(alpha, this);
       },
-      onStart: () => this.fire(`${phase}animationstart`, { preset: "custom" } as Pick<MarkerLifecycleAnimationEventData, "preset">),
+      onStart: () => this.fire(`${phase}animationstart`, { preset: "custom" }),
       onEnd: (alpha) => {
         this.clearEnterMask();
         this.activeTransitions.delete("opacity");
         spec.custom(alpha, this);
-        this.fire(`${phase}animationend`, { preset: "custom" } as Pick<MarkerLifecycleAnimationEventData, "preset">);
+        this.fire(`${phase}animationend`, { preset: "custom" });
         onComplete?.();
       },
     });
@@ -1313,11 +1312,11 @@ export class Marker extends maplibregl.Marker {
   ): void {
     const animation = new MaptilerAnimation({ keyframes, duration, iterations, delay });
 
-    animation.addEventListener("play", () => this.fire("idleanimationstart", { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">));
+    animation.addEventListener("play", () => this.fire("idleanimationstart", { preset }));
     animation.addEventListener("timeupdate", (event) => {
       apply(event.props.value);
     });
-    animation.addEventListener("iteration", () => this.fire("idleanimationiteration", { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">));
+    animation.addEventListener("iteration", () => this.fire("idleanimationiteration", { preset }));
     // "animationend" fires on every loop-boundary reset, not just a true
     // stop — "stop" only fires once, when `stopIdleAnimation()` interrupts it
     // or (for a finite `iterations`) it naturally runs out. Never call
@@ -1325,7 +1324,7 @@ export class Marker extends maplibregl.Marker {
     // re-emit "stop" into this same listener and recurse.
     animation.addEventListener("stop", () => {
       this.idleAnimation = null;
-      this.fire("idleanimationend", { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">);
+      this.fire("idleanimationend", { preset });
     });
 
     this.idleAnimation = animation;

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -17,6 +17,9 @@ import type {
   MapTilerMarkerTransitions,
   MarkerTransitionSpec,
   MarkerTransitionEventData,
+  MapTilerMarkerAnimations,
+  MarkerAnimationOptions,
+  MarkerLifecycleAnimationEventData,
 } from "./types";
 import { omit } from "../utils/object";
 import { v4 as uuid } from "uuid";
@@ -42,6 +45,7 @@ import {
   rotationTransitionCodec,
   colorTransitionCodec,
   positionTransitionCodec,
+  opacityTransitionCodec,
   type TransitionValueCodec,
 } from "./marker-transitions";
 import type { MaptilerAnimation } from "../MaptilerAnimation";
@@ -189,8 +193,24 @@ export class Marker extends maplibregl.Marker {
   /** Registered per-property transition config, keyed by property name. */
   private transitions: MapTilerMarkerTransitions;
 
-  /** In-flight transitions, keyed by property name — at most one per property. */
-  private readonly activeTransitions = new Map<MarkerTransitionProperty, MaptilerAnimation>();
+  /**
+   * In-flight transitions, keyed by property name — at most one per property.
+   * `"opacity"` isn't a public {@link MarkerTransitionProperty}; it's reused
+   * here so an enter/exit fade is cancelled the same way any other in-flight
+   * transition would be.
+   */
+  private readonly activeTransitions = new Map<MarkerTransitionProperty | "opacity", MaptilerAnimation>();
+
+  /** Configured enter/idle/exit lifecycle animations. */
+  private animations: MapTilerMarkerAnimations;
+
+  /**
+   * Set while `addTo()` is calling into MapLibre's base `addTo()`, which
+   * itself calls `this.remove()` first (to detach from any previous map).
+   * Without this guard that reentrant call would play a full exit animation
+   * every time a marker is (re-)added.
+   */
+  private suppressLifecycleAnimations = false;
 
   //#endregion
 
@@ -261,6 +281,7 @@ export class Marker extends maplibregl.Marker {
     this.options = options;
     this.uiStates = { ...options.states };
     this.transitions = { ...options.transitions };
+    this.animations = { ...options.animations };
     this.attachUIStateListeners();
   }
 
@@ -272,10 +293,20 @@ export class Marker extends maplibregl.Marker {
    * Adds the marker to a map.
    *
    * Overrides the MapLibre signature to also accept the SDK `Map` type.
+   * Plays the configured `enter` animation, if any, once attached.
    * @param map - Target map instance.
    */
   addTo(map: SDKMap): this {
-    return super.addTo(map);
+    // MapLibre's own addTo() calls this.remove() first (to detach from any
+    // previous map) — suppress the exit animation for that reentrant call.
+    this.suppressLifecycleAnimations = true;
+    super.addTo(map);
+    this.suppressLifecycleAnimations = false;
+
+    const enterSpec = this.animations.enter;
+    if (enterSpec) this.playLifecycleAnimation("enter", enterSpec);
+
+    return this;
   }
 
   /**
@@ -1089,7 +1120,7 @@ export class Marker extends maplibregl.Marker {
   }
 
   /** Cancels any transition in flight for `property`, leaving its current (mid-transition) value as-is. */
-  private cancelTransition(property: MarkerTransitionProperty): void {
+  private cancelTransition(property: MarkerTransitionProperty | "opacity"): void {
     const animation = this.activeTransitions.get(property);
     if (!animation) return;
     animation.destroy();
@@ -1099,6 +1130,38 @@ export class Marker extends maplibregl.Marker {
   /** Cancels every transition in flight. Called on removal so a destroyed marker's props can't keep animating. */
   private cancelAllTransitions(): void {
     for (const property of [...this.activeTransitions.keys()]) this.cancelTransition(property);
+  }
+
+  //#endregion
+
+  //#region Lifecycle Animations
+
+  /**
+   * Plays the configured `enter`/`exit` fade. Every preset currently resolves
+   * to the same opacity fade — distinct per-preset keyframes land later.
+   * Fires `${phase}animationstart`/`${phase}animationend` and calls
+   * `onComplete` once the target opacity is reached.
+   */
+  private playLifecycleAnimation(phase: "enter" | "exit", spec: MarkerAnimationOptions, onComplete?: () => void): void {
+    this.cancelTransition("opacity");
+
+    const baseOpacity = this.props.opacity ?? 1;
+    const from = phase === "enter" ? 0 : baseOpacity;
+    const to = phase === "enter" ? baseOpacity : 0;
+
+    const animation = runPropertyTransition(from, to, [spec.duration ?? 1000, spec.easing, spec.delay ?? 0], {
+      codec: opacityTransitionCodec,
+      onUpdate: (v) => this.setProp("opacity", v),
+      onStart: () => this.fire(`${phase}animationstart`, { preset: spec.preset } as Pick<MarkerLifecycleAnimationEventData, "preset">),
+      onEnd: (finalValue) => {
+        this.activeTransitions.delete("opacity");
+        this.setProp("opacity", finalValue);
+        this.fire(`${phase}animationend`, { preset: spec.preset } as Pick<MarkerLifecycleAnimationEventData, "preset">);
+        onComplete?.();
+      },
+    });
+
+    this.activeTransitions.set("opacity", animation);
   }
 
   //#endregion
@@ -1118,17 +1181,38 @@ export class Marker extends maplibregl.Marker {
 
   /**
    * Deregisters the marker from {@link MarkerManager} and removes it from
-   * the map.
+   * the map. If an `exit` animation is configured, the marker is deregistered
+   * immediately (collision/index bookkeeping updates right away) but stays
+   * attached and visible until the animation finishes.
    * @returns `this` for chaining.
    */
   override remove(): this {
+    // reentrant call from addTo()'s internal remove(), or a genuine remove()
+    // with nothing configured to animate — plain, immediate removal.
+    if (this.suppressLifecycleAnimations) {
+      this.detachImmediately();
+      return this;
+    }
+
+    const exitSpec = this.animations.exit;
+    if (!exitSpec || !MarkerManager.getMap(this)) {
+      this.detachImmediately();
+      return this;
+    }
+
+    MarkerManager.deregister(this, { deferDetach: true });
+    this.playLifecycleAnimation("exit", exitSpec, () => this[DetachFromDOMSymbol]());
+    return this;
+  }
+
+  /** Deregisters (if registered) and detaches from the DOM immediately — no exit animation. */
+  private detachImmediately(): void {
     if (MarkerManager.getMap(this)) {
       MarkerManager.deregister(this);
     } else {
       // never registered (added via addTo() directly) — plain MapLibre removal
-      super.remove();
+      this[DetachFromDOMSymbol]();
     }
-    return this;
   }
 
   //#endregion

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -18,14 +18,21 @@ import type {
   MarkerTransitionSpec,
   MarkerTransitionEventData,
   MapTilerMarkerAnimations,
+  MarkerAnimationBase,
   MarkerAnimationOptions,
+  MarkerCustomAnimationOptions,
+  MarkerIdleAnimationOptions,
   MarkerLifecycleAnimationEventData,
+  EnterAnimationPreset,
+  ExitAnimationPreset,
+  IdleAnimationPreset,
 } from "./types";
 import { omit } from "../utils/object";
 import { v4 as uuid } from "uuid";
 import {
   applyCollisionCulled,
   applyCollisionHidden,
+  applyLifecycleLift,
   applyMarkerStyleVariables,
   applyMinimizedDot,
   createMarkerElement,
@@ -45,10 +52,23 @@ import {
   rotationTransitionCodec,
   colorTransitionCodec,
   positionTransitionCodec,
+  lifecycleTransitionCodec,
   opacityTransitionCodec,
   type TransitionValueCodec,
 } from "./marker-transitions";
-import type { MaptilerAnimation } from "../MaptilerAnimation";
+import { MaptilerAnimation } from "../MaptilerAnimation";
+import type { Keyframe } from "../MaptilerAnimation/types";
+import {
+  ENTER_PRESET_EASING,
+  EXIT_PRESET_EASING,
+  enterPresetHiddenValue,
+  exitPresetHiddenValue,
+  scaleLifecycleMagnitude,
+  scaleIdleMagnitude,
+  IDLE_PRESET_CONFIG,
+  IDLE_PRESET_DEFAULT_DURATION,
+  type LifecycleAnimationValue,
+} from "./marker-animation-presets";
 import {
   PendingUpdatesSymbol,
   DetachFromDOMSymbol,
@@ -201,6 +221,9 @@ export class Marker extends maplibregl.Marker {
    */
   private readonly activeTransitions = new Map<MarkerTransitionProperty | "opacity", MaptilerAnimation>();
 
+  /** The currently-looping `idle` animation, if any — started after `enter` finishes (or immediately), stopped on `remove()`. */
+  private idleAnimation: MaptilerAnimation | null = null;
+
   /** Configured enter/idle/exit lifecycle animations. */
   private animations: MapTilerMarkerAnimations;
 
@@ -254,6 +277,25 @@ export class Marker extends maplibregl.Marker {
     // custom elements skip createMarkerElement, so seed their style variables here
     if (options.element) applyMarkerStyleVariables(options.element, options);
 
+    // If an `enter` animation is configured, mask the element right away.
+    // addTo() attaches it to the DOM synchronously, but MaptilerAnimation
+    // only applies its first keyframe on the *next* animation frame (play()
+    // just starts the clock) — without this, the marker would render at its
+    // full configured opacity for one frame before the enter animation's
+    // first tick pulls it down to its hidden starting state, a visible
+    // "flash" before it fades/grows/pops in.
+    //
+    // This has to be the *outer* element (not the inner `.marker-transform-
+    // wrapper` a preset animates via setProp) so it's just as effective for
+    // a `custom` enter — whose callback can only reach the marker through
+    // the public `getElement()`, i.e. this same outer element. Whichever
+    // kind of enter animation actually runs is responsible for clearing this
+    // mask on its first real frame (see playLifecycleTransition /
+    // playCustomLifecycleAnimation) — until then it stays fully masked.
+    if (options.animations?.enter) {
+      element.style.opacity = "0";
+    }
+
     this.managesOffset = !options.offset && !options.element;
 
     this.props = {
@@ -304,7 +346,15 @@ export class Marker extends maplibregl.Marker {
     this.suppressLifecycleAnimations = false;
 
     const enterSpec = this.animations.enter;
-    if (enterSpec) this.playLifecycleAnimation("enter", enterSpec);
+    const idleSpec = this.animations.idle;
+
+    if (enterSpec) {
+      this.playEnterAnimation(enterSpec, () => {
+        if (idleSpec) this.startIdleAnimation(idleSpec);
+      });
+    } else if (idleSpec) {
+      this.startIdleAnimation(idleSpec);
+    }
 
     return this;
   }
@@ -1137,31 +1187,215 @@ export class Marker extends maplibregl.Marker {
   //#region Lifecycle Animations
 
   /**
-   * Plays the configured `enter`/`exit` fade. Every preset currently resolves
-   * to the same opacity fade — distinct per-preset keyframes land later.
-   * Fires `${phase}animationstart`/`${phase}animationend` and calls
-   * `onComplete` once the target opacity is reached.
+   * Runs `preset`'s enter/exit motion (opacity + scale + lift, see
+   * {@link enterPresetHiddenValue}/{@link exitPresetHiddenValue}) from `from`
+   * to `to`. Fires `${phase}animationstart`/`${phase}animationend` and calls
+   * `onComplete` once the target state is reached.
    */
-  private playLifecycleAnimation(phase: "enter" | "exit", spec: MarkerAnimationOptions, onComplete?: () => void): void {
+  private playLifecycleTransition(
+    phase: "enter" | "exit",
+    from: LifecycleAnimationValue,
+    to: LifecycleAnimationValue,
+    easing: MarkerAnimationBase["easing"],
+    spec: MarkerAnimationBase,
+    preset: EnterAnimationPreset | ExitAnimationPreset,
+    onComplete?: () => void,
+  ): void {
     this.cancelTransition("opacity");
+    this.cancelTransition("scale");
 
-    const baseOpacity = this.props.opacity ?? 1;
-    const from = phase === "enter" ? 0 : baseOpacity;
-    const to = phase === "enter" ? baseOpacity : 0;
-
-    const animation = runPropertyTransition(from, to, [spec.duration ?? 1000, spec.easing, spec.delay ?? 0], {
-      codec: opacityTransitionCodec,
-      onUpdate: (v) => this.setProp("opacity", v),
-      onStart: () => this.fire(`${phase}animationstart`, { preset: spec.preset } as Pick<MarkerLifecycleAnimationEventData, "preset">),
+    const animation = runPropertyTransition(from, to, [spec.duration ?? 1000, easing, spec.delay ?? 0], {
+      codec: lifecycleTransitionCodec,
+      onUpdate: (v) => {
+        this.clearEnterMask();
+        this.setProp("opacity", v.opacity);
+        this.setProp("scale", v.scale);
+        applyLifecycleLift(this[MarkerElementSymbol], v.lift);
+      },
+      onStart: () => this.fire(`${phase}animationstart`, { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">),
       onEnd: (finalValue) => {
+        this.clearEnterMask();
         this.activeTransitions.delete("opacity");
-        this.setProp("opacity", finalValue);
-        this.fire(`${phase}animationend`, { preset: spec.preset } as Pick<MarkerLifecycleAnimationEventData, "preset">);
+        this.activeTransitions.delete("scale");
+        this.setProp("opacity", finalValue.opacity);
+        this.setProp("scale", finalValue.scale);
+        applyLifecycleLift(this[MarkerElementSymbol], finalValue.lift);
+        this.fire(`${phase}animationend`, { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">);
         onComplete?.();
       },
     });
 
     this.activeTransitions.set("opacity", animation);
+    this.activeTransitions.set("scale", animation);
+  }
+
+  /**
+   * Runs a `custom` enter/exit animation: a plain `0`→`1` alpha (already
+   * eased) handed to `spec.custom` every frame. `0` is enter's hidden /
+   * exit's shown state; `1` is the opposite end.
+   */
+  private playCustomLifecycleAnimation(phase: "enter" | "exit", spec: MarkerCustomAnimationOptions, onComplete?: () => void): void {
+    this.cancelTransition("opacity");
+    this.cancelTransition("scale");
+
+    const animation = runPropertyTransition(0, 1, [spec.duration ?? 1000, spec.easing, spec.delay ?? 0], {
+      codec: opacityTransitionCodec,
+      onUpdate: (alpha) => {
+        this.clearEnterMask();
+        spec.custom(alpha, this);
+      },
+      onStart: () => this.fire(`${phase}animationstart`, { preset: "custom" } as Pick<MarkerLifecycleAnimationEventData, "preset">),
+      onEnd: (alpha) => {
+        this.clearEnterMask();
+        this.activeTransitions.delete("opacity");
+        spec.custom(alpha, this);
+        this.fire(`${phase}animationend`, { preset: "custom" } as Pick<MarkerLifecycleAnimationEventData, "preset">);
+        onComplete?.();
+      },
+    });
+
+    this.activeTransitions.set("opacity", animation);
+  }
+
+  /**
+   * Clears the outer-element opacity mask set at construction time when an
+   * `enter` animation is configured (see the constructor). Called from the
+   * first real frame of whichever enter/exit animation runs — preset or
+   * `custom` — so a `custom` enter is never left invisible: it's the only
+   * thing responsible for un-masking itself, since the SDK has no way to
+   * know in advance whether (or how) a `custom` callback touches opacity.
+   * Safe to call unconditionally, including for `exit` (never masked) and
+   * repeatedly (idempotent) — it's just clearing an inline style back to "".
+   */
+  private clearEnterMask(): void {
+    this[MarkerElementSymbol].style.opacity = "";
+  }
+
+  /** Plays the configured `enter` animation, easing from {@link enterPresetHiddenValue} up to the marker's own configured state. */
+  private playEnterAnimation(spec: MarkerAnimationOptions<EnterAnimationPreset>, onComplete?: () => void): void {
+    if (typeof spec.custom === "function") {
+      this.playCustomLifecycleAnimation("enter", spec, onComplete);
+      return;
+    }
+
+    const baseOpacity = this.props.opacity ?? 1;
+    const baseScale = this.props.scale ?? [1, 1];
+    const shown: LifecycleAnimationValue = { opacity: baseOpacity, scale: baseScale, lift: 0 };
+    const hidden = scaleLifecycleMagnitude(shown, enterPresetHiddenValue(spec.preset, baseOpacity, baseScale), spec.magnitude ?? 1);
+    this.playLifecycleTransition("enter", hidden, shown, spec.easing ?? ENTER_PRESET_EASING[spec.preset], spec, spec.preset, onComplete);
+  }
+
+  /** Plays the configured `exit` animation, easing from the marker's own configured state down to {@link exitPresetHiddenValue}. */
+  private playExitAnimation(spec: MarkerAnimationOptions<ExitAnimationPreset>, onComplete?: () => void): void {
+    if (typeof spec.custom === "function") {
+      this.playCustomLifecycleAnimation("exit", spec, onComplete);
+      return;
+    }
+
+    const baseOpacity = this.props.opacity ?? 1;
+    const baseScale = this.props.scale ?? [1, 1];
+    const shown: LifecycleAnimationValue = { opacity: baseOpacity, scale: baseScale, lift: 0 };
+    const hidden = scaleLifecycleMagnitude(shown, exitPresetHiddenValue(spec.preset, baseOpacity, baseScale), spec.magnitude ?? 1);
+    this.playLifecycleTransition("exit", shown, hidden, spec.easing ?? EXIT_PRESET_EASING[spec.preset], spec, spec.preset, onComplete);
+  }
+
+  /**
+   * Wires the play/iteration/stop bookkeeping shared by every idle loop
+   * (preset or `custom`) around a `value`-keyframed animation, and plays it.
+   */
+  private runIdleAnimation(
+    preset: IdleAnimationPreset | "custom",
+    keyframes: Keyframe[],
+    apply: (value: number) => void,
+    duration: number,
+    iterations: number,
+    delay: number,
+  ): void {
+    const animation = new MaptilerAnimation({ keyframes, duration, iterations, delay });
+
+    animation.addEventListener("play", () => this.fire("idleanimationstart", { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">));
+    animation.addEventListener("timeupdate", (event) => {
+      apply(event.props.value);
+    });
+    animation.addEventListener("iteration", () => this.fire("idleanimationiteration", { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">));
+    // "animationend" fires on every loop-boundary reset, not just a true
+    // stop — "stop" only fires once, when `stopIdleAnimation()` interrupts it
+    // or (for a finite `iterations`) it naturally runs out. Never call
+    // `destroy()` in here: `destroy()` itself calls `stop()`, which would
+    // re-emit "stop" into this same listener and recurse.
+    animation.addEventListener("stop", () => {
+      this.idleAnimation = null;
+      this.fire("idleanimationend", { preset } as Pick<MarkerLifecycleAnimationEventData, "preset">);
+    });
+
+    this.idleAnimation = animation;
+    animation.play();
+  }
+
+  /**
+   * Starts the configured `idle` loop — `preset`'s single channel (see
+   * {@link IDLE_PRESET_CONFIG}) eased out from rest and back per iteration,
+   * or a `custom` callback fed a `0`→`1` alpha that resets every iteration.
+   * Replaces any idle animation already running.
+   */
+  private startIdleAnimation(spec: MarkerIdleAnimationOptions): void {
+    this.stopIdleAnimation();
+
+    if (typeof spec.custom === "function") {
+      this.runIdleAnimation(
+        "custom",
+        [
+          { delta: 0, props: { value: 0 }, easing: spec.easing ?? "Linear" },
+          { delta: 1, props: { value: 1 } },
+        ],
+        (value) => {
+          spec.custom(value, this);
+        },
+        spec.duration ?? 1000,
+        spec.iterations ?? Infinity,
+        spec.delay ?? 0,
+      );
+      return;
+    }
+
+    const { channel, keyframes } = IDLE_PRESET_CONFIG[spec.preset];
+    const magnitude = spec.magnitude ?? 1;
+    const baseOpacity = this.props.opacity ?? 1;
+    const baseScale = this.props.scale ?? [1, 1];
+    const baseRotation = this.props.rotation ?? 0;
+
+    const apply = (value: number) => {
+      switch (channel) {
+        case "scale":
+          this.setProp("scale", [baseScale[0] * value, baseScale[1] * value]);
+          break;
+        case "opacity":
+          this.setProp("opacity", baseOpacity * value);
+          break;
+        case "rotation":
+          this.setRotation(baseRotation + value);
+          break;
+        case "lift":
+          applyLifecycleLift(this[MarkerElementSymbol], value);
+          break;
+      }
+    };
+
+    this.runIdleAnimation(
+      spec.preset,
+      keyframes.map((kf) => ({ delta: kf.delta, props: { value: scaleIdleMagnitude(channel, kf.value, magnitude) }, easing: kf.easing ?? "Linear" })),
+      apply,
+      spec.duration ?? IDLE_PRESET_DEFAULT_DURATION[spec.preset],
+      spec.iterations ?? Infinity,
+      spec.delay ?? 0,
+    );
+  }
+
+  /** Stops the currently-looping `idle` animation, if any, leaving the marker at its current (mid-loop) state. */
+  private stopIdleAnimation(): void {
+    if (!this.idleAnimation) return;
+    this.idleAnimation.destroy();
+    this.idleAnimation = null;
   }
 
   //#endregion
@@ -1175,6 +1409,7 @@ export class Marker extends maplibregl.Marker {
    * up its own state — calling `remove()` here would cause infinite recursion.
    */
   [DetachFromDOMSymbol](): void {
+    this.stopIdleAnimation();
     this.cancelAllTransitions();
     super.remove();
   }
@@ -1194,6 +1429,11 @@ export class Marker extends maplibregl.Marker {
       return this;
     }
 
+    // stop straight away, not deferred to [DetachFromDOMSymbol] — otherwise
+    // it would keep looping (and fighting the exit motion) for the whole
+    // exit animation instead of stopping the moment removal starts.
+    this.stopIdleAnimation();
+
     const exitSpec = this.animations.exit;
     if (!exitSpec || !MarkerManager.getMap(this)) {
       this.detachImmediately();
@@ -1201,7 +1441,9 @@ export class Marker extends maplibregl.Marker {
     }
 
     MarkerManager.deregister(this, { deferDetach: true });
-    this.playLifecycleAnimation("exit", exitSpec, () => this[DetachFromDOMSymbol]());
+    this.playExitAnimation(exitSpec, () => {
+      this[DetachFromDOMSymbol]();
+    });
     return this;
   }
 

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -559,12 +559,7 @@ class MarkerManagerImpl {
   private applyCollisionBehaviours(map: SDKMap, state: MapCollisionState, entries: CollisionEntry[]): void {
     const resolution: ResolutionEntry[] = entries.map((entry) => {
       const behaviour = this.effectiveBehaviour(entry.marker, state);
-      const mode: ResolutionMode =
-        behaviour === CollisionBehaviour.HIDE_BY_PRIORITY
-          ? "hide"
-          : behaviour === CollisionBehaviour.MINIMIZE_BY_PRIORITY
-            ? "minimize"
-            : "always";
+      const mode: ResolutionMode = behaviour === CollisionBehaviour.HIDE_BY_PRIORITY ? "hide" : behaviour === CollisionBehaviour.MINIMIZE_BY_PRIORITY ? "minimize" : "always";
       return { mode, priority: numericPriority(entry.marker), obb: entry.obb };
     });
 
@@ -576,8 +571,7 @@ class MarkerManagerImpl {
     // marker (a dense zoom threshold un-hiding hundreds stalled for frames)
     // reduce (not `.some`) — every visible marker must be un-culled; short-circuit would skip the rest
     const needsReflow = entries.reduce(
-      (needs, entry) =>
-        displayStates[entry.index] === "hidden" ? needs : applyCollisionCulled(entry.marker.getElement(), false) || needs,
+      (needs, entry) => (displayStates[entry.index] === "hidden" ? needs : applyCollisionCulled(entry.marker.getElement(), false) || needs),
       false,
     );
     if (needsReflow) void map.getContainer().offsetWidth;

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -222,8 +222,11 @@ class MarkerManagerImpl {
     marker[RefreshAdaptiveColorSymbol]();
   }
 
-  // unregisters a Marker that no longer needs to be managed.
-  deregister(marker: Marker): void {
+  // unregisters a Marker that no longer needs to be managed. `deferDetach`
+  // skips the final DOM detach — used by Marker.remove() to play an exit
+  // animation while every other bookkeeping (index, collisions, drag
+  // handlers) updates immediately, same as a normal removal.
+  deregister(marker: Marker, options?: { deferDetach?: boolean }): void {
     const map = this.markerMap.get(marker);
 
     if (!map) return;
@@ -250,7 +253,7 @@ class MarkerManagerImpl {
     marker[ApplyCollisionDisplayStateSymbol]("visible");
     this.invalidateCollisions(map);
 
-    marker[DetachFromDOMSymbol]();
+    if (!options?.deferDetach) marker[DetachFromDOMSymbol]();
   }
 
   // As above but with a Markers ID instead.

--- a/src/Marker/marker-animation-presets.ts
+++ b/src/Marker/marker-animation-presets.ts
@@ -1,0 +1,209 @@
+import type { EasingFunctionName } from "../MaptilerAnimation/types";
+import type { EnterAnimationPreset, ExitAnimationPreset, IdleAnimationPreset, Vector2 } from "./types";
+
+//#region Enter / Exit
+
+/**
+ * An `enter`/`exit` preset's animated state at one end of its motion:
+ * opacity, 2-D scale, and a vertical `lift` offset in CSS px (used by
+ * `enter`'s `drop`/`bounce`; `0` elsewhere).
+ */
+export type LifecycleAnimationValue = {
+  opacity: number;
+  scale: Vector2;
+  lift: number;
+};
+
+/** Vertical offset (CSS px) `enter`'s `drop`/`bounce` start from on `enter`. */
+export const LIFECYCLE_LIFT_PX = 48;
+
+/** Default easing per `enter` preset, used when `MarkerAnimationOptions.easing` doesn't override it. */
+export const ENTER_PRESET_EASING: Record<EnterAnimationPreset, EasingFunctionName> = {
+  fade: "Linear",
+  grow: "CubicOut",
+  pop: "ElasticOut",
+  drop: "CubicOut",
+  bounce: "BounceOut",
+};
+
+/**
+ * The "hidden" end of `preset`'s `enter` animation — the value a marker
+ * eases from. `baseOpacity`/`baseScale` are the marker's own configured
+ * values, i.e. the "shown" end shared by every preset.
+ */
+export function enterPresetHiddenValue(preset: EnterAnimationPreset, baseOpacity: number, baseScale: Vector2): LifecycleAnimationValue {
+  switch (preset) {
+    case "fade":
+      return { opacity: 0, scale: baseScale, lift: 0 };
+    case "grow":
+    case "pop":
+      return { opacity: 0, scale: [0, 0], lift: 0 };
+    case "drop":
+      return { opacity: 0, scale: baseScale, lift: -LIFECYCLE_LIFT_PX };
+    case "bounce":
+      return { opacity: baseOpacity, scale: baseScale, lift: -LIFECYCLE_LIFT_PX };
+  }
+}
+
+/** Default easing per `exit` preset, used when `MarkerAnimationOptions.easing` doesn't override it. */
+export const EXIT_PRESET_EASING: Record<ExitAnimationPreset, EasingFunctionName> = {
+  fade: "Linear",
+  shrink: "CubicIn",
+  pop: "ElasticIn",
+  explode: "CubicOut",
+};
+
+/** Scale multiplier `explode` grows the marker to (from its own base scale) while it fades out. */
+const EXPLODE_SCALE_MULTIPLIER = 2;
+
+/**
+ * The "hidden" end of `preset`'s `exit` animation — the value a marker
+ * eases to. `baseOpacity`/`baseScale` are the marker's own configured
+ * values, i.e. the "shown" end shared by every preset.
+ */
+export function exitPresetHiddenValue(preset: ExitAnimationPreset, baseOpacity: number, baseScale: Vector2): LifecycleAnimationValue {
+  switch (preset) {
+    case "fade":
+      return { opacity: 0, scale: baseScale, lift: 0 };
+    case "shrink":
+      return { opacity: baseOpacity, scale: [0, 0], lift: 0 };
+    case "pop":
+      return { opacity: 0, scale: [0, 0], lift: 0 };
+    case "explode":
+      return { opacity: 0, scale: [baseScale[0] * EXPLODE_SCALE_MULTIPLIER, baseScale[1] * EXPLODE_SCALE_MULTIPLIER], lift: 0 };
+  }
+}
+
+/**
+ * Scales a preset's `hidden` value by `magnitude` — `1` (the default) is the
+ * full designed motion (`hidden` as-is), `0` is no motion at all (`shown`),
+ * values beyond `1` extrapolate past `hidden`.
+ */
+export function scaleLifecycleMagnitude(shown: LifecycleAnimationValue, hidden: LifecycleAnimationValue, magnitude: number): LifecycleAnimationValue {
+  const lerp = (from: number, to: number) => from + (to - from) * magnitude;
+  return {
+    opacity: lerp(shown.opacity, hidden.opacity),
+    scale: [lerp(shown.scale[0], hidden.scale[0]), lerp(shown.scale[1], hidden.scale[1])],
+    lift: lerp(shown.lift, hidden.lift),
+  };
+}
+
+//#endregion
+
+//#region Idle
+
+/**
+ * Which marker channel an idle preset animates. `value` at a keyframe
+ * multiplies the marker's base value for `scale`/`opacity` (rest = `1`), or
+ * is added to it for `rotation`/`lift` (rest = `0`).
+ */
+export type IdleAnimationChannel = "scale" | "opacity" | "rotation" | "lift";
+
+/**
+ * Scales an idle keyframe's `value` by `magnitude` around its channel's rest
+ * value (`1` for `scale`/`opacity`, `0` for `rotation`/`lift`) — `1` (the
+ * default) is the full designed motion, `0` is no motion at all (rest).
+ */
+export function scaleIdleMagnitude(channel: IdleAnimationChannel, value: number, magnitude: number): number {
+  const rest = channel === "scale" || channel === "opacity" ? 1 : 0;
+  return rest + (value - rest) * magnitude;
+}
+
+/** One control point in an idle preset's per-iteration curve. */
+export type IdleAnimationKeyframe = {
+  /** Position within one loop iteration, `0`–`1`. */
+  delta: number;
+  /** Channel value at this point — see {@link IdleAnimationChannel}. */
+  value: number;
+  /** Easing from the previous keyframe to this one. Defaults to `"Linear"`. */
+  easing?: EasingFunctionName;
+};
+
+export type IdlePresetConfig = {
+  channel: IdleAnimationChannel;
+  /**
+   * Always starts and ends at rest (`delta` `0` and `1`); every preset's
+   * animated motion is centered on `delta` `0.5`.
+   */
+  keyframes: IdleAnimationKeyframe[];
+};
+
+const PULSE_SCALE_PEAK = 1.15;
+const PULSE_OPACITY_PEAK = 0.45;
+const RING_PEAK_DEG = 12;
+const IDLE_BOUNCE_LIFT_PX = 14;
+
+//region Idle Animation Presets
+
+export const IDLE_PRESET_CONFIG: Record<IdleAnimationPreset, IdlePresetConfig> = {
+  //region pulsescale
+  // Rest for the first/last ~35%, a single smooth "breathing" scale pulse in between.
+  pulsescale: {
+    channel: "scale",
+    keyframes: [
+      { delta: 0, value: 1 },
+      { delta: 0.4, value: 1 },
+      { delta: 0.5, value: PULSE_SCALE_PEAK, easing: "SinusoidalInOut" },
+      { delta: 0.65, value: 1, easing: "SinusoidalInOut" },
+      { delta: 1, value: 1 },
+    ],
+  },
+  //endregion
+
+  //region pulseopacity
+  // Same shape as pulsescale, on opacity instead of scale.
+  pulseopacity: {
+    channel: "opacity",
+    keyframes: [
+      { delta: 0, value: 1 },
+      { delta: 0.5, value: PULSE_OPACITY_PEAK, easing: "SinusoidalInOut" },
+      { delta: 1, value: 1, easing: "SinusoidalInOut" },
+    ],
+  },
+  //endregion
+
+  //region ring
+  // Rest for the first/last ~40%, several alternating rotation wiggles clustered around the midpoint.
+  ring: {
+    channel: "rotation",
+    keyframes: [
+      { delta: 0, value: 0 },
+      { delta: 0.4, value: 0 },
+      { delta: 0.45, value: -RING_PEAK_DEG, easing: "SinusoidalInOut" },
+      { delta: 0.5, value: RING_PEAK_DEG, easing: "SinusoidalInOut" },
+      { delta: 0.55, value: -RING_PEAK_DEG * 0.6, easing: "SinusoidalInOut" },
+      { delta: 0.6, value: 0, easing: "SinusoidalInOut" },
+      { delta: 1, value: 0 },
+    ],
+  },
+  //endregion
+
+  //region bounce
+  // Rest to 0.25, rise to the peak by the midpoint, bounce back down to rest by 0.75, rest out the rest.
+  bounce: {
+    channel: "lift",
+    keyframes: [
+      { delta: 0, value: 0 },
+      { delta: 0.45, value: 0, easing: "SinusoidalOut" },
+      { delta: 0.5, value: -IDLE_BOUNCE_LIFT_PX, easing: "BounceOut" },
+      { delta: 0.7, value: 0 },
+      { delta: 1, value: 0 },
+    ],
+  },
+  //endregion
+};
+
+/**
+ * Default loop duration (ms) per idle preset, used when
+ * `MarkerIdleAnimationOptions.duration` is omitted — overrides the generic
+ * `1000` documented on {@link MarkerAnimationOptions}. `pulsescale`/
+ * `pulseopacity` default to ~1Hz; `ring`/`bounce` recur every few seconds.
+ */
+export const IDLE_PRESET_DEFAULT_DURATION: Record<IdleAnimationPreset, number> = {
+  pulsescale: 1000,
+  pulseopacity: 1000,
+  ring: 3000,
+  bounce: 3000,
+};
+
+//#endregion

--- a/src/Marker/marker-dom-utils.ts
+++ b/src/Marker/marker-dom-utils.ts
@@ -691,17 +691,35 @@ function buildInnerElement(inner: ShapeDescriptor["inner"]): SVGCircleElement | 
 //#region applyTransform
 
 /**
- * Composes `data-scaleX`, `data-scaleY`, and `data-rotation` into a single
- * CSS `transform` string on the wrapper. Reading from dataset rather than
- * accepting individual arguments ensures scale and rotation never clobber
- * each other when only one property changes at a time.
+ * Composes `data-scaleX`, `data-scaleY`, `data-rotation`, and `data-lift`
+ * into a single CSS `transform` string on the wrapper. Reading from dataset
+ * rather than accepting individual arguments ensures these never clobber
+ * each other when only one changes at a time.
+ *
+ * `translateY` is listed first (outermost) so `data-lift` is always a fixed
+ * CSS px offset, unaffected by the scale applied after it.
  * @param wrapper - The marker wrapper element.
  */
 function applyTransform(wrapper: HTMLElement): void {
   const sx = wrapper.dataset.scaleX ?? "1";
   const sy = wrapper.dataset.scaleY ?? "1";
   const rot = wrapper.dataset.rotation ?? "0";
-  wrapper.style.transform = `scale(${sx}, ${sy}) rotate(${rot}deg)`;
+  const lift = wrapper.dataset.lift ?? "0";
+  wrapper.style.transform = `translateY(${lift}px) scale(${sx}, ${sy}) rotate(${rot}deg)`;
+}
+
+/**
+ * Sets the wrapper's lifecycle-animation vertical offset (`enter`'s
+ * `drop`/`bounce`, idle's `bounce`) in CSS px. Animation-only — not a public
+ * marker property, so it bypasses {@link updateMarkerElement}'s
+ * pending-update batching.
+ * @param element - The marker's outer root element.
+ * @param liftPx - Vertical offset in CSS px; `0` is the resting position.
+ */
+export function applyLifecycleLift(element: HTMLElement, liftPx: number): void {
+  const wrapper = resolveMarkerWrapper(element);
+  wrapper.dataset.lift = String(liftPx);
+  applyTransform(wrapper);
 }
 
 //#endregion

--- a/src/Marker/marker-transitions.ts
+++ b/src/Marker/marker-transitions.ts
@@ -2,6 +2,7 @@ import { LngLat } from "../index";
 import { MaptilerAnimation } from "../MaptilerAnimation";
 import { parseColorStringToVec4 } from "../utils/webgl-utils";
 import type { MarkerTransitionSpec, Vector2 } from "./types";
+import type { LifecycleAnimationValue } from "./marker-animation-presets";
 
 // Without this codec layer, either MaptilerAnimation would need bespoke interpolation
 // logic per property type (defeating the point of a shared engine), or Marker.ts would
@@ -25,6 +26,12 @@ export const rotationTransitionCodec: TransitionValueCodec<number> = {
 export const opacityTransitionCodec: TransitionValueCodec<number> = {
   toNumeric: (value) => ({ value }),
   fromNumeric: (props) => props.value,
+};
+
+/** Bridges an `enter`/`exit` preset's combined opacity/scale/lift state to the numeric props {@link MaptilerAnimation} interpolates between. */
+export const lifecycleTransitionCodec: TransitionValueCodec<LifecycleAnimationValue> = {
+  toNumeric: ({ opacity, scale: [scaleX, scaleY], lift }) => ({ opacity, scaleX, scaleY, lift }),
+  fromNumeric: ({ opacity, scaleX, scaleY, lift }) => ({ opacity, scale: [scaleX, scaleY], lift }),
 };
 
 export const positionTransitionCodec: TransitionValueCodec<LngLat> = {

--- a/src/Marker/marker-transitions.ts
+++ b/src/Marker/marker-transitions.ts
@@ -22,6 +22,11 @@ export const rotationTransitionCodec: TransitionValueCodec<number> = {
   fromNumeric: (props) => props.value,
 };
 
+export const opacityTransitionCodec: TransitionValueCodec<number> = {
+  toNumeric: (value) => ({ value }),
+  fromNumeric: (props) => props.value,
+};
+
 export const positionTransitionCodec: TransitionValueCodec<LngLat> = {
   // this looks pointless, but its designed to strip the LngLat object of its type
   // so that it can be passed to the MaptilerAnimation engine

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -132,34 +132,68 @@ export type MarkerPriorityExpression = unknown[];
 
 //#endregion
 
-//#region Pending features
+//#region Lifecycle Animations
 
-// Animation (Non MVP)
+/**
+ * Predefined lifecycle animation types. Every preset currently resolves to a
+ * simple opacity fade (in for `enter`, out for `exit`) — distinct per-preset
+ * keyframes (e.g. `drop` translating in from above) land in a later pass.
+ */
+export type AnimationPreset = "grow" | "drop" | "emerge" | "pop" | "fade" | "draw";
 
-// /** Predefined animation preset names. Each preset ships with a default easing curve. */
-// export type AnimationPreset = "grow" | "drop" | "emerge" | "pop" | "fade" | "draw";
+/** Configures a marker's `enter` or `exit` lifecycle animation. */
+export type MarkerAnimationOptions = {
+  /** Predefined animation type. */
+  preset: AnimationPreset;
+  /** Overrides the preset's default easing. Defaults to `"Linear"`. */
+  easing?: EasingFunctionName;
+  /** Duration in milliseconds. Defaults to `1000`. */
+  duration?: number;
+  /** Delay before the animation starts, in milliseconds. Defaults to `0`. */
+  delay?: number;
+};
 
-// /**
-//  * Configures a single animation stage for a marker lifecycle event.
-//  * Accepts either a preset-based config object or an existing `MaptilerAnimation` instance.
-//  */
-// export type AnimationOptions =
-//   | {
-//       /** Predefined animation type. The preset also supplies a default easing function. */
-//       preset: AnimationPreset;
-//       /** Overrides the default easing function for the preset. */
-//       easing?: (t: number) => number;
-//       /** Duration in milliseconds. Defaults to 1000. */
-//       duration?: number;
-//       /** Delay before the animation starts in milliseconds. Defaults to 0. */
-//       delay?: number;
-//       /**
-//        * When `true` the animation plays immediately on creation.
-//        * When `false` and `delay` is set, playback waits `delay` ms after `play()` is called.
-//        */
-//       autoplay?: boolean;
-//     }
-//   | MaptilerAnimation;
+/** Configures a marker's `idle` lifecycle animation. */
+export type MarkerIdleAnimationOptions = MarkerAnimationOptions & {
+  /** Number of loop iterations. Omit, or pass `Infinity`, to loop continuously. */
+  iterations?: number;
+};
+
+/**
+ * Lifecycle animations played as a marker enters, idles on, and exits the map.
+ */
+export type MapTilerMarkerAnimations = {
+  /** Played once the marker is added to a map. */
+  enter?: MarkerAnimationOptions;
+  /**
+   * Played when `remove()` is called. The marker stays on the map, still
+   * receiving updates, until this animation finishes.
+   */
+  exit?: MarkerAnimationOptions;
+  /**
+   * Looped while the marker sits on the map, after `enter` finishes (or
+   * immediately, if no `enter` is configured).
+   */
+  idle?: MarkerIdleAnimationOptions;
+};
+
+/**
+ * Event fired by a marker's lifecycle animations — `enter`/`exit` fire
+ * `start`/`end` once each; `idle` additionally fires `iteration` once per loop.
+ */
+export type MarkerLifecycleAnimationEventData = {
+  type:
+    | "enteranimationstart"
+    | "enteranimationend"
+    | "exitanimationstart"
+    | "exitanimationend"
+    | "idleanimationstart"
+    | "idleanimationiteration"
+    | "idleanimationend";
+  target: Marker;
+  /** The preset configured for the phase that fired this event. */
+  preset: AnimationPreset;
+};
 
 //#endregion
 
@@ -321,15 +355,8 @@ export type MapTilerMarkerBaseOptions = Omit<MarkerOptions, "scale" | "opacity" 
   visible?: boolean;
   /** Rendering priority used for collision detection. Accepts a numeric value or a MapLibre-style expression. */
   priority?: number | MarkerPriorityExpression;
-  // /** Lifecycle animations. (Non MVP) Certain fields (e.g. `iterations`) are ignored for `enter` and `exit` animations. */
-  // animations?: {
-  //   /** Played when the marker is added to the map. Defaults to a subtle drop-in effect. */
-  //   enter?: AnimationOptions[];
-  //   /** Played when the marker is removed from the map. Defaults to a fade-out effect. */
-  //   exit?: AnimationOptions[];
-  //   /** Loops continuously while the marker is idle on the map. */
-  //   idle?: AnimationOptions[];
-  // };
+  /** Lifecycle animations played as the marker enters, idles on, and exits the map. */
+  animations?: MapTilerMarkerAnimations;
   /**
    * Per-property easing applied when a transitionable property (`position`,
    * `scale`, `rotation`, or a colour) is next set, instead of the change

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -135,17 +135,43 @@ export type MarkerPriorityExpression = unknown[];
 //#region Lifecycle Animations
 
 /**
- * Predefined lifecycle animation types. Every preset currently resolves to a
- * simple opacity fade (in for `enter`, out for `exit`) — distinct per-preset
- * keyframes (e.g. `drop` translating in from above) land in a later pass.
+ * Predefined `enter` animation types.
+ * - `fade` — opacity only.
+ * - `grow` — uniform scale from nothing, plus fade.
+ * - `pop` — uniform scale from nothing with a springy overshoot, plus fade.
+ * - `drop` — slides straight down into place, plus fade.
+ * - `bounce` — slides down into place with a bounce-settle, fully opaque throughout.
+ *
+ * See `marker-animation-presets.ts` for each preset's exact motion/easing config.
  */
-export type AnimationPreset = "grow" | "drop" | "emerge" | "pop" | "fade" | "draw";
+export type EnterAnimationPreset = "grow" | "drop" | "pop" | "bounce" | "fade";
 
-/** Configures a marker's `enter` or `exit` lifecycle animation. */
-export type MarkerAnimationOptions = {
-  /** Predefined animation type. */
-  preset: AnimationPreset;
-  /** Overrides the preset's default easing. Defaults to `"Linear"`. */
+/**
+ * Predefined `exit` animation types.
+ * - `fade` — opacity only.
+ * - `shrink` — uniform scale to nothing, fully opaque throughout.
+ * - `pop` — scale to nothing combined with a fade, springy overshoot.
+ * - `explode` — scales up (2x) while fading out.
+ *
+ * See `marker-animation-presets.ts` for each preset's exact motion/easing config.
+ */
+export type ExitAnimationPreset = "shrink" | "fade" | "pop" | "explode";
+
+/**
+ * Predefined `idle` animation types — each loops a single channel out and
+ * back to rest once per iteration, peaking at the midpoint (`delta` `0.5`).
+ * - `pulsescale` — scales up and back down, ~1 cycle/second by default.
+ * - `pulseopacity` — dims and back to full opacity, ~1 cycle/second by default.
+ * - `ring` — a rotational shake (several alternating wiggles) clustered around the midpoint, every few seconds by default.
+ * - `bounce` — a vertical hop clustered around the midpoint, every few seconds by default.
+ *
+ * See `marker-animation-presets.ts` for each preset's exact keyframe config.
+ */
+export type IdleAnimationPreset = "pulsescale" | "ring" | "pulseopacity" | "bounce";
+
+/** Fields shared by every enter/exit/idle animation spec, whether preset-based or {@link MarkerCustomAnimationOptions}. */
+export type MarkerAnimationBase = {
+  /** Overrides the preset's default easing. Defaults to `"Linear"`. Also applies to a `custom` animation's `alpha`. */
   easing?: EasingFunctionName;
   /** Duration in milliseconds. Defaults to `1000`. */
   duration?: number;
@@ -153,8 +179,38 @@ export type MarkerAnimationOptions = {
   delay?: number;
 };
 
+/** Configures a marker's `enter`/`exit`/`idle` animation via a predefined preset. */
+export type MarkerPresetAnimationOptions<Preset extends string> = MarkerAnimationBase & {
+  /** Predefined animation type. */
+  preset: Preset;
+  custom?: never;
+  /**
+   * Scales the preset's motion from rest (`0`) up to its full designed
+   * displacement (`1`, the default) — values beyond `1` exaggerate it.
+   * Has no effect on presets with no independent "how far" axis.
+   */
+  magnitude?: number;
+};
+
+/** Configures a marker's `enter`/`exit`/`idle` animation via a custom per-frame callback instead of a preset. */
+export type MarkerCustomAnimationOptions = MarkerAnimationBase & {
+  preset?: never;
+  magnitude?: never;
+  /**
+   * Called every frame with the already-eased progress (`0`–`1`, `easing`
+   * already applied) and the marker being animated. For `enter`, `0` is the
+   * starting (hidden) state and `1` is fully shown; for `exit`, `0` is fully
+   * shown and `1` is the end (hidden) state; for `idle`, `alpha` resets to
+   * `0` at the start of every loop iteration.
+   */
+  custom: (alpha: number, marker: Marker) => void;
+};
+
+/** Configures a marker's `enter` or `exit` lifecycle animation. */
+export type MarkerAnimationOptions<Preset extends string = EnterAnimationPreset | ExitAnimationPreset> = MarkerPresetAnimationOptions<Preset> | MarkerCustomAnimationOptions;
+
 /** Configures a marker's `idle` lifecycle animation. */
-export type MarkerIdleAnimationOptions = MarkerAnimationOptions & {
+export type MarkerIdleAnimationOptions = MarkerAnimationOptions<IdleAnimationPreset> & {
   /** Number of loop iterations. Omit, or pass `Infinity`, to loop continuously. */
   iterations?: number;
 };
@@ -164,12 +220,12 @@ export type MarkerIdleAnimationOptions = MarkerAnimationOptions & {
  */
 export type MapTilerMarkerAnimations = {
   /** Played once the marker is added to a map. */
-  enter?: MarkerAnimationOptions;
+  enter?: MarkerAnimationOptions<EnterAnimationPreset>;
   /**
    * Played when `remove()` is called. The marker stays on the map, still
    * receiving updates, until this animation finishes.
    */
-  exit?: MarkerAnimationOptions;
+  exit?: MarkerAnimationOptions<ExitAnimationPreset>;
   /**
    * Looped while the marker sits on the map, after `enter` finishes (or
    * immediately, if no `enter` is configured).
@@ -182,17 +238,10 @@ export type MapTilerMarkerAnimations = {
  * `start`/`end` once each; `idle` additionally fires `iteration` once per loop.
  */
 export type MarkerLifecycleAnimationEventData = {
-  type:
-    | "enteranimationstart"
-    | "enteranimationend"
-    | "exitanimationstart"
-    | "exitanimationend"
-    | "idleanimationstart"
-    | "idleanimationiteration"
-    | "idleanimationend";
+  type: "enteranimationstart" | "enteranimationend" | "exitanimationstart" | "exitanimationend" | "idleanimationstart" | "idleanimationiteration" | "idleanimationend";
   target: Marker;
-  /** The preset configured for the phase that fired this event. */
-  preset: AnimationPreset;
+  /** The preset configured for the phase that fired this event, or `"custom"` for a {@link MarkerCustomAnimationOptions} animation. */
+  preset: EnterAnimationPreset | ExitAnimationPreset | IdleAnimationPreset | "custom";
 };
 
 //#endregion


### PR DESCRIPTION
## Objective
[Add enter, idle and exit animations]:(https://maptiler.atlassian.net/browse/RD-2134)

## Description
Adds marker lifecycle animations: enter, idle, exit.

 - New enter/exit/idle config on MapTilerMarkerAnimations (src/Marker/types.ts), preset-based or custom per-frame callback
 - Presets: enter (grow, pop, drop, bounce, fade), exit (shrink, pop, explode, fade), idle (pulsescale, pulseopacity, ring, bounce) — keyframes in new src/Marker/marker-animation-presets.ts
 - Marker.ts wired to play enter on add, exit on remove() (marker stays until exit finishes), idle looping after enter
 - New lifecycle events: enteranimationstart/end, exitanimationstart/end, idleanimationstart/iteration/end
 - Transition codec updated for lifecycle transitions
 - Demo 19-maptiler-markers-lifecycle-animations added/updated to showcase presets

## Acceptance
- Manually tested in demo
- Unit tests in subsequent PR

## Checklist
- [ ] ~I have added relevant info to the CHANGELOG.md~ N/A Changelog entry will come in future PR.