### PR TITLE
RD-1414 Add marker altitude support

### DIFF
--- a/demos/public/20-marker-altitude.html
+++ b/demos/public/20-marker-altitude.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Marker Altitude</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      width: 100%;
+      height: 100%;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+
+    #map {
+      position: absolute;
+      inset: 0;
+    }
+
+    #panel {
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      z-index: 100;
+      width: 220px;
+      max-height: calc(100vh - 24px);
+      overflow-y: auto;
+      background: rgba(255, 255, 255, 0.92);
+      backdrop-filter: blur(12px);
+      border: 1px solid rgba(0, 0, 0, 0.1);
+      border-radius: 10px;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+      padding: 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .ctrl-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .ctrl-label {
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(0, 0, 0, 0.45);
+    }
+
+    .scale-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .scale-row input[type="range"] {
+      flex: 1;
+      height: 4px;
+      accent-color: hsl(223, 100%, 65%);
+    }
+
+    .scale-val {
+      font-size: 11px;
+      font-weight: 500;
+      color: rgba(0, 0, 0, 0.6);
+      width: 38px;
+      text-align: right;
+      flex-shrink: 0;
+    }
+
+    .debug-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+      color: rgba(0, 0, 0, 0.6);
+      cursor: pointer;
+    }
+
+    .debug-row input[type="checkbox"] {
+      accent-color: hsl(223, 100%, 65%);
+    }
+
+    /* Ground-line default appearance lives in the SDK stylesheet
+       (`:where(.maptiler-marker-groundline)`, zero specificity) — thicker
+       and bright yellow here for visibility while checking it against
+       terrain. */
+    .groundline-red, .groundline-blue, .groundline-green {
+      border-top-width: 3px;
+      border-top-color: #ffea00;
+    }
+  </style>
+
+  <link rel="stylesheet" href="../build/maptiler-sdk.css">
+</head>
+
+<body>
+  <div id="map"></div>
+
+  <div id="panel">
+    <div class="ctrl-group">
+      <div class="ctrl-label">Pitch</div>
+      <div class="scale-row">
+        <input id="pitch" type="range" min="0" max="85" step="1" value="55" />
+        <span class="scale-val" id="pitch-val">55°</span>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Altitude reference</div>
+      <div class="scale-row" style="gap: 14px;">
+        <label class="debug-row"><input type="radio" name="altref" value="ground" checked /><span>Ground (terrain)</span></label>
+        <label class="debug-row"><input type="radio" name="altref" value="sea" /><span>Sea level</span></label>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Drone 1 altitude</div>
+      <div class="scale-row">
+        <input id="alt1" type="range" min="0" max="1500" step="10" value="400" />
+        <span class="scale-val" id="alt1-val">400m</span>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Drone 2 altitude</div>
+      <div class="scale-row">
+        <input id="alt2" type="range" min="0" max="1500" step="10" value="900" />
+        <span class="scale-val" id="alt2-val">900m</span>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Drone 3 altitude</div>
+      <div class="scale-row">
+        <input id="alt3" type="range" min="0" max="1500" step="10" value="150" />
+        <span class="scale-val" id="alt3-val">150m</span>
+      </div>
+    </div>
+
+    <div class="ctrl-group">
+      <div class="ctrl-label">Ground lines</div>
+      <label class="debug-row">
+        <input id="groundlines" type="checkbox" checked />
+        <span>Show</span>
+      </label>
+    </div>
+  </div>
+
+  <script type="module" src="/src/20-marker-altitude.ts"></script>
+</body>
+
+</html>

--- a/demos/public/index.html
+++ b/demos/public/index.html
@@ -70,6 +70,7 @@
       <a href="17-maptiler-markers-collision.html">MapTiler Markers – Collisions →</a>
       <a href="18-maptiler-markers-ui-states.html">MapTiler Markers – UI States →</a>
       <a href="19-maptiler-markers-lifecycle-animations.html">MapTiler Markers – Lifecycle Animations →</a>
+      <a href="20-marker-altitude.html">Marker Altitude →</a>
     </div>
   </div>
 </body>

--- a/demos/src/20-marker-altitude.ts
+++ b/demos/src/20-marker-altitude.ts
@@ -1,0 +1,119 @@
+import type { GeoJSONSource } from "maplibre-gl";
+import { Map, MapStyle, Marker, config } from "../../src/index";
+import { setupMapTilerApiKey } from "./demo-utils";
+
+setupMapTilerApiKey({ config });
+
+function el<T extends HTMLElement = HTMLElement>(id: string): T {
+  const found = document.getElementById(id);
+  if (!found) throw new Error(`#${id} not found`);
+  return found as T;
+}
+
+// Mercator only — see altitude-math.ts's projectLngLatAltitude doc comment.
+// Don't switch this demo to `projection: "globe"`.
+//
+// Glencoe, Scotland — steep glen walls either side, good for checking
+// altitude/ground-line behaviour against real terrain relief.
+const zoom = 13;
+const center: [number, number] = [-4.988, 56.678];
+
+interface Drone {
+  id: string;
+  lngLat: [number, number];
+  color: string;
+  groundLineClass: string;
+}
+
+const drones: Drone[] = [
+  { id: "alt1", lngLat: [-4.988, 56.678], color: "#e63946", groundLineClass: "groundline-red" },
+  { id: "alt2", lngLat: [-4.978, 56.682], color: "#457b9d", groundLineClass: "groundline-blue" },
+  { id: "alt3", lngLat: [-4.998, 56.674], color: "#2a9d8f", groundLineClass: "groundline-green" },
+];
+
+async function main() {
+  const map = new Map({
+    container: el("map"),
+    style: MapStyle.HYBRID.DEFAULT,
+    zoom,
+    center,
+    pitch: 55,
+    bearing: -20,
+    terrain: true,
+    terrainExaggeration: 1.3,
+  });
+
+  await map.onLoadAsync();
+
+  // Drop points: one added per marker each time a drag ends, at the lngLat
+  // it was released over (altitude is a pixel offset only — it never
+  // changes the marker's actual lngLat, so this is exactly "where dropped").
+  const dropFeatures: GeoJSON.Feature<GeoJSON.Point, { color: string }>[] = [];
+
+  map.addSource("altitude-drop-points", {
+    type: "geojson",
+    data: { type: "FeatureCollection", features: dropFeatures },
+  });
+  map.addLayer({
+    id: "altitude-drop-points",
+    type: "circle",
+    source: "altitude-drop-points",
+    paint: {
+      "circle-radius": 5,
+      "circle-color": ["get", "color"],
+      "circle-stroke-width": 1.5,
+      "circle-stroke-color": "#ffffff",
+    },
+  });
+
+  function addDropPoint(lngLat: [number, number], color: string) {
+    dropFeatures.push({ type: "Feature", geometry: { type: "Point", coordinates: lngLat }, properties: { color } });
+    map.getSource<GeoJSONSource>("altitude-drop-points")?.setData({ type: "FeatureCollection", features: dropFeatures });
+  }
+
+  let altitudeReference: "ground" | "sea" = "ground";
+
+  const markers = drones.map((drone) => {
+    const marker = new Marker({ shape: "bulb", outerColor: drone.color, draggable: true }).setLngLat(drone.lngLat).setGroundLine(true, { className: drone.groundLineClass });
+    map.addMarker(marker);
+    marker.setAltitude(Number(el<HTMLInputElement>(drone.id).value), { relativeTo: altitudeReference });
+    marker.on("dragend", () => {
+      const lngLat = marker.getLngLat();
+      addDropPoint([lngLat.lng, lngLat.lat], drone.color);
+    });
+    return marker;
+  });
+
+  drones.forEach((drone, i) => {
+    const slider = el<HTMLInputElement>(drone.id);
+    const valueLabel = el(`${drone.id}-val`);
+    slider.addEventListener("input", () => {
+      const meters = Number(slider.value);
+      valueLabel.textContent = `${String(meters)}m`;
+      markers[i].setAltitude(meters, { relativeTo: altitudeReference });
+    });
+  });
+
+  document.querySelectorAll<HTMLInputElement>('input[name="altref"]').forEach((radio) => {
+    radio.addEventListener("change", () => {
+      if (!radio.checked) return;
+      altitudeReference = radio.value as "ground" | "sea";
+      markers.forEach((marker) => marker.setAltitude(marker.getAltitude(), { relativeTo: altitudeReference }));
+    });
+  });
+
+  const pitchSlider = el<HTMLInputElement>("pitch");
+  const pitchValue = el("pitch-val");
+  pitchSlider.addEventListener("input", () => {
+    const pitch = Number(pitchSlider.value);
+    pitchValue.textContent = `${String(pitch)}°`;
+    map.setPitch(pitch);
+  });
+
+  el<HTMLInputElement>("groundlines").addEventListener("change", (e) => {
+    const checked = (e.target as HTMLInputElement).checked;
+    markers.forEach((marker, i) => marker.setGroundLine(checked, { className: drones[i].groundLineClass }));
+  });
+}
+
+void main();

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -1,5 +1,6 @@
 import maplibregl from "maplibre-gl";
 import type { LngLatLike, MarkerOptions, PointLike } from "maplibre-gl";
+import type { mat4 } from "gl-matrix";
 import type { Map as SDKMap } from "../Map";
 import type {
   MapTilerMarkerElementProps,
@@ -25,12 +26,16 @@ import type {
   EnterAnimationPreset,
   ExitAnimationPreset,
   IdleAnimationPreset,
+  GroundLineOptions,
+  AltitudeReference,
+  SetAltitudeOptions,
 } from "./types";
 import { omit } from "../utils/object";
 import { v4 as uuid } from "uuid";
 import {
   applyCollisionCulled,
   applyCollisionHidden,
+  applyAltitudeHidden,
   applyLifecycleLift,
   applyMarkerStyleVariables,
   applyMinimizedDot,
@@ -39,12 +44,14 @@ import {
   resolveMarkerWrapper,
   releaseCollisionFadeClass,
   COLLISION_FADE_DURATION_MS,
+  GROUND_LINE_CLASSNAME,
 } from "./marker-dom-utils";
 import { DEFAULT_SHAPE, DEFAULT_SIZE, SHAPES, SIZE_PX, getShapeAnchorOffset } from "./marker-svg-config";
 import { getAdaptiveBgColor, resolveAdaptiveColor } from "./marker-adaptive-colors";
 import { MarkerManager } from "./MarkerManager";
 import type { MarkerFootprint } from "./collision-helpers";
 import { flattenUIStates } from "./marker-state-helpers";
+import { computeAltitudeProjection } from "./altitude-math";
 import {
   runPropertyTransition,
   scaleTransitionCodec,
@@ -77,6 +84,7 @@ import {
   CollisionFootprintSymbol,
   EmitCollisionDiffSymbol,
   ApplyCollisionDisplayStateSymbol,
+  ApplyAltitudeFrameSymbol,
   MeasuredElementSizeSymbol,
   ClearFocusStateSymbol,
 } from "./marker-symbols";
@@ -84,6 +92,11 @@ import {
 const maplibreMarkerConstructorOverrides: MarkerOptions = {
   scale: 1, // scale in our class will be a 2D vector.
 };
+
+/** `PointLike` is a `Point` (from point-geometry) or a plain `[number, number]` — normalizes either to a tuple. */
+function pointLikeToXY(point: PointLike): [number, number] {
+  return Array.isArray(point) ? [point[0], point[1]] : [point.x, point.y];
+}
 
 // custom elements minimize to a dot — only these props are consumable as
 // CSS custom properties by the dot (or the element's own styles)
@@ -234,6 +247,61 @@ export class Marker extends maplibregl.Marker {
    */
   private suppressLifecycleAnimations = false;
 
+  /**
+   * Altitude in meters above the ground plane, faked via a per-frame pixel
+   * offset (MapLibre's Marker has no native Z). 0 is the default and a
+   * genuine no-op — see {@link setAltitude}.
+   */
+  private altitudeMeters = 0;
+
+  /** What {@link altitudeMeters} is measured from — see {@link AltitudeReference}. */
+  private altitudeReference: AltitudeReference = "ground";
+
+  /** True once {@link setAltitude} has been called at least once — distinguishes "never touched altitude" from "explicitly set to ground-relative 0m", which still needs tracking. See {@link needsAltitudeTracking}. */
+  private altitudeEngaged = false;
+
+  /**
+   * The offset MapLibre would show with no altitude applied — the shape
+   * anchor offset, an explicit `setOffset()` call, or the minimized-shape
+   * offset. The single source of truth {@link writeOffset} composes the
+   * altitude delta on top of; every internal call site that decides "what
+   * the offset should be" for a reason other than altitude must go through
+   * `writeOffset`, not `super.setOffset` directly, or altitude gets silently
+   * clobbered the next time that call site runs (e.g. a shape/size change).
+   */
+  private baseOffset: PointLike = [0, 0];
+
+  /**
+   * Pixel delta from `groundBase` (the point MapLibre's own `_pos` already
+   * sits at natively — terrain-elevated whenever the map has terrain,
+   * regardless of this marker's `relativeTo`) to `elevated`. This is what
+   * gets added to {@link baseOffset} and written to MapLibre, AND what the
+   * ground line's geometry comes from — both measured from the same
+   * baseline, since `groundBase` doubles as "the real ground" too. See
+   * `computeAltitudeProjection`'s doc comment. Null when off-screen/behind
+   * the camera.
+   */
+  private altitudeDelta: { x: number; y: number } | null = null;
+
+  /**
+   * The `elevated` point in absolute canvas CSS pixels — where the ground
+   * line's element gets positioned. The line lives in a shared container at
+   * the map level (see {@link MarkerManager.getGroundLineContainer}), not
+   * nested inside this marker's own (z-indexed, for camera-depth ordering)
+   * element, so a long line can't paint on top of some *other* marker's icon
+   * just because it happens to cross over it on screen. That independence
+   * means it needs its own absolute position every frame — it doesn't ride
+   * along with the marker's CSS transform for free the way a nested child would.
+   */
+  private groundLineOrigin: { x: number; y: number } | null = null;
+
+  /** Whether this marker is currently hidden because its altitude projection is off-screen/behind the camera. Independent of collision hide/minimize — see the CSS comment on `.maptiler-marker-altitude-hidden`. */
+  private altitudeHidden = false;
+
+  private groundLineEnabled = false;
+  private groundLineOptions: GroundLineOptions = {};
+  private groundLineEl: HTMLDivElement | null = null;
+
   //#endregion
 
   //#region Constructor
@@ -272,6 +340,7 @@ export class Marker extends maplibregl.Marker {
     });
 
     this[MarkerElementSymbol] = element;
+    this.baseOffset = superOptions.offset ?? [0, 0];
 
     // custom elements skip createMarkerElement, so seed their style variables here
     if (options.element) applyMarkerStyleVariables(options.element, options);
@@ -638,7 +707,9 @@ export class Marker extends maplibregl.Marker {
       if (this.minimizedKeys.length > 0) updateMarkerElement(this[MarkerElementSymbol], overrides, styleId);
       if (this.managesOffset) {
         const { shape, size } = this.effectiveShapeAndSize(true);
-        super.setOffset(getShapeAnchorOffset(shape, size));
+        // writeOffset, not super.setOffset directly — this is a "what the
+        // offset should be" call site, altitude must compose on top of it.
+        this.writeOffset(getShapeAnchorOffset(shape, size));
       }
       return;
     }
@@ -648,7 +719,7 @@ export class Marker extends maplibregl.Marker {
     if (this.options.element) applyMinimizedDot(this.options.element, this.options.anchor ?? "center", false);
     if (Object.keys(restore).length > 0) updateMarkerElement(this[MarkerElementSymbol], restore, styleId);
     if (this.managesOffset) {
-      super.setOffset(getShapeAnchorOffset(this.props.shape ?? DEFAULT_SHAPE, this.props.size ?? DEFAULT_SIZE));
+      this.writeOffset(getShapeAnchorOffset(this.props.shape ?? DEFAULT_SHAPE, this.props.size ?? DEFAULT_SIZE));
     }
   }
 
@@ -692,14 +763,39 @@ export class Marker extends maplibregl.Marker {
    * Sets the marker's screen-space pixel offset.
    *
    * Overridden to re-run collision detection — the offset shifts the
-   * marker's collision box.
+   * marker's collision box — and to compose with any active altitude (see
+   * {@link writeOffset}): this becomes the new {@link baseOffset}, altitude
+   * is layered on top of it, not replaced by it.
    * @param offset - Offset in pixels (+y down).
    */
   override setOffset(offset: PointLike): this {
-    super.setOffset(offset);
+    this.writeOffset(offset);
     const map = MarkerManager.getMap(this);
     if (map) MarkerManager.invalidateCollisions(map);
     return this;
+  }
+
+  /**
+   * The single choke point for "what the offset should be right now, for
+   * reasons other than altitude": records `offset` as {@link baseOffset} and
+   * writes `base + altitudeDelta` to the real MapLibre offset. Every
+   * internal call site that used to call `super.setOffset` directly
+   * ({@link applyMinimizedAppearance}) now calls this instead — otherwise
+   * altitude would be silently overwritten the next time one of them runs
+   * (e.g. minimizing while elevated would drop back to ground level).
+   */
+  private writeOffset(offset: PointLike): void {
+    this.baseOffset = offset;
+    // `altitudeDelta` can be a real (non-zero) vector even at
+    // `altitudeMeters === 0` under `relativeTo: "ground"` — it's undoing
+    // MapLibre's own native terrain elevation in that case, not adding a
+    // user-visible altitude — so this always composes rather than
+    // special-casing `altitudeMeters === 0`; `?? 0` covers "not tracking at
+    // all" (altitudeDelta null) on its own.
+    const [baseX, baseY] = pointLikeToXY(offset);
+    const dx = this.altitudeDelta?.x ?? 0;
+    const dy = this.altitudeDelta?.y ?? 0;
+    super.setOffset([baseX + dx, baseY + dy]);
   }
 
   //#endregion
@@ -1395,6 +1491,219 @@ export class Marker extends maplibregl.Marker {
     if (!this.idleAnimation) return;
     this.idleAnimation.destroy();
     this.idleAnimation = null;
+  }
+
+  //#endregion
+
+  //#region Altitude
+
+  /**
+   * Sets altitude in meters above the ground plane, faked via a per-frame
+   * pixel offset composed with {@link setOffset}/{@link baseOffset} (see
+   * {@link writeOffset}) — MapLibre's `Marker` has no native Z. Mercator
+   * projection only, see `altitude-math.ts`.
+   *
+   * `options.relativeTo` (default `"ground"`) picks what the meters are
+   * measured from — see {@link AltitudeReference}. Passing it alone without
+   * changing `meters` still takes effect (e.g. flipping an already-elevated
+   * marker from ground- to sea-relative).
+   *
+   * Never having called this at all is a genuine no-op: never registers with
+   * {@link MarkerManager}'s shared per-map render loop, never writes an
+   * offset, costs nothing. Once engaged, `meters: 0` is a true no-op again
+   * ONLY under `relativeTo: "sea"` — 0m above sea level really is nothing to
+   * track. Under `relativeTo: "ground"` (the default), 0m still means "sit
+   * exactly on the terrain surface", which is a moving target as the camera
+   * or terrain changes, so it keeps tracking — see
+   * {@link needsAltitudeTracking}. (MapTiler's 3D module — `Item3D`/
+   * `Layer3D` in maptiler-3d-js — does the same: it re-queries
+   * `queryTerrainElevation` every update for `AltitudeReference.GROUND`
+   * regardless of the altitude value, branching only on reference type.)
+   *
+   * Only takes effect once the marker is on a map via {@link MarkerManager}
+   * (i.e. added through `map.addMarker()`) — same requirement as collision
+   * detection. Calling it before the marker has a map is fine; registration
+   * happens once it's added. If the map is otherwise idle (no camera
+   * movement in flight), this triggers a repaint so the change is visible
+   * immediately rather than on the next unrelated frame.
+   * @param meters - Altitude in meters, measured per `options.relativeTo`.
+   * @param options - See {@link SetAltitudeOptions}.
+   */
+  setAltitude(meters: number, options: SetAltitudeOptions = {}): this {
+    const relativeTo = options.relativeTo ?? this.altitudeReference;
+    if (this.altitudeEngaged && this.altitudeMeters === meters && this.altitudeReference === relativeTo) return this;
+    this.altitudeEngaged = true;
+    this.altitudeMeters = meters;
+    this.altitudeReference = relativeTo;
+
+    const map = MarkerManager.getMap(this);
+
+    if (!this.needsAltitudeTracking()) {
+      // true no-op: 0m above sea level is always exactly baseOffset, nothing to track
+      if (map) MarkerManager.deregisterAltitudeParticipant(this, map);
+      this.altitudeDelta = null;
+      this.groundLineOrigin = null;
+      this.writeOffset(this.baseOffset);
+      this.setAltitudeHidden(false);
+      this.updateGroundLineElement();
+      // camera-depth z-index only applies while altitude-active (see
+      // MarkerManager's onRender) — restore whatever it was before that,
+      // same as the constructor's own initial write.
+      if (typeof this.options.priority === "number") this[MarkerElementSymbol].style.zIndex = String(this.options.priority);
+      else this[MarkerElementSymbol].style.removeProperty("z-index");
+      return this;
+    }
+
+    if (map) {
+      MarkerManager.registerAltitudeParticipant(this, map);
+      map.triggerRepaint();
+    }
+    return this;
+  }
+
+  /** Returns the current altitude in meters, or 0 if never set. */
+  getAltitude(): number {
+    return this.altitudeMeters;
+  }
+
+  /** Returns what {@link getAltitude}'s meters are measured from. Defaults to `"ground"`. */
+  getAltitudeReference(): AltitudeReference {
+    return this.altitudeReference;
+  }
+
+  /** Whether this marker currently needs per-frame altitude tracking — see {@link setAltitude}'s doc comment for why `meters: 0` alone doesn't decide this. Used by {@link MarkerManager} to catch `setAltitude()` calls made before the marker had a map. */
+  hasActiveAltitude(): boolean {
+    return this.needsAltitudeTracking();
+  }
+
+  /**
+   * True whenever there's a per-frame projection to maintain: a non-zero
+   * offset (`altitudeMeters !== 0`), or a ground reference that has to keep
+   * tracking the terrain surface even at exactly 0m above it.
+   */
+  private needsAltitudeTracking(): boolean {
+    return this.altitudeEngaged && (this.altitudeMeters !== 0 || this.altitudeReference === "ground");
+  }
+
+  /**
+   * Toggles a dashed line from the marker down (or up) to its ground point.
+   * Off by default. Styled via CSS — see `.maptiler-marker-groundline` in
+   * the SDK stylesheet and {@link GroundLineOptions.className}.
+   * @param enabled - Whether to show the line.
+   * @param options - Optional extra CSS class for styling.
+   */
+  setGroundLine(enabled: boolean, options: GroundLineOptions = {}): this {
+    this.groundLineEnabled = enabled;
+    this.groundLineOptions = options;
+
+    if (!enabled) {
+      this.groundLineEl?.remove();
+      this.groundLineEl = null;
+      return this;
+    }
+
+    this.updateGroundLineElement();
+    const map = MarkerManager.getMap(this);
+    if (map && this.altitudeMeters !== 0) map.triggerRepaint();
+    return this;
+  }
+
+  /**
+   * Per-frame altitude hook, called by {@link MarkerManager} once per render
+   * frame for every altitude-active marker, with the mercator -> clip-space
+   * matrix it captured from its shared no-op custom layer. Not part of the
+   * public API.
+   *
+   * Returns this frame's camera depth (the elevated point's clip-space W —
+   * see {@link ScreenPoint.depth}), or `null` when off-screen/hidden.
+   * {@link MarkerManager} ranks every altitude-active marker on the map by
+   * this and assigns z-index by rank (nearest on top) — DOM markers have no
+   * real depth buffer, so without it a marker that's actually farther away
+   * can still render in front of a nearer one purely because of DOM order.
+   */
+  [ApplyAltitudeFrameSymbol](matrix: mat4, map: SDKMap): number | null {
+    if (!this.needsAltitudeTracking()) return null; // shouldn't be registered, but state may have raced back to inert mid-frame
+
+    const projected = computeAltitudeProjection(this.getLngLat(), this.altitudeMeters, matrix, map, this.altitudeReference);
+    if (!projected) {
+      this.altitudeDelta = null;
+      this.groundLineOrigin = null;
+      this.setAltitudeHidden(true);
+      this.updateGroundLineElement();
+      return null;
+    }
+
+    this.altitudeDelta = {
+      x: projected.elevated.x - projected.groundBase.x,
+      y: projected.elevated.y - projected.groundBase.y,
+    };
+    this.groundLineOrigin = { x: projected.elevated.x, y: projected.elevated.y };
+    this.setAltitudeHidden(false);
+    this.writeOffset(this.baseOffset);
+    this.updateGroundLineElement();
+    return projected.elevated.depth;
+  }
+
+  private setAltitudeHidden(hidden: boolean): void {
+    if (this.altitudeHidden === hidden) return;
+    this.altitudeHidden = hidden;
+    applyAltitudeHidden(this[MarkerElementSymbol], hidden);
+  }
+
+  /**
+   * Creates/updates/removes the ground-line element. Its geometry
+   * (position/width/rotation) comes straight from {@link altitudeDelta} and
+   * {@link groundLineOrigin} — no second projection. Lives in a shared,
+   * always-behind-markers container at the map level (see
+   * {@link MarkerManager.getGroundLineContainer}) rather than nested inside
+   * this marker's own element — otherwise a long line inherits its marker's
+   * camera-depth z-index and can paint on top of some *other* marker's icon
+   * it happens to cross on screen, which a purely decorative line should
+   * never do. Because it's independent, its absolute position gets written
+   * every frame here, not just its width/rotation.
+   *
+   * The rotation is a pure vector, so a marker that ends up below its ground
+   * point on screen (e.g. looking up from underneath at a steep pitch)
+   * renders correctly with no special-casing.
+   */
+  private updateGroundLineElement(): void {
+    if (!this.groundLineEnabled) return;
+
+    if (!this.altitudeDelta || !this.groundLineOrigin || this.altitudeHidden) {
+      this.groundLineEl?.remove();
+      this.groundLineEl = null;
+      return;
+    }
+
+    const map = MarkerManager.getMap(this);
+    if (!map) {
+      this.groundLineEl?.remove();
+      this.groundLineEl = null;
+      return;
+    }
+
+    if (!this.groundLineEl) {
+      const el = document.createElement("div");
+      el.className = this.groundLineOptions.className ? `${GROUND_LINE_CLASSNAME} ${this.groundLineOptions.className}` : GROUND_LINE_CLASSNAME;
+      el.style.position = "absolute";
+      el.style.pointerEvents = "none";
+      MarkerManager.getGroundLineContainer(map).appendChild(el);
+      this.groundLineEl = el;
+    }
+
+    this.groundLineEl.style.left = `${String(this.groundLineOrigin.x)}px`;
+    this.groundLineEl.style.top = `${String(this.groundLineOrigin.y)}px`;
+
+    const { x: dx, y: dy } = this.altitudeDelta;
+    const length = Math.hypot(dx, dy);
+    if (length === 0) {
+      this.groundLineEl.style.width = "0px";
+      return;
+    }
+
+    const angleRad = Math.atan2(-dy, -dx);
+    this.groundLineEl.style.width = `${String(length)}px`;
+    this.groundLineEl.style.transform = `rotate(${String(angleRad)}rad)`;
   }
 
   //#endregion

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -1,5 +1,6 @@
 import type { Marker } from "./Marker";
 import type { Map as SDKMap } from "../Map";
+import type { mat4 } from "gl-matrix";
 import { CollisionBehaviour } from "./types";
 import type { MarkerCollisionAccuracy, MarkerCollisionGroups, MarkerCollisionKind, MarkerCollisionOptions } from "./types";
 import {
@@ -25,6 +26,7 @@ import {
   CollisionFootprintSymbol,
   EmitCollisionDiffSymbol,
   ApplyCollisionDisplayStateSymbol,
+  ApplyAltitudeFrameSymbol,
   MeasuredElementSizeSymbol,
   MarkerElementSymbol,
   ClearFocusStateSymbol,
@@ -40,6 +42,16 @@ const FOOTPRINT_PROPS = ["shape", "size", "scale", "rotation"] as const;
  * or edge behaviour would churn while panning.
  */
 const VIEWPORT_CULL_MARGIN_PX = 200;
+
+/**
+ * Base z-index for camera-depth ordering among altitude-active markers (see
+ * the altitude render loop's `onRender`). Well above the small integers
+ * `priority` typically produces, so depth-ordered altitude markers land
+ * above statically-ordered ones rather than interleaving with them —
+ * "closer to the camera" is a different axis from "higher priority", and
+ * mixing the two into one ranking isn't attempted here.
+ */
+const ALTITUDE_Z_INDEX_BASE = 1000;
 
 /** Per-map state of the collision detection engine. */
 type MapCollisionState = {
@@ -57,6 +69,27 @@ type MapCollisionState = {
   transitionDuration: number;
   /** CSS easing function for the fade transition. */
   transitionEasing: string;
+};
+
+/** Per-map state of the altitude render loop — one shared no-op layer + `render` listener for every altitude-active marker on that map. */
+type MapAltitudeState = {
+  /** Markers currently faking altitude on this map. Empty ⇒ torn down. */
+  participants: Set<Marker>;
+  /** Id of the no-op custom layer used purely to read the projection matrix out of MapLibre's render pass. */
+  layerId: string;
+  /** The matrix captured by the layer's `render()` this frame; null until the first frame after installation. */
+  currentMatrix: mat4 | null;
+  installed: boolean;
+  renderListener: (() => void) | null;
+  styleLoadListener: (() => void) | null;
+  terrainListener: (() => void) | null;
+  /**
+   * Shared container for every marker's ground-line element on this map —
+   * a sibling of the marker elements (not nested inside any one marker's own
+   * z-indexed element), pinned to a low z-index so lines never paint on top
+   * of a marker's icon. See {@link MarkerManagerImpl.getGroundLineContainer}.
+   */
+  groundLineContainer: HTMLDivElement;
 };
 
 /** One marker's resolved geometry within a detection pass. */
@@ -119,6 +152,10 @@ class MarkerManagerImpl {
 
   // Per-marker drag handlers (`drag` + `dragend`), kept so deregister can detach them.
   private readonly dragEndHandlers = new WeakMap<Marker, () => void>();
+
+  // Per-map altitude render-loop state (see MapAltitudeState).
+  private readonly altitudeState = new WeakMap<SDKMap, MapAltitudeState>();
+  private altitudeLayerSequence = 0;
 
   //#endregion
 
@@ -207,9 +244,13 @@ class MarkerManagerImpl {
     }
 
     // dragging moves the marker with no map event to re-run detection on;
-    // `drag` fires per pointer move and the pass is rAF-coalesced
+    // `drag` fires per pointer move and the pass is rAF-coalesced. Dragging
+    // also doesn't move the camera, so it doesn't imply a map repaint on its
+    // own — an altitude-active marker needs one anyway (its offset/ground
+    // line are computed inside the render loop, not written by drag itself).
     const onDrag = () => {
       this.invalidateCollisions(map);
+      if (marker.hasActiveAltitude()) map.triggerRepaint();
     };
     marker.on("drag", onDrag);
     marker.on("dragend", onDrag);
@@ -220,6 +261,10 @@ class MarkerManagerImpl {
     // adaptive colours could only resolve to `base` before the marker had a
     // map — re-resolve against this map's style
     marker[RefreshAdaptiveColorSymbol]();
+
+    // altitude may have been set before the marker had a map (setAltitude()
+    // no-ops with nowhere to register); pick that up now
+    if (marker.hasActiveAltitude()) this.registerAltitudeParticipant(marker, map);
   }
 
   // unregisters a Marker that no longer needs to be managed. `deferDetach`
@@ -234,6 +279,7 @@ class MarkerManagerImpl {
     this.markerMap.delete(marker);
     this.mapIndex.get(map)?.delete(marker.id);
     this.cancelCuedUpdatesForMarker(marker);
+    this.deregisterAltitudeParticipant(marker, map);
 
     const onDrag = this.dragEndHandlers.get(marker);
     if (onDrag) {
@@ -626,6 +672,212 @@ class MarkerManagerImpl {
       if (entered.length === 0 && exited.length === 0) continue;
       marker[EmitCollisionDiffSymbol]({ kind, entered, exited, current: [...nextSet] });
     }
+  }
+
+  //#endregion
+
+  //#region Altitude
+
+  /**
+   * Starts driving `marker`'s per-frame altitude projection on `map`. Shared
+   * across every altitude-active marker on the map — several markers here
+   * still cost one no-op custom layer and one `render` listener, not one
+   * each. Called by {@link Marker.setAltitude} (and by {@link register} for
+   * a marker whose altitude was set before it had a map).
+   */
+  registerAltitudeParticipant(marker: Marker, map: SDKMap): void {
+    const state = this.getOrCreateAltitudeState(map);
+    state.participants.add(marker);
+    this.ensureAltitudeLayerInstalled(map, state);
+  }
+
+  /** Stops driving `marker`'s altitude projection. Tears down the shared layer/listener once the last participant on `map` leaves. */
+  deregisterAltitudeParticipant(marker: Marker, map: SDKMap): void {
+    const state = this.altitudeState.get(map);
+    if (!state) return;
+    state.participants.delete(marker);
+    if (state.participants.size === 0) this.teardownAltitudeLayer(map, state);
+  }
+
+  /**
+   * The shared, always-behind-markers container every marker's ground-line
+   * element gets appended to on this map — a sibling of the marker elements
+   * (both live in `map.getCanvasContainer()`), not a descendant of any one
+   * marker, so a long line can never inherit a marker's camera-depth
+   * z-index and paint over some *other* marker's icon. Created together
+   * with the rest of the per-map altitude state.
+   */
+  getGroundLineContainer(map: SDKMap): HTMLDivElement {
+    return this.getOrCreateAltitudeState(map).groundLineContainer;
+  }
+
+  // lazily creates the per-map altitude state; final cleanup on map removal
+  // mirrors getOrCreateCollisionState's — release what this added, nothing
+  // heavier, since the map itself is already going away
+  private getOrCreateAltitudeState(map: SDKMap): MapAltitudeState {
+    const existing = this.altitudeState.get(map);
+    if (existing) return existing;
+
+    const groundLineContainer = document.createElement("div");
+    groundLineContainer.style.position = "absolute";
+    groundLineContainer.style.inset = "0";
+    groundLineContainer.style.pointerEvents = "none";
+    // Negative, not just "low" — reliably behind every marker regardless of
+    // `priority` (small non-negative ints) or the camera-depth ranking
+    // markers get while altitude-active (ALTITUDE_Z_INDEX_BASE and up).
+    groundLineContainer.style.zIndex = "-1";
+    map.getCanvasContainer().appendChild(groundLineContainer);
+
+    const state: MapAltitudeState = {
+      participants: new Set(),
+      layerId: `__maptiler-altitude-capture-${String(this.altitudeLayerSequence++)}__`,
+      currentMatrix: null,
+      installed: false,
+      renderListener: null,
+      styleLoadListener: null,
+      terrainListener: null,
+      groundLineContainer,
+    };
+    this.altitudeState.set(map, state);
+
+    void map.once("remove", () => {
+      if (state.renderListener) map.off("render", state.renderListener);
+      if (state.styleLoadListener) map.off("style.load", state.styleLoadListener);
+      if (state.terrainListener) {
+        map.off("terrain", state.terrainListener);
+        map.off("terrainAnimationStop", state.terrainListener);
+        map.off("loadWithTerrain", state.terrainListener);
+      }
+      this.altitudeState.delete(map);
+    });
+
+    return state;
+  }
+
+  // MapLibre throws if you `addLayer` before the style has finished loading
+  // — defer installation until then. Safe to call redundantly; only the
+  // first call (with participants still non-empty) actually installs.
+  //
+  // Waits on "idle", not "load": "load" fires exactly once per map, ever.
+  // Markers are almost always registered well *after* the map's initial
+  // load (typically from application code that itself awaits load first),
+  // so by the time this runs "load" has usually already fired and been
+  // consumed — if `isStyleLoaded()` happens to be false at that exact
+  // moment (e.g. right after applying a style with extra sources/sprites
+  // still settling, like a terrain source), `once("load", ...)` would wait
+  // forever for an event that's never coming again. "idle" fires every time
+  // the map has no pending work, so it's safe to wait on regardless of
+  // where in the map's lifecycle this gets called.
+  private ensureAltitudeLayerInstalled(map: SDKMap, state: MapAltitudeState): void {
+    if (state.installed) return;
+    if (map.isStyleLoaded()) {
+      this.installAltitudeLayer(map, state);
+      return;
+    }
+    void map.once("idle", () => {
+      this.ensureAltitudeLayerInstalled(map, state);
+    });
+  }
+
+  private installAltitudeLayer(map: SDKMap, state: MapAltitudeState): void {
+    // a pending once('load', ...) can still fire after the last participant
+    // left (and teardown already ran) — don't resurrect the layer for nobody
+    if (state.installed || state.participants.size === 0) return;
+    if (map.getLayer(state.layerId)) return;
+
+    map.addLayer({
+      id: state.layerId,
+      type: "custom",
+      // "2d" is enough — this layer never draws anything, it only reads the
+      // projection args MapLibre hands to every custom layer.
+      renderingMode: "2d",
+      render: (_gl, args) => {
+        // MapLibre v5+: render(gl, args: CustomRenderMethodInput).
+        // MapLibre v4 called this render(gl, matrix: mat4) — `args` was the
+        // matrix itself and `defaultProjectionData` didn't exist.
+        state.currentMatrix = args.defaultProjectionData.mainMatrix;
+      },
+    });
+
+    const onRender = () => {
+      if (!state.currentMatrix) return;
+
+      // Each marker projects itself and reports back its camera depth (or
+      // null if off-screen/hidden this frame) — collected here rather than
+      // acted on inline so every participant's depth is known before any
+      // z-index gets written.
+      const depths: { marker: Marker; depth: number }[] = [];
+      for (const marker of state.participants) {
+        const depth = marker[ApplyAltitudeFrameSymbol](state.currentMatrix, map);
+        if (depth !== null) depths.push({ marker, depth });
+      }
+
+      // DOM markers have no real depth buffer — without this, a marker
+      // that's actually farther from the camera can still render on top of
+      // a nearer one purely because of DOM insertion order. Sort far-to-near
+      // and assign z-index by rank so nearer always wins, only among this
+      // map's altitude-active markers (a marker with no altitude keeps
+      // whatever static `priority`-based z-index it already had).
+      depths.sort((a, b) => b.depth - a.depth);
+      depths.forEach(({ marker }, index) => {
+        marker[MarkerElementSymbol].style.zIndex = String(ALTITUDE_Z_INDEX_BASE + index);
+      });
+    };
+    // `setStyle()` tears down every layer, including this one — reinstall
+    // once the new style finishes loading so altitude keeps working across
+    // style switches.
+    const onStyleLoad = () => {
+      state.installed = false;
+      state.currentMatrix = null;
+      this.ensureAltitudeLayerInstalled(map, state);
+    };
+
+    // Terrain readiness fires across a few different events, and markers
+    // need a fresh `queryTerrainElevation()` (i.e. a repaint) right when any
+    // of them land, not just "probably soon after" via some other repaint:
+    //  - "terrain": MapLibre's own event, fires as soon as `map.terrain` is
+    //    set/unset — early, DEM tiles for a given marker may not be loaded yet.
+    //  - "terrainAnimationStop": the SDK's grow/flatten animation (see
+    //    `Map.growTerrain`) reaching its target exaggeration — the actual
+    //    "terrain is ready and settled" moment for markers already on screen.
+    //  - "loadWithTerrain": the SDK's own "map ready with terrain non-null"
+    //    event, for the initial-load case (`terrain: true` in the constructor).
+    // growTerrain's own rAF loop already calls triggerRepaint() every tick,
+    // so onRender above tends to self-heal mid-animation anyway — but that's
+    // the same kind of implicit assumption that bit us for
+    // setAltitude()-while-idle and drag earlier, so it's not relied on here.
+    const onTerrainChange = () => {
+      map.triggerRepaint();
+    };
+
+    map.on("render", onRender);
+    map.on("style.load", onStyleLoad);
+    map.on("terrain", onTerrainChange);
+    map.on("terrainAnimationStop", onTerrainChange);
+    map.on("loadWithTerrain", onTerrainChange);
+    state.renderListener = onRender;
+    state.styleLoadListener = onStyleLoad;
+    state.terrainListener = onTerrainChange;
+    state.installed = true;
+  }
+
+  // the map is still alive here (unlike the 'remove' cleanup above) — actually remove the layer, not just the listeners
+  private teardownAltitudeLayer(map: SDKMap, state: MapAltitudeState): void {
+    if (state.renderListener) map.off("render", state.renderListener);
+    if (state.styleLoadListener) map.off("style.load", state.styleLoadListener);
+    if (state.terrainListener) {
+      map.off("terrain", state.terrainListener);
+      map.off("terrainAnimationStop", state.terrainListener);
+      map.off("loadWithTerrain", state.terrainListener);
+    }
+    if (map.getLayer(state.layerId)) map.removeLayer(state.layerId);
+    state.groundLineContainer.remove();
+    state.installed = false;
+    state.currentMatrix = null;
+    state.renderListener = null;
+    state.styleLoadListener = null;
+    state.terrainListener = null;
+    this.altitudeState.delete(map);
   }
 
   //#endregion

--- a/src/Marker/altitude-math.ts
+++ b/src/Marker/altitude-math.ts
@@ -1,0 +1,106 @@
+import maplibregl from "maplibre-gl";
+import type { mat4 } from "gl-matrix";
+import type { AltitudeReference } from "./types";
+
+/** A screen-space position in CSS pixels, DOM convention (+y down). */
+export interface ScreenPoint {
+  x: number;
+  y: number;
+  /**
+   * Clip-space W for this point — proportional to distance from the camera
+   * along the view direction. Larger = farther away. Only meaningful for
+   * *ordering* points against each other from the same frame/matrix, not as
+   * a physical distance (it's not in meters, and its scale depends on the
+   * projection matrix).
+   */
+  depth: number;
+}
+
+/**
+ * `matrix` is column-major, OpenGL convention: element `matrix[col * 4 + row]`.
+ * clip = matrix * [x, y, z, 1] — only the x, y and w rows are needed since
+ * we're projecting a single point, not building a full transform.
+ *
+ * Mercator only: under globe projection this same matrix instead projects a
+ * unit-sphere planet, not flat mercator tile space, and `MercatorCoordinate`
+ * stops meaning the same thing to it — this function would silently return
+ * plausible-looking but wrong screen positions. Guard on
+ * `map.getProjection?.().type !== 'mercator'` before relying on any of this
+ * if the app supports globe.
+ */
+export function projectLngLatAltitude(lngLat: maplibregl.LngLat, altitudeMeters: number, matrix: mat4, map: maplibregl.Map): ScreenPoint | null {
+  const mercator = maplibregl.MercatorCoordinate.fromLngLat(lngLat, altitudeMeters);
+
+  const clipX = matrix[0] * mercator.x + matrix[4] * mercator.y + matrix[8] * mercator.z + matrix[12];
+  const clipY = matrix[1] * mercator.x + matrix[5] * mercator.y + matrix[9] * mercator.z + matrix[13];
+  const clipW = matrix[3] * mercator.x + matrix[7] * mercator.y + matrix[11] * mercator.z + matrix[15];
+
+  // Point projects behind the camera — there is no sane screen position for it.
+  if (clipW <= 0) return null;
+
+  // Perspective divide: clip space -> normalized device coordinates (-1..1 on both axes).
+  const ndcX = clipX / clipW;
+  const ndcY = clipY / clipW;
+
+  // clientWidth/clientHeight are CSS pixels; the canvas's own width/height
+  // attributes are the (possibly devicePixelRatio-scaled) backing store —
+  // using those instead would place everything wrong by the DPR factor on retina.
+  const cssWidth = map.getCanvas().clientWidth;
+  const cssHeight = map.getCanvas().clientHeight;
+
+  return {
+    x: (ndcX * 0.5 + 0.5) * cssWidth,
+    // NDC's Y axis points up (+1 = top); the DOM's points down (+y = down) — flipped here.
+    y: (1 - (ndcY * 0.5 + 0.5)) * cssHeight,
+    depth: clipW,
+  };
+}
+
+/**
+ * Two points, through the same matrix/frame:
+ *
+ * - `groundBase` — mercator Z = `nativeElevation`, the terrain height at
+ *   `lngLat` whenever the *map* has terrain enabled, 0 otherwise. This is
+ *   NOT gated on `relativeTo` — it's what MapLibre's own `Marker` positions
+ *   itself at natively (`this._pos = this._map.project(this._lngLat)`,
+ *   and `Map.prototype.project` internally calls
+ *   `this.transform.locationToScreenPoint(lngLat, this.style && this.terrain)`
+ *   — it passes the map's terrain through unconditionally). MapLibre has no
+ *   concept of a per-marker altitude reference: whenever the map has
+ *   terrain, EVERY marker's native position already sits on it, regardless
+ *   of what this specific marker's `relativeTo` is set to. Every pixel
+ *   offset this SDK writes gets added on top of that already-elevated
+ *   native `_pos`, so our own offset has to be measured from this same
+ *   baseline, or the two double up (`relativeTo: "ground"`) or fight
+ *   (`relativeTo: "sea"`, where MapLibre still elevates the base natively
+ *   even though the *target* shouldn't be terrain-relative at all).
+ * - `elevated` — mercator Z = `nativeElevation + altitudeMeters` under
+ *   `relativeTo: "ground"` (both terms are the *same* terrain query, so this
+ *   just means "however high MapLibre already put it, plus the user's
+ *   meters"), or plain `altitudeMeters` under `relativeTo: "sea"` (absolute,
+ *   deliberately ignoring `nativeElevation` — this is what makes the
+ *   resulting delta *subtract* the terrain height back out, undoing
+ *   MapLibre's native elevation to land at a true sea-level position).
+ *
+ * The ground-line's visual "ground" endpoint is the same `groundBase` point
+ * — there's only one ground (the real terrain surface, or sea level when
+ * there's no terrain), and it's also exactly what the offset is measured
+ * from, so no second projection or separate point is needed for it.
+ *
+ * `queryTerrainElevation` returns `null` when terrain isn't enabled/loaded,
+ * treated as 0.
+ */
+export function computeAltitudeProjection(
+  lngLat: maplibregl.LngLat,
+  altitudeMeters: number,
+  matrix: mat4,
+  map: maplibregl.Map,
+  relativeTo: AltitudeReference,
+): { groundBase: ScreenPoint; elevated: ScreenPoint } | null {
+  const nativeElevation = map.getTerrain() ? (map.queryTerrainElevation(lngLat) ?? 0) : 0;
+  const groundBase = projectLngLatAltitude(lngLat, nativeElevation, matrix, map);
+  const targetElevation = relativeTo === "ground" ? nativeElevation + altitudeMeters : altitudeMeters;
+  const elevated = projectLngLatAltitude(lngLat, targetElevation, matrix, map);
+  if (!groundBase || !elevated) return null;
+  return { groundBase, elevated };
+}

--- a/src/Marker/marker-dom-utils.ts
+++ b/src/Marker/marker-dom-utils.ts
@@ -575,6 +575,25 @@ export function applyCollisionCulled(element: HTMLElement, culled: boolean): boo
 
 //#endregion
 
+//#region applyAltitudeHidden
+
+const ALTITUDE_HIDDEN_CLASSNAME = "maptiler-marker-altitude-hidden";
+export const GROUND_LINE_CLASSNAME = "maptiler-marker-groundline";
+
+/**
+ * Toggles whether a marker is hidden because its altitude-projected
+ * position is off-screen/behind the camera. Independent of
+ * {@link applyCollisionHidden} — see the CSS comment in the SDK stylesheet
+ * for why the two never fight over the same element.
+ * @param element - The marker's outer root element (or the custom element).
+ * @param hidden - Whether the marker's altitude projection is currently unusable.
+ */
+export function applyAltitudeHidden(element: HTMLElement, hidden: boolean): void {
+  element.classList.toggle(ALTITUDE_HIDDEN_CLASSNAME, hidden);
+}
+
+//#endregion
+
 //#region applyMinimizedDot
 
 const MINIMIZED_DOT_CLASSNAME = "marker-minimized-dot";

--- a/src/Marker/marker-symbols.ts
+++ b/src/Marker/marker-symbols.ts
@@ -8,3 +8,4 @@ export const EmitCollisionDiffSymbol = Symbol("MapTiler:Marker:emitCollisionDiff
 export const ApplyCollisionDisplayStateSymbol = Symbol("MapTiler:Marker:applyCollisionDisplayState");
 export const MeasuredElementSizeSymbol = Symbol("MapTiler:Marker:measuredElementSize");
 export const ClearFocusStateSymbol = Symbol("MapTiler:Marker:clearFocusState");
+export const ApplyAltitudeFrameSymbol = Symbol("MapTiler:Marker:applyAltitudeFrame");

--- a/src/Marker/types.ts
+++ b/src/Marker/types.ts
@@ -132,6 +132,39 @@ export type MarkerPriorityExpression = unknown[];
 
 //#endregion
 
+//#region Altitude
+
+/**
+ * What {@link Marker.setAltitude}'s meters are measured from.
+ * - `ground` (default) — above the terrain surface under the marker's
+ *   lngLat, via `map.queryTerrainElevation()`. Falls back to the flat
+ *   mercator plane (sea level) when terrain isn't enabled/loaded — so this
+ *   is a safe default whether or not the map has terrain.
+ * - `sea` — above sea level / the flat mercator plane outright, ignoring
+ *   terrain entirely, even when it's enabled.
+ */
+export type AltitudeReference = "ground" | "sea";
+
+/** Options for {@link Marker.setAltitude}. */
+export type SetAltitudeOptions = {
+  /** What the altitude is measured from. Defaults to `"ground"`. */
+  relativeTo?: AltitudeReference;
+};
+
+/** Configures the optional dashed line from a marker down (or up) to its ground point. Off by default — see {@link Marker.setGroundLine}. */
+export type GroundLineOptions = {
+  /**
+   * Extra class applied to the ground-line element alongside the default
+   * `maptiler-marker-groundline`. Style colour/width/dashing from your own
+   * stylesheet using either selector — the line carries no inline colour so
+   * your CSS always wins (see the `:where()`-scoped default in the SDK
+   * stylesheet, kept at zero specificity for exactly this reason).
+   */
+  className?: string;
+};
+
+//#endregion
+
 //#region Lifecycle Animations
 
 /**

--- a/src/style/style_template.css
+++ b/src/style/style_template.css
@@ -215,6 +215,35 @@
   transform: scale(0) !important;
 }
 
+/* Marker altitude (setAltitude/setGroundLine). Hidden when the altitude
+   projection is off-screen/behind the camera — independent of, and
+   composes with, the collision engine's own hide above (both are plain
+   "force hidden, else say nothing" rules on the same element, so either one
+   hiding it is enough; opacity on this element also visually hides the
+   ground-line child below, no extra wiring needed for that). */
+.maptiler-marker-altitude-hidden {
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+/* Dashed line from a marker down (or up) to its ground point. Geometry
+   (left/top/width/rotation — left/top set once, from the marker's own
+   `anchor`, so the line pivots on the real anchor point rather than the
+   marker box's corner; width/rotation every frame) is written inline by the
+   marker; only the visual appearance belongs here. `:where()` keeps this at
+   zero specificity so a single-class override of your own always wins,
+   loaded before or after this stylesheet. */
+.maptiler-marker-groundline {
+  position: absolute;
+  height: 0;
+  transform-origin: 0 0;
+  pointer-events: none;
+}
+
+:where(.maptiler-marker-groundline) {
+  border-top: 1.5px dashed rgba(20, 20, 20, 0.55);
+}
+
 .webgl-warning-div {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Objective
Let markers show a fake 3D altitude above or below the map surface — MapLibre's `Marker` has no native Z, so there's no way to place one at a height today.

## Description
- Add `setAltitude`/`getAltitude` — fakes height via a per-frame pixel offset composed with the marker's existing offset
- Add ground/sea altitude reference modes, terrain-aware via `queryTerrainElevation`
- Add ground line (`setGroundLine`) — CSS-styleable dashed line from marker down to its ground point
- Add camera-depth z-index ordering so altitude-active markers stack correctly by distance from camera
- Add marker altitude demo with terrain + draggable markers

## Acceptance
- Manually tested
- Unit tests in forthcoming PR

## Checklist
N/A changelog will be updated upon final PR ~~I have added relevant info to the CHANGELOG.md~~

Part 1 of 4 in this stack.