### PR TITLE
RD-1414 Fix marker altitude under globe projection, add below-ground fade

### DIFF
--- a/demos/public/20-marker-altitude.html
+++ b/demos/public/20-marker-altitude.html
@@ -109,37 +109,10 @@
       </div>
     </div>
 
-    <div class="ctrl-group">
-      <div class="ctrl-label">Altitude reference</div>
-      <div class="scale-row" style="gap: 14px;">
-        <label class="debug-row"><input type="radio" name="altref" value="ground" checked /><span>Ground (terrain)</span></label>
-        <label class="debug-row"><input type="radio" name="altref" value="sea" /><span>Sea level</span></label>
-      </div>
-    </div>
-
-    <div class="ctrl-group">
-      <div class="ctrl-label">Drone 1 altitude</div>
-      <div class="scale-row">
-        <input id="alt1" type="range" min="0" max="1500" step="10" value="400" />
-        <span class="scale-val" id="alt1-val">400m</span>
-      </div>
-    </div>
-
-    <div class="ctrl-group">
-      <div class="ctrl-label">Drone 2 altitude</div>
-      <div class="scale-row">
-        <input id="alt2" type="range" min="0" max="1500" step="10" value="900" />
-        <span class="scale-val" id="alt2-val">900m</span>
-      </div>
-    </div>
-
-    <div class="ctrl-group">
-      <div class="ctrl-label">Drone 3 altitude</div>
-      <div class="scale-row">
-        <input id="alt3" type="range" min="0" max="1500" step="10" value="150" />
-        <span class="scale-val" id="alt3-val">150m</span>
-      </div>
-    </div>
+    <!-- One block per drone injected here by 20-marker-altitude.ts (see
+         #drone-controls-template below) — each with its own altitude slider
+         AND its own ground/sea reference toggle, independent per marker. -->
+    <div id="drone-controls"></div>
 
     <div class="ctrl-group">
       <div class="ctrl-label">Ground lines</div>
@@ -149,6 +122,24 @@
       </label>
     </div>
   </div>
+
+  <template id="drone-controls-template">
+    <div class="ctrl-group">
+      <div class="ctrl-label drone-label"></div>
+      <div class="scale-row">
+        <input class="drone-altitude" type="range" min="0" max="20000" step="50" />
+        <span class="scale-val drone-altitude-val"></span>
+      </div>
+      <div class="scale-row" style="gap: 14px;">
+        <label class="debug-row"><input class="drone-altref" type="radio" value="ground" /><span>Ground</span></label>
+        <label class="debug-row"><input class="drone-altref" type="radio" value="sea" /><span>Sea</span></label>
+      </div>
+      <label class="debug-row">
+        <input class="drone-unset" type="checkbox" />
+        <span>Unset altitude (drape to terrain)</span>
+      </label>
+    </div>
+  </template>
 
   <script type="module" src="/src/20-marker-altitude.ts"></script>
 </body>

--- a/demos/src/20-marker-altitude.ts
+++ b/demos/src/20-marker-altitude.ts
@@ -10,25 +10,38 @@ function el<T extends HTMLElement = HTMLElement>(id: string): T {
   return found as T;
 }
 
-// Mercator only — see altitude-math.ts's projectLngLatAltitude doc comment.
-// Don't switch this demo to `projection: "globe"`.
+/** Throws instead of returning null — for required lookups inside a cloned `<template>`, where a miss means the template markup itself is wrong. */
+function must<T>(value: T | null): T {
+  if (!value) throw new Error("expected element not found in #drone-controls-template");
+  return value;
+}
+
+// Altitude/ground-line math works under both mercator and globe (see
+// altitude-math.ts's projectLngLatAltitude doc comment) — the sanctioned
+// MaptilerProjectionControl (top-right) switches freely between the two.
+// Terrain still gets disabled on globe (see the "projectiontransition"
+// handler below), but that's an unrelated MapLibre globe+terrain+drag bug,
+// not an altitude-math limitation.
 //
 // Glencoe, Scotland — steep glen walls either side, good for checking
 // altitude/ground-line behaviour against real terrain relief.
 const zoom = 13;
 const center: [number, number] = [-4.988, 56.678];
+const terrainExaggeration = 1.3;
 
 interface Drone {
   id: string;
+  label: string;
   lngLat: [number, number];
   color: string;
   groundLineClass: string;
+  defaultAltitude: number;
 }
 
 const drones: Drone[] = [
-  { id: "alt1", lngLat: [-4.988, 56.678], color: "#e63946", groundLineClass: "groundline-red" },
-  { id: "alt2", lngLat: [-4.978, 56.682], color: "#457b9d", groundLineClass: "groundline-blue" },
-  { id: "alt3", lngLat: [-4.998, 56.674], color: "#2a9d8f", groundLineClass: "groundline-green" },
+  { id: "alt1", label: "Drone 1 altitude", lngLat: [-4.988, 56.678], color: "#e63946", groundLineClass: "groundline-red", defaultAltitude: 400 },
+  { id: "alt2", label: "Drone 2 altitude", lngLat: [-4.978, 56.682], color: "#457b9d", groundLineClass: "groundline-blue", defaultAltitude: 900 },
+  { id: "alt3", label: "Drone 3 altitude", lngLat: [-4.998, 56.674], color: "#2a9d8f", groundLineClass: "groundline-green", defaultAltitude: 150 },
 ];
 
 async function main() {
@@ -38,9 +51,12 @@ async function main() {
     zoom,
     center,
     pitch: 55,
+    maxPitch: 90,
     bearing: -20,
     terrain: true,
-    terrainExaggeration: 1.3,
+    terrainExaggeration,
+    terrainControl: true,
+    projectionControl: true,
   });
 
   await map.onLoadAsync();
@@ -71,35 +87,88 @@ async function main() {
     map.getSource<GeoJSONSource>("altitude-drop-points")?.setData({ type: "FeatureCollection", features: dropFeatures });
   }
 
-  let altitudeReference: "ground" | "sea" = "ground";
+  // Each drone gets its own control block (slider + ground/sea radios),
+  // cloned from the <template> in the HTML (#drone-controls-template) —
+  // the radios get a unique `name` per drone below so each pair only
+  // groups with its own drone, not the other two.
+  const template = el<HTMLTemplateElement>("drone-controls-template");
+  const controlsContainer = el("drone-controls");
 
   const markers = drones.map((drone) => {
+    const fragment = template.content.cloneNode(true) as DocumentFragment;
+    const label = must(fragment.querySelector<HTMLElement>(".drone-label"));
+    const slider = must(fragment.querySelector<HTMLInputElement>(".drone-altitude"));
+    const valueLabel = must(fragment.querySelector<HTMLElement>(".drone-altitude-val"));
+    const altrefRadios = Array.from(fragment.querySelectorAll<HTMLInputElement>(".drone-altref"));
+    const unsetCheckbox = must(fragment.querySelector<HTMLInputElement>(".drone-unset"));
+
+    label.textContent = drone.label;
+    slider.value = String(drone.defaultAltitude);
+    valueLabel.textContent = `${String(drone.defaultAltitude)}m`;
+    altrefRadios.forEach((radio) => {
+      radio.name = `altref-${drone.id}`; // unique per drone, or every drone's radios would fight over one shared selection
+      radio.checked = radio.value === "ground";
+    });
+
+    // appendChild moves the fragment's nodes into the document — the
+    // references above stay valid, they just now point at attached elements.
+    controlsContainer.appendChild(fragment);
+
     const marker = new Marker({ shape: "bulb", outerColor: drone.color, draggable: true }).setLngLat(drone.lngLat).setGroundLine(true, { className: drone.groundLineClass });
     map.addMarker(marker);
-    marker.setAltitude(Number(el<HTMLInputElement>(drone.id).value), { relativeTo: altitudeReference });
+    marker.setAltitude(drone.defaultAltitude, { relativeTo: "ground" });
     marker.on("dragend", () => {
       const lngLat = marker.getLngLat();
       addDropPoint([lngLat.lng, lngLat.lat], drone.color);
     });
-    return marker;
-  });
 
-  drones.forEach((drone, i) => {
-    const slider = el<HTMLInputElement>(drone.id);
-    const valueLabel = el(`${drone.id}-val`);
+    function currentAltitudeReference(): "ground" | "sea" {
+      const checked = altrefRadios.find((radio) => radio.checked);
+      return checked?.value === "sea" ? "sea" : "ground";
+    }
+
+    // Slider/radio changes are no-ops while unset — re-engaging altitude is
+    // the checkbox's job (below), not theirs, so these just skip out early
+    // rather than fighting over what the marker's altitude currently means.
     slider.addEventListener("input", () => {
       const meters = Number(slider.value);
       valueLabel.textContent = `${String(meters)}m`;
-      markers[i].setAltitude(meters, { relativeTo: altitudeReference });
+      if (unsetCheckbox.checked) return;
+      marker.setAltitude(meters, { relativeTo: currentAltitudeReference() });
     });
+
+    altrefRadios.forEach((radio) => {
+      radio.addEventListener("change", () => {
+        if (!radio.checked || unsetCheckbox.checked) return;
+        marker.setAltitude(Number(slider.value), { relativeTo: currentAltitudeReference() });
+      });
+    });
+
+    unsetCheckbox.addEventListener("change", () => {
+      slider.disabled = unsetCheckbox.checked;
+      altrefRadios.forEach((radio) => (radio.disabled = unsetCheckbox.checked));
+      if (unsetCheckbox.checked) {
+        // Skips all per-frame altitude tracking — the marker drapes onto
+        // MapLibre's own native (terrain-following, if the map has terrain)
+        // position, same as a marker that never called setAltitude() at all.
+        marker.setAltitude(false);
+      } else {
+        marker.setAltitude(Number(slider.value), { relativeTo: currentAltitudeReference() });
+      }
+    });
+
+    return marker;
   });
 
-  document.querySelectorAll<HTMLInputElement>('input[name="altref"]').forEach((radio) => {
-    radio.addEventListener("change", () => {
-      if (!radio.checked) return;
-      altitudeReference = radio.value as "ground" | "sea";
-      markers.forEach((marker) => marker.setAltitude(marker.getAltitude(), { relativeTo: altitudeReference }));
-    });
+  map.on("projectiontransition", () => {
+    // Globe + terrain + a pitch/rotate drag currently throws inside
+    // MapLibre itself (globe's camera-drag helper calls
+    // getRayDirectionFromPixel, which mercator_transform.ts only stubs as
+    // "Not implemented" — a MapLibre bug, nothing to do with this SDK's
+    // altitude code, but it kills map interaction entirely). Side-step it
+    // by disabling terrain while on globe, restoring it back on mercator.
+    if (map.isGlobeProjection()) map.disableTerrain();
+    else map.enableTerrain(terrainExaggeration);
   });
 
   const pitchSlider = el<HTMLInputElement>("pitch");

--- a/src/Marker/Marker.ts
+++ b/src/Marker/Marker.ts
@@ -36,6 +36,7 @@ import {
   applyCollisionCulled,
   applyCollisionHidden,
   applyAltitudeHidden,
+  applyAltitudeOccluded,
   applyLifecycleLift,
   applyMarkerStyleVariables,
   applyMinimizedDot,
@@ -257,7 +258,7 @@ export class Marker extends maplibregl.Marker {
   /** What {@link altitudeMeters} is measured from — see {@link AltitudeReference}. */
   private altitudeReference: AltitudeReference = "ground";
 
-  /** True once {@link setAltitude} has been called at least once — distinguishes "never touched altitude" from "explicitly set to ground-relative 0m", which still needs tracking. See {@link needsAltitudeTracking}. */
+  /** True once {@link setAltitude} has been called at least once — from then on, tracking stays on for the marker's lifetime regardless of value; see {@link hasActiveAltitude}. */
   private altitudeEngaged = false;
 
   /**
@@ -295,8 +296,11 @@ export class Marker extends maplibregl.Marker {
    */
   private groundLineOrigin: { x: number; y: number } | null = null;
 
-  /** Whether this marker is currently hidden because its altitude projection is off-screen/behind the camera. Independent of collision hide/minimize — see the CSS comment on `.maptiler-marker-altitude-hidden`. */
+  /** Whether this marker is currently hidden because its altitude projection is off-screen/behind the camera — no valid position exists at all. Independent of collision hide/minimize — see the CSS comment on `.maptiler-marker-altitude-hidden`. NOT the below-ground case, see {@link altitudeOccluded}. */
   private altitudeHidden = false;
+
+  /** Whether this marker is currently faded because it's below ground (see {@link computeAltitudeProjection}'s `belowGround`) — DOM markers aren't depth-tested against the terrain mesh, so this stands in for a hillside occluding it. Unlike {@link altitudeHidden}, the marker still has a real position and renders there. */
+  private altitudeOccluded = false;
 
   private groundLineEnabled = false;
   private groundLineOptions: GroundLineOptions = {};
@@ -1498,10 +1502,11 @@ export class Marker extends maplibregl.Marker {
   //#region Altitude
 
   /**
-   * Sets altitude in meters above the ground plane, faked via a per-frame
-   * pixel offset composed with {@link setOffset}/{@link baseOffset} (see
-   * {@link writeOffset}) — MapLibre's `Marker` has no native Z. Mercator
-   * projection only, see `altitude-math.ts`.
+   * Sets altitude in meters above the ground plane (negative is fine — below
+   * ground/sea level), faked via a per-frame pixel offset composed with
+   * {@link setOffset}/{@link baseOffset} (see {@link writeOffset}) —
+   * MapLibre's `Marker` has no native Z. Works under both mercator and
+   * globe projections, see `altitude-math.ts`.
    *
    * `options.relativeTo` (default `"ground"`) picks what the meters are
    * measured from — see {@link AltitudeReference}. Passing it alone without
@@ -1510,15 +1515,26 @@ export class Marker extends maplibregl.Marker {
    *
    * Never having called this at all is a genuine no-op: never registers with
    * {@link MarkerManager}'s shared per-map render loop, never writes an
-   * offset, costs nothing. Once engaged, `meters: 0` is a true no-op again
-   * ONLY under `relativeTo: "sea"` — 0m above sea level really is nothing to
-   * track. Under `relativeTo: "ground"` (the default), 0m still means "sit
-   * exactly on the terrain surface", which is a moving target as the camera
-   * or terrain changes, so it keeps tracking — see
-   * {@link needsAltitudeTracking}. (MapTiler's 3D module — `Item3D`/
-   * `Layer3D` in maptiler-3d-js — does the same: it re-queries
-   * `queryTerrainElevation` every update for `AltitudeReference.GROUND`
-   * regardless of the altitude value, branching only on reference type.)
+   * offset, costs nothing. Pass `false` to explicitly go back to that inert
+   * state — deregisters, restores the plain {@link baseOffset} and static
+   * `priority`-based z-index, and clamps the marker to wherever MapLibre's
+   * own native (terrain-aware, if the map has terrain) positioning puts it,
+   * skipping the per-frame altitude math entirely from then on. That's the
+   * ONLY zero-cost path once altitude has been touched at all — there is
+   * deliberately no "0 is free" fast path for `meters: 0` on either
+   * reference, not even `relativeTo: "sea"`. MapLibre's own native marker
+   * position (`_pos = map.project(lngLat)`) is ALREADY terrain-elevated
+   * whenever the *map* has terrain, regardless of this marker's
+   * `relativeTo` — MapLibre has no concept of a per-marker altitude
+   * reference. So doing nothing at `meters: 0` under `"sea"` would leave the
+   * marker sitting wherever MapLibre's native terrain-aware position puts
+   * it — on the terrain, not at sea level. Once engaged, only the actual
+   * composed delta (which can be a real non-zero vector even at
+   * `meters: 0`, to pull the marker back down off terrain MapLibre already
+   * elevated it onto) decides where the marker sits — see
+   * `computeAltitudeProjection`. (MapTiler's 3D module — `Item3D`/`Layer3D`
+   * in maptiler-3d-js — takes the same approach: no special-casing on the
+   * altitude value, only on reference type.)
    *
    * Only takes effect once the marker is on a map via {@link MarkerManager}
    * (i.e. added through `map.addMarker()`) — same requirement as collision
@@ -1526,25 +1542,27 @@ export class Marker extends maplibregl.Marker {
    * happens once it's added. If the map is otherwise idle (no camera
    * movement in flight), this triggers a repaint so the change is visible
    * immediately rather than on the next unrelated frame.
-   * @param meters - Altitude in meters, measured per `options.relativeTo`.
-   * @param options - See {@link SetAltitudeOptions}.
+   * @param meters - Altitude in meters, measured per `options.relativeTo`, or `false` to unset altitude entirely.
+   * @param options - See {@link SetAltitudeOptions}. Ignored when `meters` is `false`.
    */
-  setAltitude(meters: number, options: SetAltitudeOptions = {}): this {
-    const relativeTo = options.relativeTo ?? this.altitudeReference;
-    if (this.altitudeEngaged && this.altitudeMeters === meters && this.altitudeReference === relativeTo) return this;
-    this.altitudeEngaged = true;
-    this.altitudeMeters = meters;
-    this.altitudeReference = relativeTo;
+  setAltitude(meters: false): this;
+  setAltitude(meters: number, options?: SetAltitudeOptions): this;
+  setAltitude(meters: number | false, options: SetAltitudeOptions = {}): this {
+    if (meters === false) {
+      if (!this.altitudeEngaged) return this; // already inert — nothing to undo
 
-    const map = MarkerManager.getMap(this);
+      this.altitudeEngaged = false;
+      this.altitudeMeters = 0;
+      this.altitudeReference = "ground";
 
-    if (!this.needsAltitudeTracking()) {
-      // true no-op: 0m above sea level is always exactly baseOffset, nothing to track
+      const map = MarkerManager.getMap(this);
       if (map) MarkerManager.deregisterAltitudeParticipant(this, map);
+
       this.altitudeDelta = null;
       this.groundLineOrigin = null;
       this.writeOffset(this.baseOffset);
       this.setAltitudeHidden(false);
+      this.setAltitudeOccluded(false);
       this.updateGroundLineElement();
       // camera-depth z-index only applies while altitude-active (see
       // MarkerManager's onRender) — restore whatever it was before that,
@@ -1554,6 +1572,13 @@ export class Marker extends maplibregl.Marker {
       return this;
     }
 
+    const relativeTo = options.relativeTo ?? this.altitudeReference;
+    if (this.altitudeEngaged && this.altitudeMeters === meters && this.altitudeReference === relativeTo) return this;
+    this.altitudeEngaged = true;
+    this.altitudeMeters = meters;
+    this.altitudeReference = relativeTo;
+
+    const map = MarkerManager.getMap(this);
     if (map) {
       MarkerManager.registerAltitudeParticipant(this, map);
       map.triggerRepaint();
@@ -1571,18 +1596,44 @@ export class Marker extends maplibregl.Marker {
     return this.altitudeReference;
   }
 
-  /** Whether this marker currently needs per-frame altitude tracking — see {@link setAltitude}'s doc comment for why `meters: 0` alone doesn't decide this. Used by {@link MarkerManager} to catch `setAltitude()` calls made before the marker had a map. */
+  /**
+   * Whether this marker currently needs per-frame altitude tracking — true
+   * for the lifetime of the marker as soon as {@link setAltitude} has been
+   * called once, regardless of the value (see its doc comment for why there
+   * is deliberately no "0 is free" fast path). Used by {@link MarkerManager}
+   * to catch `setAltitude()` calls made before the marker had a map.
+   */
   hasActiveAltitude(): boolean {
-    return this.needsAltitudeTracking();
+    return this.altitudeEngaged;
   }
 
   /**
-   * True whenever there's a per-frame projection to maintain: a non-zero
-   * offset (`altitudeMeters !== 0`), or a ground reference that has to keep
-   * tracking the terrain surface even at exactly 0m above it.
+   * Stamps `altitude`/`altitudeReference`/`altitudeEngaged` onto every
+   * `dragstart`/`drag`/`dragend` event before it reaches listeners.
+   * MapLibre's base `Marker` fires these itself (from its own internal
+   * pointer handlers), with only `target`/`type` attached (see
+   * {@link Evented.fire}) — a drag listener otherwise has no way to read
+   * altitude without also holding a reference to the marker (`event.target`
+   * works, but only because it happens to be the marker itself; this makes
+   * it explicit and avoids an extra `getAltitude()`/`getAltitudeReference()`
+   * round-trip per listener).
    */
-  private needsAltitudeTracking(): boolean {
-    return this.altitudeEngaged && (this.altitudeMeters !== 0 || this.altitudeReference === "ground");
+  override fire(event: string | { type: string }, properties?: Record<string, unknown>) {
+    const type = typeof event === "string" ? event : event.type;
+    if (type === "dragstart" || type === "drag" || type === "dragend") {
+      const altitudeData = {
+        altitude: this.getAltitude(),
+        altitudeReference: this.getAltitudeReference(),
+        altitudeEngaged: this.hasActiveAltitude(),
+      };
+      if (typeof event === "string") {
+        properties = { ...properties, ...altitudeData };
+      } else {
+        Object.assign(event, altitudeData);
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- base Evented's Event type isn't exported by maplibre-gl
+    return super.fire(event as any, properties);
   }
 
   /**
@@ -1615,39 +1666,57 @@ export class Marker extends maplibregl.Marker {
    * public API.
    *
    * Returns this frame's camera depth (the elevated point's clip-space W —
-   * see {@link ScreenPoint.depth}), or `null` when off-screen/hidden.
+   * see {@link ScreenPoint.depth}), or `null` when off-screen/behind the
+   * camera/below ground (hidden either way — see {@link setAltitudeHidden}).
    * {@link MarkerManager} ranks every altitude-active marker on the map by
    * this and assigns z-index by rank (nearest on top) — DOM markers have no
    * real depth buffer, so without it a marker that's actually farther away
    * can still render in front of a nearer one purely because of DOM order.
    */
   [ApplyAltitudeFrameSymbol](matrix: mat4, map: SDKMap): number | null {
-    if (!this.needsAltitudeTracking()) return null; // shouldn't be registered, but state may have raced back to inert mid-frame
+    if (!this.altitudeEngaged) return null; // shouldn't be registered otherwise
 
     const projected = computeAltitudeProjection(this.getLngLat(), this.altitudeMeters, matrix, map, this.altitudeReference);
     if (!projected) {
+      // No valid screen position at all this frame (off-screen/behind the
+      // camera) — unlike belowGround below, there's nothing sane to
+      // position at, so this genuinely hides rather than fades.
       this.altitudeDelta = null;
       this.groundLineOrigin = null;
       this.setAltitudeHidden(true);
+      this.setAltitudeOccluded(false);
       this.updateGroundLineElement();
       return null;
     }
+
+    // belowGround still has a perfectly good position — only the CSS
+    // opacity changes (setAltitudeOccluded), so the offset/ground-line math
+    // below runs exactly as normal either way.
+    this.setAltitudeHidden(false);
+    this.setAltitudeOccluded(projected.belowGround);
 
     this.altitudeDelta = {
       x: projected.elevated.x - projected.groundBase.x,
       y: projected.elevated.y - projected.groundBase.y,
     };
     this.groundLineOrigin = { x: projected.elevated.x, y: projected.elevated.y };
-    this.setAltitudeHidden(false);
     this.writeOffset(this.baseOffset);
     this.updateGroundLineElement();
     return projected.elevated.depth;
   }
 
+  /** Idempotent toggle for {@link altitudeHidden} — cheap to call every frame regardless of whether the state actually changed. */
   private setAltitudeHidden(hidden: boolean): void {
     if (this.altitudeHidden === hidden) return;
     this.altitudeHidden = hidden;
     applyAltitudeHidden(this[MarkerElementSymbol], hidden);
+  }
+
+  /** Idempotent toggle for {@link altitudeOccluded} — cheap to call every frame regardless of whether the state actually changed. */
+  private setAltitudeOccluded(occluded: boolean): void {
+    if (this.altitudeOccluded === occluded) return;
+    this.altitudeOccluded = occluded;
+    applyAltitudeOccluded(this[MarkerElementSymbol], occluded);
   }
 
   /**
@@ -1693,6 +1762,12 @@ export class Marker extends maplibregl.Marker {
 
     this.groundLineEl.style.left = `${String(this.groundLineOrigin.x)}px`;
     this.groundLineEl.style.top = `${String(this.groundLineOrigin.y)}px`;
+    // The line lives in its own shared container, not nested inside the
+    // marker — so it doesn't inherit the marker's opacity from the
+    // occluded CSS class the way a real child would. Applied here too so a
+    // below-ground marker's line fades along with it instead of staying
+    // full-strength on its own.
+    applyAltitudeOccluded(this.groundLineEl, this.altitudeOccluded);
 
     const { x: dx, y: dy } = this.altitudeDelta;
     const length = Math.hypot(dx, dy);

--- a/src/Marker/MarkerManager.ts
+++ b/src/Marker/MarkerManager.ts
@@ -79,6 +79,16 @@ type MapAltitudeState = {
   layerId: string;
   /** The matrix captured by the layer's `render()` this frame; null until the first frame after installation. */
   currentMatrix: mat4 | null;
+  /**
+   * `args.defaultProjectionData.projectionTransition` from that same frame —
+   * 0 (pure mercator) or 1 (pure globe) at rest, fractional mid-morph
+   * between projections. `getMatrixForModel`'s per-projection placement (see
+   * altitude-math.ts) has no defined meaning at fractional values, so the
+   * render loop freezes markers at their last good position rather than
+   * projecting through a blend it can't represent — same guard
+   * maptiler-3d-js's Layer3D uses for its 3D models.
+   */
+  currentProjectionTransition: number | null;
   installed: boolean;
   renderListener: (() => void) | null;
   styleLoadListener: (() => void) | null;
@@ -722,16 +732,23 @@ class MarkerManagerImpl {
     groundLineContainer.style.position = "absolute";
     groundLineContainer.style.inset = "0";
     groundLineContainer.style.pointerEvents = "none";
-    // Negative, not just "low" — reliably behind every marker regardless of
-    // `priority` (small non-negative ints) or the camera-depth ranking
-    // markers get while altitude-active (ALTITUDE_Z_INDEX_BASE and up).
-    groundLineContainer.style.zIndex = "-1";
-    map.getCanvasContainer().appendChild(groundLineContainer);
+    // No z-index here, deliberately — a negative one would drop this into
+    // the CSS "negative z-index" stacking bucket, which paints BEHIND the
+    // map's own WebGL canvas (z-index: auto, i.e. the normal/0 bucket) —
+    // the lines would still render, just hidden behind the opaque map
+    // surface. Instead this relies on DOM order within that same normal
+    // bucket: inserted right after the canvas (so it's above the map), and
+    // every marker element is `appendChild`ed later (so markers, later in
+    // DOM order, always paint on top of this) — markers with an explicit
+    // z-index (`priority`, or the camera-depth ranking altitude-active
+    // markers get) are in a higher bucket regardless and stay on top too.
+    map.getCanvas().after(groundLineContainer);
 
     const state: MapAltitudeState = {
       participants: new Set(),
       layerId: `__maptiler-altitude-capture-${String(this.altitudeLayerSequence++)}__`,
       currentMatrix: null,
+      currentProjectionTransition: null,
       installed: false,
       renderListener: null,
       styleLoadListener: null,
@@ -796,11 +813,16 @@ class MarkerManagerImpl {
         // MapLibre v4 called this render(gl, matrix: mat4) — `args` was the
         // matrix itself and `defaultProjectionData` didn't exist.
         state.currentMatrix = args.defaultProjectionData.mainMatrix;
+        state.currentProjectionTransition = args.defaultProjectionData.projectionTransition;
       },
     });
 
     const onRender = () => {
       if (!state.currentMatrix) return;
+      // Mid-morph between mercator and globe — freeze rather than project
+      // through a blend `getMatrixForModel` can't represent (see
+      // `currentProjectionTransition`'s doc comment).
+      if (state.currentProjectionTransition !== 0 && state.currentProjectionTransition !== 1) return;
 
       // Each marker projects itself and reports back its camera depth (or
       // null if off-screen/hidden this frame) — collected here rather than

--- a/src/Marker/altitude-math.ts
+++ b/src/Marker/altitude-math.ts
@@ -1,6 +1,12 @@
+// This module is pure math — no DOM, no MapLibre subclassing, no side
+// effects. Everything here is called once per marker per render frame (see
+// MarkerManager's altitude render loop), so it stays allocation-light and
+// free of anything that would need cleanup.
 import maplibregl from "maplibre-gl";
 import type { mat4 } from "gl-matrix";
 import type { AltitudeReference } from "./types";
+
+//#region ScreenPoint
 
 /** A screen-space position in CSS pixels, DOM convention (+y down). */
 export interface ScreenPoint {
@@ -16,24 +22,35 @@ export interface ScreenPoint {
   depth: number;
 }
 
+//#endregion
+
+//#region projectLngLatAltitude
+
 /**
  * `matrix` is column-major, OpenGL convention: element `matrix[col * 4 + row]`.
  * clip = matrix * [x, y, z, 1] — only the x, y and w rows are needed since
  * we're projecting a single point, not building a full transform.
  *
- * Mercator only: under globe projection this same matrix instead projects a
- * unit-sphere planet, not flat mercator tile space, and `MercatorCoordinate`
- * stops meaning the same thing to it — this function would silently return
- * plausible-looking but wrong screen positions. Guard on
- * `map.getProjection?.().type !== 'mercator'` before relying on any of this
- * if the app supports globe.
+ * Projection-agnostic: `map.transform.getMatrixForModel(lngLat, altitude)`
+ * (the same primitive maptiler-3d-js uses to place 3D models correctly under
+ * both projections) returns a matrix whose translation column is the world
+ * point for `lngLat`/`altitude` in whatever space the active projection
+ * uses — flat mercator tile space under mercator, a point on the unit-sphere
+ * planet under globe — which is exactly the space `matrix` (the custom
+ * layer's `mainMatrix`) expects either way. Under mercator this translation
+ * column is numerically identical to `MercatorCoordinate.fromLngLat`, so
+ * this is a superset of the old mercator-only math, not a behaviour change
+ * for it.
  */
 export function projectLngLatAltitude(lngLat: maplibregl.LngLat, altitudeMeters: number, matrix: mat4, map: maplibregl.Map): ScreenPoint | null {
-  const mercator = maplibregl.MercatorCoordinate.fromLngLat(lngLat, altitudeMeters);
+  const model = map.transform.getMatrixForModel(lngLat, altitudeMeters);
+  const worldX = model[12];
+  const worldY = model[13];
+  const worldZ = model[14];
 
-  const clipX = matrix[0] * mercator.x + matrix[4] * mercator.y + matrix[8] * mercator.z + matrix[12];
-  const clipY = matrix[1] * mercator.x + matrix[5] * mercator.y + matrix[9] * mercator.z + matrix[13];
-  const clipW = matrix[3] * mercator.x + matrix[7] * mercator.y + matrix[11] * mercator.z + matrix[15];
+  const clipX = matrix[0] * worldX + matrix[4] * worldY + matrix[8] * worldZ + matrix[12];
+  const clipY = matrix[1] * worldX + matrix[5] * worldY + matrix[9] * worldZ + matrix[13];
+  const clipW = matrix[3] * worldX + matrix[7] * worldY + matrix[11] * worldZ + matrix[15];
 
   // Point projects behind the camera — there is no sane screen position for it.
   if (clipW <= 0) return null;
@@ -55,6 +72,10 @@ export function projectLngLatAltitude(lngLat: maplibregl.LngLat, altitudeMeters:
     depth: clipW,
   };
 }
+
+//#endregion
+
+//#region computeAltitudeProjection
 
 /**
  * Two points, through the same matrix/frame:
@@ -89,6 +110,15 @@ export function projectLngLatAltitude(lngLat: maplibregl.LngLat, altitudeMeters:
  *
  * `queryTerrainElevation` returns `null` when terrain isn't enabled/loaded,
  * treated as 0.
+ *
+ * `belowGround` — `targetElevation < nativeElevation` — is mode-agnostic for
+ * free: under `"ground"` it only trips with a negative `altitudeMeters`
+ * (tunneling below whatever terrain/sea level it's relative to); under
+ * `"sea"` it trips whenever the absolute altitude is lower than the real
+ * terrain surface there, e.g. `0` over a hill. DOM markers aren't
+ * depth-tested against the terrain mesh, so without this a marker "below
+ * ground" would render right through the hillside instead of being hidden
+ * by it.
  */
 export function computeAltitudeProjection(
   lngLat: maplibregl.LngLat,
@@ -96,11 +126,25 @@ export function computeAltitudeProjection(
   matrix: mat4,
   map: maplibregl.Map,
   relativeTo: AltitudeReference,
-): { groundBase: ScreenPoint; elevated: ScreenPoint } | null {
+): { groundBase: ScreenPoint; elevated: ScreenPoint; belowGround: boolean } | null {
+  // 0 whenever the map has no terrain (or it hasn't loaded for this
+  // lngLat yet) — see the doc comment above for why this ignores `relativeTo`.
   const nativeElevation = map.getTerrain() ? (map.queryTerrainElevation(lngLat) ?? 0) : 0;
+
+  // Where MapLibre's own marker _pos already sits — the baseline every
+  // pixel offset this SDK writes has to be measured from.
   const groundBase = projectLngLatAltitude(lngLat, nativeElevation, matrix, map);
+
+  // Where the marker should actually end up, in mercator Z terms — see the
+  // `elevated` bullet in the doc comment for the two branches.
   const targetElevation = relativeTo === "ground" ? nativeElevation + altitudeMeters : altitudeMeters;
   const elevated = projectLngLatAltitude(lngLat, targetElevation, matrix, map);
+
+  // Either point can come back null if it's behind the camera this frame —
+  // bail out rather than return a partially-valid result.
   if (!groundBase || !elevated) return null;
-  return { groundBase, elevated };
+
+  return { groundBase, elevated, belowGround: targetElevation < nativeElevation };
 }
+
+//#endregion

--- a/src/Marker/marker-dom-utils.ts
+++ b/src/Marker/marker-dom-utils.ts
@@ -582,7 +582,10 @@ export const GROUND_LINE_CLASSNAME = "maptiler-marker-groundline";
 
 /**
  * Toggles whether a marker is hidden because its altitude-projected
- * position is off-screen/behind the camera. Independent of
+ * position is unusable this frame — off-screen or behind the camera, i.e.
+ * there is no screen position to render it at, at all. NOT the below-ground
+ * case (see {@link applyAltitudeOccluded}), which has a perfectly good
+ * position and should still render there, just faded. Independent of
  * {@link applyCollisionHidden} — see the CSS comment in the SDK stylesheet
  * for why the two never fight over the same element.
  * @param element - The marker's outer root element (or the custom element).
@@ -590,6 +593,26 @@ export const GROUND_LINE_CLASSNAME = "maptiler-marker-groundline";
  */
 export function applyAltitudeHidden(element: HTMLElement, hidden: boolean): void {
   element.classList.toggle(ALTITUDE_HIDDEN_CLASSNAME, hidden);
+}
+
+//#endregion
+
+//#region applyAltitudeOccluded
+
+const ALTITUDE_OCCLUDED_CLASSNAME = "maptiler-marker-altitude-occluded";
+
+/**
+ * Toggles whether a marker is faded because it's below ground (see
+ * `computeAltitudeProjection`'s `belowGround`) — DOM markers aren't
+ * depth-tested against the terrain mesh, so nothing else would stand in for
+ * a hillside occluding it. Unlike {@link applyAltitudeHidden}, the marker
+ * still has a real position and stays there (and pointer events stay on —
+ * it's still there, just visually behind something) — only opacity changes.
+ * @param element - The marker's outer root element (or the custom element).
+ * @param occluded - Whether the marker is currently below ground.
+ */
+export function applyAltitudeOccluded(element: HTMLElement, occluded: boolean): void {
+  element.classList.toggle(ALTITUDE_OCCLUDED_CLASSNAME, occluded);
 }
 
 //#endregion

--- a/src/style/style_template.css
+++ b/src/style/style_template.css
@@ -215,15 +215,25 @@
   transform: scale(0) !important;
 }
 
-/* Marker altitude (setAltitude/setGroundLine). Hidden when the altitude
-   projection is off-screen/behind the camera — independent of, and
-   composes with, the collision engine's own hide above (both are plain
-   "force hidden, else say nothing" rules on the same element, so either one
-   hiding it is enough; opacity on this element also visually hides the
-   ground-line child below, no extra wiring needed for that). */
+/* Marker altitude (setAltitude/setGroundLine). Fully hidden only when the
+   altitude projection is off-screen/behind the camera — no valid screen
+   position exists at all. Independent of, and composes with, the collision
+   engine's own hide above (both are plain "force hidden, else say nothing"
+   rules on the same element, so either one hiding it is enough; opacity on
+   this element also visually hides the ground-line child below, no extra
+   wiring needed for that). */
 .maptiler-marker-altitude-hidden {
   opacity: 0 !important;
   pointer-events: none !important;
+}
+
+/* Below ground (see `computeAltitudeProjection`'s `belowGround`) — the
+   marker has a perfectly good position and stays there, just faded, since
+   DOM markers aren't depth-tested against the terrain mesh and this is what
+   stands in for a hillside occluding it. Pointer events deliberately stay
+   on — it's still there, just visually behind something. */
+.maptiler-marker-altitude-occluded {
+  opacity: 0.35 !important;
 }
 
 /* Dashed line from a marker down (or up) to its ground point. Geometry


### PR DESCRIPTION
## Objective
Altitude markers were mercator-only — under globe projection the position math was silently wrong (a real coordinate-space mismatch, not a rounding error), and there was no way to represent a marker sitting below the ground/terrain surface, or to fully unset altitude back to native draping.

## Description
- Support markers below ground: fade instead of clipping through terrain, plus unset altitude entirely back to native draping via `setAltitude(false)`
- Fix marker altitude/ground-line positioning under globe projection by projecting through `map.transform.getMatrixForModel()` instead of raw `MercatorCoordinate` math — the same technique `maptiler-3d-js` uses to place 3D models correctly under both projections
- Freeze altitude-active markers during a mercator/globe transition blend instead of projecting through an undefined intermediate state
- Stamp `altitude`/`altitudeReference`/`altitudeEngaged` onto marker `dragstart`/`drag`/`dragend` events, so listeners don't need a separate `getAltitude()` round-trip
- Swap demo's custom pitch/projection UI for the sanctioned `MaptilerTerrainControl`/`MaptilerProjectionControl`

## Acceptance
- Manually tested
- Unit tests in forthcoming PR

## Checklist
N/A changelog will be updated upon final PR ~~I have added relevant info to the CHANGELOG.md~~

Part 2 of 4 in this stack — based on #413.